### PR TITLE
Add C-API for constructing Complex Attributes

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Async/IR/Async.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
@@ -62,6 +63,27 @@
 using namespace mlir;
 using namespace llvm;
 using namespace xla;
+
+// MLIR C-API extras
+#pragma region MLIR Extra
+MLIR_CAPI_EXPORTED MlirAttribute mlirComplexFloatAttrGet(MlirContext ctx, MlirType type, float real, float imag) {
+    return wrap(complex::NumberAttr::get(unwrap(type), static_cast<double>(real), static_cast<double>(imag)));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute mlirComplexFloatAttrGetChecked(MlirLocation loc, MlirType type, float real, float imag) {
+    return wrap(complex::NumberAttr::getChecked(unwrap(loc), unwrap(type), real, imag));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute mlirComplexDoubleAttrGet(MlirContext ctx, MlirType type, double real, double imag) {
+    return wrap(complex::NumberAttr::get(unwrap(type), real, imag));
+}
+
+MLIR_CAPI_EXPORTED MlirAttribute mlirComplexDoubleAttrGetChecked(MlirLocation loc, MlirType type, double real, double imag) {
+    return wrap(complex::NumberAttr::getChecked(unwrap(loc), unwrap(type), unwrap(type), real, imag));
+}
+
+MlirTypeID mlirComplexAttrGetTypeID(void) { return wrap(complex::NumberAttr::getTypeID()); }
+#pragma endregion
 
 // int google::protobuf::io::CodedInputStream::default_recursion_limit_ = 100;
 // int xla::_LayoutProto_default_instance_;

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -66,19 +66,11 @@ using namespace xla;
 
 // MLIR C-API extras
 #pragma region MLIR Extra
-MLIR_CAPI_EXPORTED MlirAttribute mlirComplexFloatAttrGet(MlirContext ctx, MlirType type, float real, float imag) {
-    return wrap(complex::NumberAttr::get(unwrap(type), static_cast<double>(real), static_cast<double>(imag)));
-}
-
-MLIR_CAPI_EXPORTED MlirAttribute mlirComplexFloatAttrGetChecked(MlirLocation loc, MlirType type, float real, float imag) {
-    return wrap(complex::NumberAttr::getChecked(unwrap(loc), unwrap(type), real, imag));
-}
-
-MLIR_CAPI_EXPORTED MlirAttribute mlirComplexDoubleAttrGet(MlirContext ctx, MlirType type, double real, double imag) {
+MLIR_CAPI_EXPORTED MlirAttribute mlirComplexAttrDoubleGet(MlirContext ctx, MlirType type, double real, double imag) {
     return wrap(complex::NumberAttr::get(unwrap(type), real, imag));
 }
 
-MLIR_CAPI_EXPORTED MlirAttribute mlirComplexDoubleAttrGetChecked(MlirLocation loc, MlirType type, double real, double imag) {
+MLIR_CAPI_EXPORTED MlirAttribute mlirComplexAttrDoubleGetChecked(MlirLocation loc, MlirType type, double real, double imag) {
     return wrap(complex::NumberAttr::getChecked(unwrap(loc), unwrap(type), unwrap(type), real, imag));
 }
 

--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -308,6 +308,7 @@ cc_library(
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:AsyncDialect",
+        "@llvm-project//mlir:ComplexDialect",
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:ConversionPasses",
         "@llvm-project//mlir:DLTIDialect",

--- a/src/mlir/IR/Attribute.jl
+++ b/src/mlir/IR/Attribute.jl
@@ -138,11 +138,21 @@ end
 
 Creates a complex attribute in the given context with the given complex value and double-precision FP semantics.
 """
-function Attribute(c::T; context::Context=context(), location::Location=Location(), check::Bool = false) where {T<:Complex}
+function Attribute(
+    c::T; context::Context=context(), location::Location=Location(), check::Bool=false
+) where {T<:Complex}
     if check
-        Attribute(API.mlirComplexAttrDoubleGetChecked(location, Type(T), Float64(real(c)), Float64(imag(c))))
+        Attribute(
+            API.mlirComplexAttrDoubleGetChecked(
+                location, Type(T), Float64(real(c)), Float64(imag(c))
+            ),
+        )
     else
-        Attribute(API.mlirComplexAttrDoubleGet(context, Type(T), Float64(real(c)), Float64(imag(c))))
+        Attribute(
+            API.mlirComplexAttrDoubleGet(
+                context, Type(T), Float64(real(c)), Float64(imag(c))
+            ),
+        )
     end
 end
 

--- a/src/mlir/IR/Attribute.jl
+++ b/src/mlir/IR/Attribute.jl
@@ -134,6 +134,19 @@ function Base.Float64(attr::Attribute)
 end
 
 """
+    Attribute(complex; context=context(), location=Location(), check=false)
+
+Creates a complex attribute in the given context with the given complex value and double-precision FP semantics.
+"""
+function Attribute(c::T; context::Context=context(), location::Location=Location(), check::Bool = false) where {T<:Complex}
+    if check
+        Attribute(API.mlirComplexAttrDoubleGetChecked(location, Type(T), Float64(real(c)), Float64(imag(c))))
+    else
+        Attribute(API.mlirComplexAttrDoubleGet(context, Type(T), Float64(real(c)), Float64(imag(c))))
+    end
+end
+
+"""
     isinteger(attr)
 
 Checks whether the given attribute is an integer attribute.

--- a/src/mlir/MLIR.jl
+++ b/src/mlir/MLIR.jl
@@ -11,6 +11,19 @@ module API
     let
         include("libMLIR_h.jl")
     end
+
+    # MLIR C API - extra
+    function mlirComplexAttrDoubleGet(ctx, type, real, imag)
+        @ccall mlir_c.mlirComplexAttrDoubleGet(
+            ctx::MlirContext, type::MlirType, real::Cdouble, imag::Cdouble
+        )::MlirAttribute
+    end
+
+    function mlirComplexAttrDoubleGetChecked(loc, type, real, imag)
+        @ccall mlir_c.mlirComplexAttrDoubleGetChecked(
+            loc::MlirLocation, type::MlirType, real::Cdouble, imag::Cdouble
+        )::MlirAttribute
+    end
 end # module API
 
 include("IR/IR.jl")


### PR DESCRIPTION
In one of our applications, we're running into this error:

```julia
MethodError: Cannot `convert` an object of type ComplexF64 to an object of type Reactant.MLIR.API.MlirAttribute

Closest candidates are:
  convert(::Type{T}, !Matched::T) where T
   @ Base Base.jl:84
  convert(::Type{T}, !Matched::ConcreteRArray{T, 0}) where T
   @ Reactant ~/.julia/packages/Reactant/dFd6D/src/ConcreteRArray.jl:73
  convert(::Type{Reactant.MLIR.API.MlirAttribute}, !Matched::Reactant.MLIR.IR.Attribute)
   @ Reactant ~/.julia/packages/Reactant/dFd6D/src/mlir/IR/Attribute.jl:12
  ...


Stacktrace:
  [1] Reactant.MLIR.IR.Attribute(attribute::ComplexF64)
    @ Reactant.MLIR.IR ~/.julia/packages/Reactant/dFd6D/src/mlir/IR/Attribute.jl:2
  [2] autodiff(::ReverseMode{true, false, FFIABI, false, true}, ::EnzymeCore.Const{typeof(expectation)}, ::Type{Active}, ::Duplicated{Reactant.TracedRArray{Float64, 1}}, ::EnzymeCore.Const{Quantum})
    @ Reactant ~/.julia/packages/Reactant/dFd6D/src/Interpreter.jl:300
```

Our overlayed `Enzyme.autodiff` method is trying to create a Complex Attribute, but the MLIR C-API has no function for creating it yet. This PR adds them.

~Note: I just added support for `complex<f32>` and `complex<f64>`. Support for `complex<f16>` and `complex<bf16>` can be added, but I don't know how to convert a `uint16_t` to a `double` :sweat-smile:~ Actually, only `double`s are used when passing values through the C-API. For smaller precision, just configure correctly the `MLIR.Type` you're passing.

CC @todorbsc @pangoraw