### PR TITLE
Write Bazel rule for IFRT dialect

### DIFF
--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -514,6 +514,20 @@ gentbl_cc_library(
     tblgen = "//:mlir-jl-tblgen",
 )
 
+gentbl_cc_library(
+    name = "IFRTJLIncGen",
+    tbl_outs = [(
+            ["--generator=jl-op-defs", "--disable-module-wrap=0"],
+            "IFRT.inc.jl"
+        )
+    ],
+    td_file = "@xla//xla/python/ifrt/ir:ifrt_ops.td",
+    deps = [
+        "@xla//xla/python/ifrt/ir:ifrt_td",
+    ],
+    tblgen = "//:mlir-jl-tblgen",
+)
+
 genrule(
     name = "libMLIR_h.jl",
     tags = [


### PR DESCRIPTION
Currently it gives this error:

```
external/xla/xla/python/ifrt/ir/ifrt_ops.td:24:9: error: Could not find include file 'xla/python/ifrt/ir/ifrt_dialect.td'
include "xla/python/ifrt/ir/ifrt_dialect.td"
```

I believe that it's missing a include path flag.