### PR TITLE
fix: local JLL build script

### DIFF
--- a/deps/build_local.jl
+++ b/deps/build_local.jl
@@ -1,5 +1,5 @@
 # Invoke with
-# `julia --project=deps deps/build_local.jl [path-to-enzyme]`
+# `julia --project=deps deps/build_local.jl [dbg/opt]`
 
 # the pre-built ReactantExtra_jll might not be loadable on this platform
 Reactant_jll = Base.UUID("0192cb87-2b54-54ad-80e0-3be72ad8a3c0")
@@ -24,7 +24,6 @@ run(Cmd(`$(Base.julia_cmd().exec[1]) --project=. -e "using Pkg; Pkg.instantiate(
 #--define=using_rocm=true --define=using_rocm_hipcc=true
 #--action_env TF_ROCM_AMDGPU_TARGETS="gfx900,gfx906,gfx908,gfx90a,gfx1030"
 
-
 # --repo_env TF_NEED_CUDA=1
 # --repo_env TF_NVCC_CLANG=1
 # --repo_env TF_NCCL_USE_STUB=1
@@ -38,16 +37,35 @@ run(Cmd(`$(Base.julia_cmd().exec[1]) --project=. -e "using Pkg; Pkg.instantiate(
 # --crosstool_top="@local_config_cuda//crosstool:toolchain"
 
 arg = try
-	run(Cmd(`nvidia-smi`))
-	"--config=cuda"
+    run(Cmd(`nvidia-smi`))
+    "--config=cuda"
 catch
-	""
+    ""
 end
 
-run(Cmd(`bazel build $(arg) -c dbg --action_env=JULIA=$(Base.julia_cmd().exec[1])
---repo_env HERMETIC_PYTHON_VERSION="3.10"
---check_visibility=false --verbose_failures :libReactantExtra.so :Builtin.inc.jl :Arith.inc.jl :Affine.inc.jl :Func.inc.jl :Enzyme.inc.jl :StableHLO.inc.jl :CHLO.inc.jl :VHLO.inc.jl`, dir=source_dir,
-))
+build_kind = if length(ARGS) == 1
+    kind = ARGS[1]
+    if kind  ∉ ("dbg", "opt")
+        error("Invalid build kind $(kind). Valid options are 'dbg' and 'opt'")
+    end
+    kind
+else
+    "dbg"
+end
+
+@info "Building JLL with -c $(build_kind)"
+
+if isempty(arg)
+    run(Cmd(`bazel build -c $(build_kind) --action_env=JULIA=$(Base.julia_cmd().exec[1])
+    --repo_env HERMETIC_PYTHON_VERSION="3.10"
+    --check_visibility=false --verbose_failures :libReactantExtra.so :Builtin.inc.jl :Arith.inc.jl :Affine.inc.jl :Func.inc.jl :Enzyme.inc.jl :StableHLO.inc.jl :CHLO.inc.jl :VHLO.inc.jl`, dir=source_dir,
+    ))
+else
+    run(Cmd(`bazel build $(arg) -c $(build_kind) --action_env=JULIA=$(Base.julia_cmd().exec[1])
+    --repo_env HERMETIC_PYTHON_VERSION="3.10"
+    --check_visibility=false --verbose_failures :libReactantExtra.so :Builtin.inc.jl :Arith.inc.jl :Affine.inc.jl :Func.inc.jl :Enzyme.inc.jl :StableHLO.inc.jl :CHLO.inc.jl :VHLO.inc.jl`, dir=source_dir,
+    ))
+end
 # env=Dict("HOME"=>ENV["HOME"], "PATH"=>joinpath(source_dir, "..")*":"*ENV["PATH"])))
 
 run(Cmd(`rm -f libReactantExtra.dylib`, dir=joinpath(source_dir, "bazel-bin")))


### PR DESCRIPTION
fixes on machines without `nvidia-smi`. Also add an option to pass in `dbg` or `opt`