### PR TITLE
Export `GetDefaultTargetTriple` symbol

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -57,6 +57,8 @@
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/Support/Process.h"
 
+#include "llvm-c/TargetMachine.h"
+
 using namespace mlir;
 using namespace llvm;
 using namespace xla;
@@ -86,6 +88,10 @@ extern "C" void SetLogLevel(int level) {
 
 extern "C" void SetModuleLogLevel(const char* module_pattern, int level) {
     //absl::SetVLOGLevel(module_pattern, level);
+}
+
+extern "C" char *GetDefaultTargetTriple(void) {
+  return LLVMGetDefaultTargetTriple();
 }
 
 extern "C"

--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -270,6 +270,7 @@ cc_library(
 "-Wl,-exported_symbol,_InitializeLogs",
 "-Wl,-exported_symbol,_SetLogLevel",
 "-Wl,-exported_symbol,_SetModuleLogLevel",
+"-Wl,-exported_symbol,_GetDefaultTargetTriple",
 "-Wl,-exported_symbol,_enzymeActivityAttrGet",
 "-Wl,-exported_symbol,_MakeCPUClient",
 "-Wl,-exported_symbol,_MakeGPUClient",


### PR DESCRIPTION
Used to explore the damn bug of not honoring Apple's aarch64 call convention.