### PR TITLE
Allow CI failure on pre-release and nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.libReactant }} libReactant - assertions=${{ matrix.assertions }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version != '1.10' }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.libReactant }} libReactant - assertions=${{ matrix.assertions }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}
+    continue-on-error: ${{ matrix.version != '1.10' }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,12 +39,6 @@ jobs:
             libReactant: packaged
             version: '1.10'
             assertions: true
-          - version: '1.10'
-            allow_failure: false
-          - version: '~1.11.0-0'
-            allow_failure: true
-          - version: 'nightly'
-            allow_failure: true
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,12 +17,13 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.libReactant }} libReactant - assertions=${{ matrix.assertions }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.10'
-          - '~1.11.0-0'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-20.04
@@ -38,6 +39,13 @@ jobs:
             libReactant: packaged
             version: '1.10'
             assertions: true
+                  include:
+          - version: '1.10'
+            allow_failure: false
+          - version: 'pre'
+            allow_failure: true
+          - version: 'nightly'
+            allow_failure: true
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,6 @@ jobs:
             libReactant: packaged
             version: '1.10'
             assertions: true
-                  include:
           - version: '1.10'
             allow_failure: false
           - version: 'pre'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - 'pre'
+          - '~1.11.0-0'
           - 'nightly'
         os:
           - ubuntu-20.04
@@ -41,7 +41,7 @@ jobs:
             assertions: true
           - version: '1.10'
             allow_failure: false
-          - version: 'pre'
+          - version: '~1.11.0-0'
             allow_failure: true
           - version: 'nightly'
             allow_failure: true


### PR DESCRIPTION
This would make CI results a bit easier to parse, since I'm guessing we expect those tests to keep failing for now.
Source: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run