### PR TITLE
Generalize `Base._cat` to non-`Val`, typed `Base._cat_t` and implement `typed_hcat`, `typed_vcat`, `typed_hvcat`, `typed_hvncat`

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -788,7 +788,7 @@ function Base._cat(dims, A::TracedRArray{T,N}, Bs::TracedRArray...) where {T,N}
     return Res
 end
 
-function maybe_expand_dims(x::AbstractArray, dims) where {T,N}
+function maybe_expand_dims(x::AbstractArray{T,N}, dims) where {T,N}
     dims = dispatch_val(dims)
     dims ≤ N && return x
     return reshape(x, ntuple(i -> i ≤ N ? size(x, i) : 1, dims))

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -779,7 +779,7 @@ function Base._cat_t(dims, ::Type{T}, X::TracedRArray...) where {T}
         MLIR.IR.result(
             # TODO maybe we should do some conversion?
             MLIR.Dialects.stablehlo.concatenate(
-                get_mlir_data.(X);
+                collect(get_mlir_data.(X));
                 result_0=MLIR.IR.TensorType(shape, MLIR.IR.Type(RT)),
                 dimension=dims - 1, # stablehlo expects this to be zero-indexed
             ),

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -788,7 +788,8 @@ function Base._cat(dims, A::TracedRArray{T,N}, Bs::TracedRArray...) where {T,N}
     return Res
 end
 
-function maybe_expand_dims(x::AbstractArray{T,N}, ::Val{D}) where {T,N,D}
-    D ≤ N && return x
-    return reshape(x, ntuple(i -> i ≤ N ? size(x, i) : 1, Val(D)))
+function maybe_expand_dims(x::AbstractArray, dims) where {T,N}
+    dims = dispatch_val(dims)
+    dims ≤ N && return x
+    return reshape(x, ntuple(i -> i ≤ N ? size(x, i) : 1, dims))
 end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -821,6 +821,10 @@ function Base._cat_t(dims, ::Type{T}, X::TracedRArray...) where {T}
     catdims = Base.dims2cat(dims)
     shape = Base.cat_size_shape(catdims, X...)
     RT = Base.promote_eltype(T, X...)
+
+    # convert to the target eltype
+    X = map(Base.Fix1(promote_to, TracedRArray{RT,length(shape)}), X)
+
     return TracedRArray{RT,length(shape)}(
         (),
         MLIR.IR.result(

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -774,7 +774,6 @@ function Base._cat_t(dims, ::Type{T}, X::TracedRArray...) where {T}
     catdims = Base.dims2cat(dims)
     shape = Base.cat_size_shape(catdims, X...)
     RT = Base.promote_eltype(T, X...)
-    
     return TracedRArray{RT,length(shape)}(
         (),
         MLIR.IR.result(

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -380,7 +380,7 @@ function make_tracer(
     if haskey(seen, prev)
         return seen[prev]
     end
-    if mode == ArrayToConcrete && eltype(RT) <: AbstractFloat
+    if mode == ArrayToConcrete && eltype(RT) <: Union{AbstractFloat, Integer}
         return seen[prev] = ConcreteRArray(prev)
     end
     TT = traced_type(eltype(RT), (), Val(mode))

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -380,7 +380,7 @@ function make_tracer(
     if haskey(seen, prev)
         return seen[prev]
     end
-    if mode == ArrayToConcrete && eltype(RT) <: Union{AbstractFloat, Integer}
+    if mode == ArrayToConcrete && eltype(RT) <: Union{AbstractFloat,Integer}
         return seen[prev] = ConcreteRArray(prev)
     end
     TT = traced_type(eltype(RT), (), Val(mode))

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -230,51 +230,51 @@ end
         # @test f(x_concrete) ≈ ones(3)
 
         # vcat
-        g(x) = [x; x; x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_vcat(x) = [x; x; x]
+        f = @compile test_vcat(x_concrete)
+        @test f(x_concrete) == test_vcat(x)
         @test eltype(f(x_concrete)) === Bool
 
         # hcat
-        g(x) = [x x x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_hcat(x) = [x x x]
+        f = @compile test_hcat(x_concrete)
+        @test f(x_concrete) == test_hcat(x)
         @test eltype(f(x_concrete)) === Bool
 
         # hvcat
-        g(x) = [x x x; x x x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_hvcat(x) = [x x x; x x x]
+        f = @compile test_hvcat(x_concrete)
+        @test f(x_concrete) == test_hvcat(x)
         @test eltype(f(x_concrete)) === Bool
 
         # hvncat
-        g(x) = [x x x; x x x;;; x x x; x x x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_hvncat(x) = [x x x; x x x;;; x x x; x x x]
+        f = @compile test_hvncat(x_concrete)
+        @test f(x_concrete) == test_hvncat(x)
         @test eltype(f(x_concrete)) === Bool
 
         # typed_vcat
-        g(x) = Int[x; x; x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_typed_vcat(x) = Int[x; x; x]
+        f = @compile test_typed_vcat(x_concrete)
+        @test f(x_concrete) == test_typed_vcat(x)
         @test eltype(f(x_concrete)) === Int
 
         # typed_hcat
-        g(x) = Int[x x x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_typed_hcat(x) = Int[x x x]
+        f = @compile test_typed_hcat(x_concrete)
+        @test f(x_concrete) == test_typed_hcat(x)
         @test eltype(f(x_concrete)) === Int
 
         # typed_hvcat
-        g(x) = Int[x x x; x x x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_typed_hvcat(x) = Int[x x x; x x x]
+        f = @compile test_typed_hvcat(x_concrete)
+        @test f(x_concrete) == test_typed_hvcat(x)
         @test eltype(f(x_concrete)) === Int
 
         # typed_hvncat
-        g(x) = Int[x x x; x x x;;; x x x; x x x]
-        f = @compile g(x_concrete)
-        @test f(x_concrete) == g(x)
+        test_hvncat(x) = Int[x x x; x x x;;; x x x; x x x]
+        f = @compile test_hvncat(x_concrete)
+        @test f(x_concrete) == test_hvncat(x)
         @test eltype(f(x_concrete)) === Int
     end
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -272,9 +272,9 @@ end
         @test eltype(f(x_concrete)) === Int
 
         # typed_hvncat
-        test_hvncat(x) = Int[x x x; x x x;;; x x x; x x x]
-        f = @compile test_hvncat(x_concrete)
-        @test f(x_concrete) == test_hvncat(x)
+        test_typed_hvncat(x) = Int[x x x; x x x;;; x x x; x x x]
+        f = @compile test_typed_hvncat(x_concrete)
+        @test f(x_concrete) == test_typed_hvncat(x)
         @test eltype(f(x_concrete)) === Int
     end
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -241,6 +241,13 @@ end
         @test f(x_concrete) == ones(Bool, 2, 3)
         @test eltype(f(x_concrete)) === Bool
 
+        # hvncat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x x x; x x x;;; x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Bool, 2, 3, 2)
+        @test eltype(f(x_concrete)) === Bool
+
         # typed_vcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x; x; x]
@@ -260,6 +267,13 @@ end
             return Int[x x x; x x x]
         end
         @test f(x_concrete) == ones(Int, 2, 3)
+        @test eltype(f(x_concrete)) === Int
+
+        # typed_hvncat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x x x; x x x;;; x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Int, 2, 3, 2)
         @test eltype(f(x_concrete)) === Int
     end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -210,6 +210,100 @@ end
 end
 
 @testset "concatenation" begin
+    @testset "0-dim" begin
+        x = fill(true)
+        x_concrete = Reactant.to_rarray(x)
+
+        # NOTE [,,,] is a call to `vect`, not `*cat`
+        # f = Reactant.compile((x_concrete,)) do x
+        #     return [x, x, x]
+        # end
+        # @test f(x_concrete) ≈ ones(3)
+
+        # vcat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x; x; x]
+        end
+        @test f(x_concrete) == ones(Bool, 3)
+
+        # hcat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x x x]
+        end
+        @test f(x_concrete) == ones(Bool, 1, 3)
+
+        # hvcat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Bool, 2, 3)
+
+        # typed_vcat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x; x; x]
+        end
+        @test f(x_concrete) == ones(Int, 3)
+
+        # typed_hcat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x; x; x]
+        end
+        @test f(x_concrete) == ones(Int, 1, 3)
+
+        # typed_hvcat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Int, 2, 3)
+    end
+
+    @testset "1-dim" begin
+        x = ones(Bool, 2)
+        x_concrete = Reactant.to_rarray(x)
+
+        # NOTE [,,,] is a call to `vect`, not `*cat`
+        # f = Reactant.compile((x_concrete,)) do x
+        #     return [x, x, x]
+        # end
+        # @test f(x_concrete) ≈ ones(3)
+
+        # vcat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x; x; x]
+        end
+        @test f(x_concrete) == ones(Bool, 6)
+
+        # hcat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x x x]
+        end
+        @test f(x_concrete) == ones(Bool, 2, 3)
+
+        # hvcat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Bool, 4, 3)
+
+        # typed_vcat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x; x; x]
+        end
+        @test f(x_concrete) == ones(Int, 6)
+
+        # typed_hcat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x; x; x]
+        end
+        @test f(x_concrete) == ones(Int, 2, 3)
+
+        # typed_hvcat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Int, 4, 3)
+    end
+
     x = ones(2, 4, 3)
     x_concrete = Reactant.to_rarray(x)
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -210,8 +210,8 @@ end
 end
 
 @testset "concatenation" begin
-    @testset "0-dim" begin
-        x = fill(true)
+    @testset "$(ndims(x))-dim" for x in [fill(true), fill(true, 2)]
+        x = [true, false]
         x_concrete = Reactant.to_rarray(x)
 
         # NOTE [,,,] is a call to `vect`, not `*cat`
@@ -221,126 +221,51 @@ end
         # @test f(x_concrete) ≈ ones(3)
 
         # vcat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x; x; x]
-        end
-        @test f(x_concrete) == ones(Bool, 3)
+        g(x) = [x; x; x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Bool
 
         # hcat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x x x]
-        end
-        @test f(x_concrete) == ones(Bool, 1, 3)
+        g(x) = [x x x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Bool
 
         # hvcat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Bool, 2, 3)
+        g(x) = [x x x; x x x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Bool
 
         # hvncat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x x x; x x x;;; x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Bool, 2, 3, 2)
+        g(x) = [x x x; x x x;;; x x x; x x x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Bool
 
         # typed_vcat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x; x; x]
-        end
-        @test f(x_concrete) == ones(Int, 3)
+        g(x) = Int[x; x; x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Int
 
         # typed_hcat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x x x]
-        end
-        @test f(x_concrete) == ones(Int, 1, 3)
+        g(x) = Int[x x x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Int
 
         # typed_hvcat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Int, 2, 3)
+        g(x) = Int[x x x; x x x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Int
 
         # typed_hvncat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x x x; x x x;;; x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Int, 2, 3, 2)
-        @test eltype(f(x_concrete)) === Int
-    end
-
-    @testset "1-dim" begin
-        x = ones(Bool, 2)
-        x_concrete = Reactant.to_rarray(x)
-
-        # NOTE [,,,] is a call to `vect`, not `*cat`
-        # f = Reactant.compile((x_concrete,)) do x
-        #     return [x, x, x]
-        # end
-        # @test f(x_concrete) ≈ ones(3)
-
-        # vcat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x; x; x]
-        end
-        @test f(x_concrete) == ones(Bool, 6)
-        @test eltype(f(x_concrete)) === Bool
-
-        # hcat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x x x]
-        end
-        @test f(x_concrete) == ones(Bool, 2, 3)
-        @test eltype(f(x_concrete)) === Bool
-
-        # hvcat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Bool, 4, 3)
-        @test eltype(f(x_concrete)) === Bool
-
-        # hvncat
-        f = Reactant.compile((x_concrete,)) do x
-            return [x x x; x x x;;; x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Bool, 4, 3, 2)
-        @test eltype(f(x_concrete)) === Bool
-
-        # typed_vcat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x; x; x]
-        end
-        @test f(x_concrete) == ones(Int, 6)
-        @test eltype(f(x_concrete)) === Int
-
-        # typed_hcat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x x x]
-        end
-        @test f(x_concrete) == ones(Int, 2, 3)
-        @test eltype(f(x_concrete)) === Int
-
-        # typed_hvcat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Int, 4, 3)
-        @test eltype(f(x_concrete)) === Int
-
-        # typed_hvncat
-        f = Reactant.compile((x_concrete,)) do x
-            return Int[x x x; x x x;;; x x x; x x x]
-        end
-        @test f(x_concrete) == ones(Int, 4, 3, 2)
+        g(x) = Int[x x x; x x x;;; x x x; x x x]
+        f = @compile g(x_concrete)
+        @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Int
     end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -225,36 +225,42 @@ end
             return [x; x; x]
         end
         @test f(x_concrete) == ones(Bool, 3)
+        @test eltype(f(x_concrete)) === Bool
 
         # hcat
         f = Reactant.compile((x_concrete,)) do x
             return [x x x]
         end
         @test f(x_concrete) == ones(Bool, 1, 3)
+        @test eltype(f(x_concrete)) === Bool
 
         # hvcat
         f = Reactant.compile((x_concrete,)) do x
             return [x x x; x x x]
         end
         @test f(x_concrete) == ones(Bool, 2, 3)
+        @test eltype(f(x_concrete)) === Bool
 
         # typed_vcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x; x; x]
         end
         @test f(x_concrete) == ones(Int, 3)
+        @test eltype(f(x_concrete)) === Int
 
         # typed_hcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x; x; x]
         end
         @test f(x_concrete) == ones(Int, 1, 3)
+        @test eltype(f(x_concrete)) === Int
 
         # typed_hvcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x x x; x x x]
         end
         @test f(x_concrete) == ones(Int, 2, 3)
+        @test eltype(f(x_concrete)) === Int
     end
 
     @testset "1-dim" begin
@@ -272,36 +278,42 @@ end
             return [x; x; x]
         end
         @test f(x_concrete) == ones(Bool, 6)
+        @test eltype(f(x_concrete)) === Bool
 
         # hcat
         f = Reactant.compile((x_concrete,)) do x
             return [x x x]
         end
         @test f(x_concrete) == ones(Bool, 2, 3)
+        @test eltype(f(x_concrete)) === Bool
 
         # hvcat
         f = Reactant.compile((x_concrete,)) do x
             return [x x x; x x x]
         end
         @test f(x_concrete) == ones(Bool, 4, 3)
+        @test eltype(f(x_concrete)) === Bool
 
         # typed_vcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x; x; x]
         end
         @test f(x_concrete) == ones(Int, 6)
+        @test eltype(f(x_concrete)) === Int
 
         # typed_hcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x; x; x]
         end
         @test f(x_concrete) == ones(Int, 2, 3)
+        @test eltype(f(x_concrete)) === Int
 
         # typed_hvcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x x x; x x x]
         end
         @test f(x_concrete) == ones(Int, 4, 3)
+        @test eltype(f(x_concrete)) === Int
     end
 
     x = ones(2, 4, 3)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -210,8 +210,17 @@ end
 end
 
 @testset "concatenation" begin
-    @testset "$(ndims(x))-dim" for x in [fill(true), fill(true, 2)]
-        x = [true, false]
+    @testset "$(ndims(x))-dim" for x in [
+        fill(true),
+        [true, false],
+        [true false],
+        [true true; true false],
+        [
+            true true true true; true true true false;;;
+            true true false true; true true false false;;;
+            true false true true; true false true false
+        ],
+    ]
         x_concrete = Reactant.to_rarray(x)
 
         # NOTE [,,,] is a call to `vect`, not `*cat`
@@ -268,21 +277,6 @@ end
         @test f(x_concrete) == g(x)
         @test eltype(f(x_concrete)) === Int
     end
-
-    x = ones(2, 4, 3)
-    x_concrete = Reactant.to_rarray(x)
-
-    cat1(x) = vcat(x, x, x)
-    cat2(x) = hcat(x, x, x)
-    cat3(x) = cat(x, x, x; dims=Val(3))
-
-    cat1_compiled = @compile cat1(x_concrete)
-    cat2_compiled = @compile cat2(x_concrete)
-    cat3_compiled = @compile cat3(x_concrete)
-
-    @test cat1(x) ≈ cat1_compiled(x_concrete)
-    @test cat2(x) ≈ cat2_compiled(x_concrete)
-    @test cat3(x) ≈ cat3_compiled(x_concrete)
 end
 
 function update_on_copy(x)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -308,6 +308,13 @@ end
         @test f(x_concrete) == ones(Bool, 4, 3)
         @test eltype(f(x_concrete)) === Bool
 
+        # hvncat
+        f = Reactant.compile((x_concrete,)) do x
+            return [x x x; x x x;;; x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Bool, 4, 3, 2)
+        @test eltype(f(x_concrete)) === Bool
+
         # typed_vcat
         f = Reactant.compile((x_concrete,)) do x
             return Int[x; x; x]
@@ -327,6 +334,13 @@ end
             return Int[x x x; x x x]
         end
         @test f(x_concrete) == ones(Int, 4, 3)
+        @test eltype(f(x_concrete)) === Int
+
+        # typed_hvncat
+        f = Reactant.compile((x_concrete,)) do x
+            return Int[x x x; x x x;;; x x x; x x x]
+        end
+        @test f(x_concrete) == ones(Int, 4, 3, 2)
         @test eltype(f(x_concrete)) === Int
     end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -257,7 +257,7 @@ end
 
         # typed_hcat
         f = Reactant.compile((x_concrete,)) do x
-            return Int[x; x; x]
+            return Int[x x x]
         end
         @test f(x_concrete) == ones(Int, 1, 3)
         @test eltype(f(x_concrete)) === Int
@@ -317,7 +317,7 @@ end
 
         # typed_hcat
         f = Reactant.compile((x_concrete,)) do x
-            return Int[x; x; x]
+            return Int[x x x]
         end
         @test f(x_concrete) == ones(Int, 2, 3)
         @test eltype(f(x_concrete)) === Int


### PR DESCRIPTION
It's not yet finished, but this should fix #148