### PR TITLE
Missing `Meta.quot`

### DIFF
--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -798,7 +798,7 @@ end
                 path = path[3:end]
             end
             for p in path
-                res = :(Base.getfield($res, $p))
+                res = :(Base.getfield($res, $(Meta.quot(p))))
             end
             res = :($res.data = $(Symbol("concrete_res_$(idx)")))
             push!(delinearized_results, res)
@@ -824,12 +824,12 @@ end
                 path = path[3:end]
             end
             for p in path
-                res = :(Base.getfield($res, $p))
+                res = :(Base.getfield($res, $(Meta.quot(p))))
             end
 
             argres = :(args[argpath[2]])
             for p in argpath[3:end]
-                argres = :(Base.getfield($argres, $p))
+                argres = :(Base.getfield($argres, $(Meta.quot(p))))
             end
 
             res = :($res.data = $argres.data)


### PR DESCRIPTION
code gets generated as `((Base.getfield(Base.getfield(args[3], layer_1), bias)).data = concrete_res_1)` instead of `((Base.getfield(Base.getfield(args[3], :layer_1), :bias)).data = concrete_res_1)`