### PR TITLE
fix: unbreak precompilation

### DIFF
--- a/src/mlir/IR/Type.jl
+++ b/src/mlir/IR/Type.jl
@@ -231,14 +231,6 @@ Checks whether the given type is an f64 type.
 """
 isf64(type::Type) = API.mlirTypeIsAF64(type)
 
-# Complex types
-"""
-    Type(Complex{T}) where {T}
-
-Creates a complex type with the given element type in the same context as the element type. The type is owned by the context.
-"""
-Type(::Core.Type{Complex{T}}) where {T} = Type(API.mlirComplexTypeGet(Type(T)))
-
 """
     iscomplex(type)
 


### PR DESCRIPTION
precompile is currently broken due to repeated definition https://buildkite.com/julialang/reactant-dot-jl/builds/1100#0192d4c6-e438-4424-ba7e-9d3aa9aa6858/277-706 