### PR TITLE
feat: add support for NNlib make causal mask

### DIFF
--- a/test/nn/nnlib.jl
+++ b/test/nn/nnlib.jl
@@ -163,3 +163,13 @@ end
 
     @test @jit(NNlib.pad_constant(x_ra, (1, 1))) ≈ NNlib.pad_constant(x, (1, 1))
 end
+
+@testset "make_causal_mask" begin
+    x = rand(2, 10)
+    x_ra = Reactant.ConcreteRArray(x)
+
+    @test @jit(NNlib.make_causal_mask(x_ra)) ≈ NNlib.make_causal_mask(x)
+
+    causal_mask2(x) = NNlib.make_causal_mask(x; dims=1)
+    @test @jit(causal_mask2(x_ra)) ≈ causal_mask2(x)
+end


### PR DESCRIPTION
The fallback generates quite an inefficient IR:

```mlir
julia> @code_hlo NNlib.make_causal_mask(x_ra)
Module:
module attributes {transform.with_named_sequence} {
  func.func @main(%arg0: tensor<4x4xf64>) -> tensor<4x4xi1> {
    %c = stablehlo.constant dense<3> : tensor<i64>
    %c_0 = stablehlo.constant dense<2> : tensor<i64>
    %c_1 = stablehlo.constant dense<false> : tensor<1x1xi1>
    %c_2 = stablehlo.constant dense<true> : tensor<1x1xi1>
    %c_3 = stablehlo.constant dense<[[true, true, true, true], [true, true, true, true], [true, false, true, true], [true, false, true, false]]> : tensor<4x4xi1>
    %c_4 = stablehlo.constant dense<1> : tensor<i64>
    %c_5 = stablehlo.constant dense<0> : tensor<i64>
    %0 = stablehlo.dynamic_update_slice %c_3, %c_2, %c_4, %c_5 : (tensor<4x4xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<4x4xi1>
    %1 = stablehlo.dynamic_update_slice %0, %c_1, %c_0, %c_5 : (tensor<4x4xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<4x4xi1>
    %2 = stablehlo.dynamic_update_slice %1, %c_1, %c, %c_5 : (tensor<4x4xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<4x4xi1>
    %3 = stablehlo.dynamic_update_slice %2, %c_1, %c_0, %c_4 : (tensor<4x4xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<4x4xi1>
    %4 = stablehlo.dynamic_update_slice %3, %c_1, %c, %c_4 : (tensor<4x4xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<4x4xi1>
    %5 = stablehlo.dynamic_update_slice %4, %c_1, %c, %c_0 : (tensor<4x4xi1>, tensor<1x1xi1>, tensor<i64>, tensor<i64>) -> tensor<4x4xi1>
    %6 = stablehlo.transpose %5, dims = [1, 0] : (tensor<4x4xi1>) -> tensor<4x4xi1>
    return %6 : tensor<4x4xi1>
  }
}
```

Now it is:

```mlir
julia> @code_hlo NNlib.make_causal_mask(x_ra)
Module:
module attributes {transform.with_named_sequence} {
  func.func @main(%arg0: tensor<4x4xf64>) -> tensor<4x4xi1> {
    %c = stablehlo.constant dense<[[true, false, false, false], [true, true, false, false], [true, true, true, false], [true, true, true, true]]> : tensor<4x4xi1>
    return %c : tensor<4x4xi1>
  }
}
```