### PR TITLE
fix resource exhaustion bug #190

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -254,6 +254,7 @@ end
 
 function compile_mlir(f, args; kwargs...)
     ctx = MLIR.IR.Context()
+    MLIR.IR.enable_multithreading!(false; context=ctx)
     Base.append!(Reactant.registry[]; context=ctx)
     @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
     MLIR.IR.context!(ctx) do
@@ -662,6 +663,7 @@ end
 function compile_xla(f, args; client=nothing, optimize=true)
     # register MLIR dialects
     ctx = MLIR.IR.Context()
+    MLIR.IR.enable_multithreading!(false; context=ctx)
     append!(Reactant.registry[]; context=ctx)
     @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
 

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -253,9 +253,7 @@ function run_pass_pipeline!(mod, pass_pipeline)
 end
 
 function compile_mlir(f, args; kwargs...)
-    ctx = MLIR.IR.Context()
-    MLIR.IR.enable_multithreading!(false; context=ctx)
-    Base.append!(Reactant.registry[]; context=ctx)
+    ctx = MLIR.IR.Context(Reactant.registry[], false)
     @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
     MLIR.IR.context!(ctx) do
         mod = MLIR.IR.Module(MLIR.IR.Location())
@@ -662,9 +660,7 @@ end
 
 function compile_xla(f, args; client=nothing, optimize=true)
     # register MLIR dialects
-    ctx = MLIR.IR.Context()
-    MLIR.IR.enable_multithreading!(false; context=ctx)
-    append!(Reactant.registry[]; context=ctx)
+    ctx = MLIR.IR.Context(Reactant.registry[], false)
     @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
 
     return MLIR.IR.context!(ctx) do

--- a/src/mlir/IR/Context.jl
+++ b/src/mlir/IR/Context.jl
@@ -28,6 +28,11 @@ function Context(f::Core.Function)
     end
 end
 
+Context(threading::Bool) = Context(API.mlirContextCreateWithThreading(threading))
+function Context(registry::DialectRegistry, threading::Bool)
+    return Context(API.mlirContextCreateWithRegistry(registry, threading))
+end
+
 Base.convert(::Core.Type{API.MlirContext}, c::Context) = c.context
 
 # Global state

--- a/src/mlir/IR/Context.jl
+++ b/src/mlir/IR/Context.jl
@@ -29,7 +29,7 @@ function Context(f::Core.Function)
 end
 
 Context(threading::Bool) = Context(API.mlirContextCreateWithThreading(threading))
-function Context(registry::DialectRegistry, threading::Bool)
+function Context(registry, threading)
     return Context(API.mlirContextCreateWithRegistry(registry, threading))
 end
 

--- a/test/bcast.jl
+++ b/test/bcast.jl
@@ -23,6 +23,7 @@ end
 
 function test()
     ctx = MLIR.IR.Context()
+    MLIR.IR.enable_multithreading!(false; context=ctx)
     Base.append!(Reactant.registry[]; context=ctx)
     @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
 

--- a/test/bcast.jl
+++ b/test/bcast.jl
@@ -22,9 +22,7 @@ end
 end
 
 function test()
-    ctx = MLIR.IR.Context()
-    MLIR.IR.enable_multithreading!(false; context=ctx)
-    Base.append!(Reactant.registry[]; context=ctx)
+    ctx = MLIR.IR.Context(Reactant.registry[], false)
     @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
 
     MLIR.IR.context!(ctx) do

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -45,9 +45,9 @@ Base.sum(x::NamedTuple{(:a,),Tuple{T}}) where {T<:Reactant.TracedRArray} = (; a=
     end
 
     @testset "resource exhaustation bug (#190)" begin
-        x = rand(2,2)
+        x = rand(2, 2)
         y = Reactant.to_rarray(x)
-        @test try 
+        @test try
             for _ in 1:10_000
                 f = @compile sum(y)
             end

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -44,16 +44,17 @@ Base.sum(x::NamedTuple{(:a,),Tuple{T}}) where {T<:Reactant.TracedRArray} = (; a=
         @test ftype2_compiled(a) ≈ Float32.(a)
     end
 
-    @testset "resource exhaustation bug (#190)" begin
-        x = rand(2, 2)
-        y = Reactant.to_rarray(x)
-        @test try
-            for _ in 1:10_000
-                f = @compile sum(y)
-            end
-            true
-        catch e
-            false
-        end
-    end
+    # disabled due to long test time (core tests go from 2m to 7m just with this test)
+    # @testset "resource exhaustation bug (#190)" begin
+    #     x = rand(2, 2)
+    #     y = Reactant.to_rarray(x)
+    #     @test try
+    #         for _ in 1:10_000
+    #             f = @compile sum(y)
+    #         end
+    #         true
+    #     catch e
+    #         false
+    #     end
+    # end
 end

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -43,4 +43,17 @@ Base.sum(x::NamedTuple{(:a,),Tuple{T}}) where {T<:Reactant.TracedRArray} = (; a=
         @test ftype1_compiled(a) ≈ Float64.(a)
         @test ftype2_compiled(a) ≈ Float32.(a)
     end
+
+    @testset "resource exhaustation bug (#190)" begin
+        x = rand(2,2)
+        y = Reactant.to_rarray(x)
+        @test try 
+            for _ in 1:10_000
+                f = @compile sum(y)
+            end
+            true
+        catch e
+            false
+        end
+    end
 end


### PR DESCRIPTION
Disables multithreaded MLIR contexts as suggested in https://github.com/jax-ml/jax/issues/16272

the test needs to run `@compile` at least a number somewhat above 8000 times in macOS (I put 10,000), so it increases core test time from 2 minutes to... 7 minutes 😅