### PR TITLE
Implement `only` for `TracedRArray`

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -29,7 +29,7 @@ function Base.show(io::IOty, X::TracedRArray{T,N}) where {T,N,IOty<:Union{IO,IOC
     return print(io, X.mlir_data, ")")
 end
 
-Base.only(A::TracedRArray) = A
+Base.only(A::TracedRArray{T,0}) where {T} = A
 
 function Base.reshape(A::TracedRArray{T,N}, dims::NTuple{NT,Int}) where {T,N,NT}
     prod(dims) == prod(size(A)) || Base._throw_dmrsa(dims, prod(size(A)))

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -29,6 +29,8 @@ function Base.show(io::IOty, X::TracedRArray{T,N}) where {T,N,IOty<:Union{IO,IOC
     return print(io, X.mlir_data, ")")
 end
 
+Base.only(A::TracedRArray) = A
+
 function Base.reshape(A::TracedRArray{T,N}, dims::NTuple{NT,Int}) where {T,N,NT}
     prod(dims) == prod(size(A)) || Base._throw_dmrsa(dims, prod(size(A)))
 


### PR DESCRIPTION
@wsmoses In Julia, a 0-dim array is not (programmatically) equal to a scalar, but we're treating as such in Reactant. We should be more careful about this, but meanwhile, I'm using this method implementation to keep compatibility between Reactant and non-Reactant code.