### PR TITLE
Despecialize some methods to lower excessive codegen

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -124,7 +124,9 @@ for (jlop, hloop, RT) in (
     (:(Base.:-), :subtract, :T),
 )
     @eval begin
-        function $jlop(lhs::TracedRArray{T,N}, rhs::TracedRArray{T2,N}) where {T,T2,N}
+        function $jlop(
+            @nospecialize(lhs::TracedRArray{T,N}), @nospecialize(rhs::TracedRArray{T2,N})
+        ) where {T,T2,N}
             commonTy = TracedRArray{Base.promote_type(T, T2),N}
             lhs = promote_to(commonTy, lhs)
             rhs = promote_to(commonTy, rhs)
@@ -137,7 +139,9 @@ for (jlop, hloop, RT) in (
             )
         end
 
-        function $jlop(lhs::TracedRArray{T,N}, rhs::TracedRArray{T,N}) where {T,N}
+        function $jlop(
+            @nospecialize(lhs::TracedRArray{T,N}), @nospecialize(rhs::TracedRArray{T,N})
+        ) where {T,N}
             return TracedRArray{$RT,N}(
                 (),
                 MLIR.IR.result(
@@ -150,7 +154,9 @@ for (jlop, hloop, RT) in (
 
     for otherType in (Number, Any) #=TracedRArray{S,0} where {S}=#
         @eval begin
-            function $jlop(lhs::TracedRArray{T,N}, rhs::$otherType) where {T,N}
+            function $jlop(
+                @nospecialize(lhs::TracedRArray{T,N}), @nospecialize(rhs::$otherType)
+            ) where {T,N}
                 rhs = promote_to(lhs, rhs)
                 return TracedRArray{$RT,N}(
                     (),
@@ -161,7 +167,9 @@ for (jlop, hloop, RT) in (
                 )
             end
 
-            function $jlop(lhs::$otherType, rhs::TracedRArray{T,N}) where {T,N}
+            function $jlop(
+                @nospecialize(lhs::$otherType), @nospecialize(rhs::TracedRArray{T,N})
+            ) where {T,N}
                 lhs = promote_to(rhs, lhs)
                 return TracedRArray{$RT,N}(
                     (),
@@ -178,7 +186,9 @@ end
 for (jlop, hloop, RT) in
     ((:(Base.:*), :multiply, :T), (:(Base.:/), :divide, :T), (:(Base.:^), :power, :T))
     @eval begin
-        function $jlop(lhs::TracedRArray{T,0}, rhs::TracedRArray{T2,0}) where {T,T2}
+        function $jlop(
+            @nospecialize(lhs::TracedRArray{T,0}), @nospecialize(rhs::TracedRArray{T2,0})
+        ) where {T,T2}
             commonTy = TracedRArray{Base.promote_type(T, T2),0}
             lhs = promote_to(commonTy, lhs)
             rhs = promote_to(commonTy, rhs)
@@ -191,7 +201,9 @@ for (jlop, hloop, RT) in
             )
         end
 
-        function $jlop(lhs::TracedRArray{T,0}, rhs::TracedRArray{T,0}) where {T}
+        function $jlop(
+            @nospecialize(lhs::TracedRArray{T,0}), @nospecialize(rhs::TracedRArray{T,0})
+        ) where {T}
             return TracedRArray{$RT,0}(
                 (),
                 MLIR.IR.result(
@@ -201,7 +213,7 @@ for (jlop, hloop, RT) in
             )
         end
 
-        function $jlop(lhs::TracedRArray{T,0}, rhs) where {T}
+        function $jlop(@nospecialize(lhs::TracedRArray{T,0}), @nospecialize(rhs)) where {T}
             rhs = promote_to(lhs, rhs)
             return TracedRArray{$RT,0}(
                 (),
@@ -212,7 +224,7 @@ for (jlop, hloop, RT) in
             )
         end
 
-        function $jlop(lhs, rhs::TracedRArray{T,0}) where {T}
+        function $jlop(@nospecialize(lhs), @nospecialize(rhs::TracedRArray{T,0})) where {T}
             lhs = promote_to(rhs, lhs)
             return TracedRArray{$RT,0}(
                 (),
@@ -224,7 +236,9 @@ for (jlop, hloop, RT) in
         end
 
         # Base defines ::AbstractArray / ::Number, so we need this to avoid ambiguity
-        function $jlop(lhs::TracedRArray{T,0}, rhs::Number) where {T}
+        function $jlop(
+            @nospecialize(lhs::TracedRArray{T,0}), @nospecialize(rhs::Number)
+        ) where {T}
             rhs = promote_to(lhs, rhs)
             return TracedRArray{$RT,0}(
                 (),
@@ -235,7 +249,9 @@ for (jlop, hloop, RT) in
             )
         end
 
-        function $jlop(lhs::Number, rhs::TracedRArray{T,0}) where {T}
+        function $jlop(
+            @nospecialize(lhs::Number), @nospecialize(rhs::TracedRArray{T,0})
+        ) where {T}
             lhs = promote_to(rhs, lhs)
             return TracedRArray{$RT,0}(
                 (),
@@ -249,7 +265,9 @@ for (jlop, hloop, RT) in
 end
 
 function Base.ifelse(
-    pred::TracedRArray{Bool,0}, x::TracedRArray{T1,0}, y::TracedRArray{T2,0}
+    @nospecialize(pred::TracedRArray{Bool,0}),
+    @nospecialize(x::TracedRArray{T1,0}),
+    @nospecialize(y::TracedRArray{T2,0})
 ) where {T1,T2}
     return TracedRArray{promote_type(T1, T2),0}(
         (),
@@ -280,7 +298,7 @@ for (jlop, hloop) in (
     (:(Base.sqrt), :sqrt),
 )
     @eval begin
-        function $jlop(lhs::TracedRArray{T,N}) where {T,N}
+        function $jlop(@nospecialize(lhs::TracedRArray{T,N})) where {T,N}
             return TracedRArray{T,N}(
                 (),
                 MLIR.IR.result(MLIR.Dialects.stablehlo.$hloop(lhs.mlir_data), 1),
@@ -372,7 +390,9 @@ for (jlop, hloop, hlocomp) in (
 )
     @eval begin
         function elem_apply(
-            ::typeof($jlop), lhs::TracedRArray{T,N}, rhs::TracedRArray{T,N}
+            ::typeof($jlop),
+            @nospecialize(lhs::TracedRArray{T,N}),
+            @nospecialize(rhs::TracedRArray{T,N})
         ) where {T,N}
             return TracedRArray{T,N}(
                 (),
@@ -390,7 +410,9 @@ for (jlop, hloop, hlocomp) in (
             )
         end
 
-        function elem_apply(::typeof($jlop), lhs::TracedRArray{T,N}, rhs) where {T,N}
+        function elem_apply(
+            ::typeof($jlop), @nospecialize(lhs::TracedRArray{T,N}), @nospecialize(rhs)
+        ) where {T,N}
             rhs = promote_to(lhs, rhs)
             return TracedRArray{T,N}(
                 (),
@@ -408,7 +430,9 @@ for (jlop, hloop, hlocomp) in (
             )
         end
 
-        function elem_apply(::typeof($jlop), lhs, rhs::TracedRArray{T,N}) where {T,N}
+        function elem_apply(
+            ::typeof($jlop), @nospecialize(lhs), @nospecialize(rhs::TracedRArray{T,N})
+        ) where {T,N}
             lhs = promote_to(rhs, lhs)
             return TracedRArray{T,N}(
                 (),
@@ -428,7 +452,9 @@ for (jlop, hloop, hlocomp) in (
     end
 end
 
-function Base.:*(lhs::TracedRArray{T,2}, rhs::TracedRArray{T,2}) where {T}
+function Base.:*(
+    @nospecialize(lhs::TracedRArray{T,2}), @nospecialize(rhs::TracedRArray{T,2})
+) where {T}
     lhsty = MLIR.IR.type(lhs.mlir_data)
     rhsty = MLIR.IR.type(rhs.mlir_data)
     resty = MLIR.IR.TensorType((size(lhs, 1), size(rhs, 2)), eltype(lhsty))
@@ -467,7 +493,13 @@ function Enzyme.Compiler.active_reg_inner(
     end
 end
 
-function Base.mapreduce(f, op, A::TracedRArray{T,N}; dims=:, init=nothing) where {T,N}
+function Base.mapreduce(
+    @nospecialize(f),
+    @nospecialize(op),
+    @nospecialize(A::TracedRArray{T,N});
+    dims=:,
+    init=nothing,
+) where {T,N}
     if dims isa Int
         dims = [dims]
     end
@@ -535,7 +567,12 @@ function Base.mapreduce(f, op, A::TracedRArray{T,N}; dims=:, init=nothing) where
     return red
 end
 
-function Base.mapreducedim!(f, op, R::TracedRArray, A::Base.AbstractArrayOrBroadcasted)
+function Base.mapreducedim!(
+    @nospecialize(f),
+    @nospecialize(op),
+    @nospecialize(R::TracedRArray),
+    A::Base.AbstractArrayOrBroadcasted,
+)
     tmp = broadcast_to_size(Base.mapreduce(f, op, A; dims=1), (1, size(R)[2:end]...))
     R.mlir_data = elem_apply(op, R, tmp).mlir_data
     return R

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -217,7 +217,14 @@ end
 
 append_path(path, i) = (path..., i)
 
-function make_tracer(seen, prev::RT, path, mode; toscalar=false, tobatch=nothing) where {RT}
+function make_tracer(
+    seen,
+    @nospecialize(prev::RT),
+    @nospecialize(path),
+    mode;
+    toscalar=false,
+    tobatch=nothing,
+) where {RT}
     if haskey(seen, prev)
         return seen[prev]
     end
@@ -275,7 +282,9 @@ function make_tracer(seen, prev::RT, path, mode; toscalar=false, tobatch=nothing
     return y
 end
 
-function make_tracer(seen, prev::ConcreteRArray{T,N}, path, mode; kwargs...) where {T,N}
+function make_tracer(
+    seen, @nospecialize(prev::ConcreteRArray{T,N}), @nospecialize(path), mode; kwargs...
+) where {T,N}
     if mode == ArrayToConcrete
         return prev
     end
@@ -292,7 +301,12 @@ function make_tracer(seen, prev::ConcreteRArray{T,N}, path, mode; kwargs...) whe
 end
 
 function make_tracer(
-    seen, prev::TracedRArray{T,N}, path, mode; toscalar=false, tobatch=nothing
+    seen,
+    @nospecialize(prev::TracedRArray{T,N}),
+    @nospecialize(path),
+    mode;
+    toscalar=false,
+    tobatch=nothing,
 ) where {T,N}
     if mode == ConcreteToTraced
         throw("Cannot trace existing trace type")
@@ -331,12 +345,21 @@ function make_tracer(
     throw("Cannot Unknown trace mode $mode")
 end
 
-make_tracer(seen, prev::RT, path, mode; kwargs...) where {RT<:AbstractFloat} = prev
+function make_tracer(
+    seen, @nospecialize(prev::RT), @nospecialize(path), mode; kwargs...
+) where {RT<:AbstractFloat}
+    return prev
+end
 
-make_tracer(seen, prev::Symbol, path, mode; kwargs...) = prev
+make_tracer(seen, prev::Symbol, @nospecialize(path), mode; kwargs...) = prev
 
 function make_tracer(
-    seen, prev::Complex{RT}, path, mode; toscalar=false, tobatch=nothing
+    seen,
+    @nospecialize(prev::Complex{RT}),
+    @nospecialize(path),
+    mode;
+    toscalar=false,
+    tobatch=nothing,
 ) where {RT}
     return Complex(
         make_tracer(seen, prev.re, append_path(path, :re), mode; toscalar, tobatch),
@@ -344,7 +367,9 @@ function make_tracer(
     )
 end
 
-function make_tracer(seen, prev::RT, path, mode; kwargs...) where {RT<:Array}
+function make_tracer(
+    seen, @nospecialize(prev::RT), @nospecialize(path), mode; kwargs...
+) where {RT<:Array}
     if haskey(seen, prev)
         return seen[prev]
     end
@@ -372,7 +397,9 @@ function make_tracer(seen, prev::RT, path, mode; kwargs...) where {RT<:Array}
     return newa
 end
 
-function make_tracer(seen, prev::RT, path, mode; kwargs...) where {RT<:Tuple}
+function make_tracer(
+    seen, @nospecialize(prev::RT), @nospecialize(path), mode; kwargs...
+) where {RT<:Tuple}
     return (
         (
             make_tracer(seen, v, append_path(path, i), mode; kwargs...) for
@@ -381,7 +408,9 @@ function make_tracer(seen, prev::RT, path, mode; kwargs...) where {RT<:Tuple}
     )
 end
 
-function make_tracer(seen, prev::NamedTuple{A,RT}, path, mode; kwargs...) where {A,RT}
+function make_tracer(
+    seen, @nospecialize(prev::NamedTuple{A,RT}), @nospecialize(path), mode; kwargs...
+) where {A,RT}
     return NamedTuple{A,traced_type(RT, (), Val(mode))}((
         (
             make_tracer(
@@ -391,7 +420,7 @@ function make_tracer(seen, prev::NamedTuple{A,RT}, path, mode; kwargs...) where 
     ))
 end
 
-function make_tracer(seen, prev::Core.Box, path, mode; kwargs...)
+function make_tracer(seen, prev::Core.Box, @nospecialize(path), mode; kwargs...)
     if haskey(seen, prev)
         return seen[prev]
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,8 +28,7 @@ function make_mlir_fn(f, args, kwargs, name="main", concretein=true; toscalar=fa
 
     N = length(args)
     seen_args = IdDict()
-    traced_args = ntuple(Val(N)) do i
-        Base.@_inline_meta
+    traced_args = ntuple(N) do i
         return make_tracer(
             seen_args,
             args[i],


### PR DESCRIPTION
Depends on #68 

~~DON'T MERGE BEFORE IT~~

It basically ads some `@nospecialize` annotations to some methods to lower the amount of codegen.

Also, it fixes a small performance bug (I wasn't reusing the `ReactantInterpreter`, so we weren't reusing the cache).