### PR TITLE
feat: partial NNlib.gather support + better indexing support

### DIFF
--- a/ext/ReactantNNlibExt.jl
+++ b/ext/ReactantNNlibExt.jl
@@ -296,6 +296,17 @@ function NNlib.make_causal_mask(x::AnyTracedRArray; dims::Int=2)
     )
 end
 
+# XXX: reevaluate this manual optimization once
+#      https://github.com/EnzymeAD/Enzyme-JAX/issues/164 is handled
+function NNlib.gather!(
+    dst::TracedRArray{T1,2},
+    src::AnyTracedRArray{T2,2},
+    idxs::Union{AbstractUnitRange{<:Number}},
+) where {T1,T2}
+    dst.mlir_data = src[:, idxs].mlir_data
+    return dst
+end
+
 function NNlib.gather!(
     dst::TracedRArray{T1,2}, src::AnyTracedRArray{T2,2}, idxs::AbstractVector{<:Number}
 ) where {T1,T2}

--- a/ext/ReactantNNlibExt.jl
+++ b/ext/ReactantNNlibExt.jl
@@ -315,13 +315,17 @@ function NNlib.gather!(
     idxs = (Reactant.promote_to(TracedRArray{Int,1}, idxs) .- 1).mlir_data
     slice_sizes = Reactant.promote_to(TracedRArray{Int,1}, [size(src, 1), 1]).mlir_data
 
-    dimension_numbers = """
-        #stablehlo.gather<
-            offset_dims = [0],
-            collapsed_slice_dims = [1],
-            start_index_map = [1],
-            index_vector_dim = 1>"""
-    dimension_numbers = parse(Reactant.MLIR.IR.Attribute, dimension_numbers)
+    #! format: off
+    dimension_numbers = MLIR.API.stablehloGatherDimensionNumbersGet(
+        MLIR.IR.context(),
+        Int64(1), Int64[0],
+        Int64(1), Int64[1],
+        Int64(0), Int64[],
+        Int64(0), Int64[],
+        Int64(1), Int64[1],
+        Int64(1)
+    )
+    #! format: on
 
     res = MLIR.IR.result(
         Reactant.MLIR.Dialects.stablehlo.dynamic_gather(

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -148,7 +148,9 @@ function Base.setindex!(
 end
 
 function Base.setindex!(
-    a::AnyTracedRArray{T,N}, v, indices::Vararg{Union{Base.AbstractUnitRange,Colon,Int},N}
+    a::AnyTracedRArray{T,N},
+    v,
+    indices::Vararg{Union{Base.AbstractUnitRange,Colon,Int,TracedRNumber{Int}},N},
 ) where {T,N}
     ancestor_indices = get_ancestor_indices(a, indices...)
     setindex!(ancestor(a), v, ancestor_indices...)

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -155,6 +155,8 @@ function Base.setindex!(
     return a
 end
 
+Base.Tuple(x::TracedRArray) = ntuple(Base.Fix1(Base.getindex, x), length(x))
+
 Base.size(x::TracedRArray) = x.shape
 
 Base.copy(A::TracedRArray{T,N}) where {T,N} = TracedRArray{T,N}((), A.mlir_data, size(A))

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -75,7 +75,7 @@ and require expensive copies and synchronization each time and therefore should 
     )
     res2 = MLIR.IR.result(
         MLIR.Dialects.stablehlo.reshape(
-            res1; result_0=MLIR.IR.TensorType(Int[], eltype(MLIR.IR.type(res1)))
+            res1; result_0=MLIR.IR.TensorType(Int64[], eltype(MLIR.IR.type(res1)))
         ),
         1,
     )

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -97,7 +97,11 @@ function Base.getindex(a::TracedRArray{T,N}, indices::Vararg{Any,N}) where {T,N}
 
     foreach(indices) do idxs
         idxs isa Number && return nothing
-        all(isone, diff(idxs)) || error("non-contiguous indexing is not supported")
+        contiguous = all(isone, diff(idxs))
+        # XXX: We want to throw error even for dynamic indexing
+        if typeof(a) <: Bool
+            contiguous || error("non-contiguous indexing is not supported")
+        end
     end
 
     start_indices = map(indices) do i
@@ -875,3 +879,6 @@ for (minT, maxT) in Iterators.product((Number, TracedRNumber), (Number, TracedRN
         return x
     end
 end
+
+Base.all(f::Function, x::TracedRArray) = mapreduce(f, &, x)
+Base.any(f::Function, x::TracedRArray) = mapreduce(f, |, x)

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -68,7 +68,7 @@ and require expensive copies and synchronization each time and therefore should 
     )
 
     start_indices = [promote_to(TracedRNumber{Int}, i - 1).mlir_data for i in index]
-    slice_sizes = [1 for _ in index]
+    slice_sizes = [Int64(1) for _ in index]
 
     res1 = MLIR.IR.result(
         MLIR.Dialects.stablehlo.dynamic_slice(a.mlir_data, start_indices; slice_sizes), 1
@@ -107,7 +107,7 @@ function Base.getindex(a::TracedRArray{T,N}, indices::Vararg{Any,N}) where {T,N}
     start_indices = map(indices) do i
         return promote_to(TracedRNumber{Int}, first(i) - 1).mlir_data
     end
-    slice_sizes = [length(i) for i in indices]
+    slice_sizes = [Int64(length(i)) for i in indices]
     res = MLIR.IR.result(
         MLIR.Dialects.stablehlo.dynamic_slice(a.mlir_data, start_indices; slice_sizes), 1
     )

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -96,7 +96,7 @@ function Base.getindex(a::TracedRArray{T,N}, indices::Vararg{Any,N}) where {T,N}
     end
 
     foreach(indices) do idxs
-        idxs isa Number && return
+        idxs isa Number && return nothing
         all(isone, diff(idxs)) || error("non-contiguous indexing is not supported")
     end
 

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -699,7 +699,7 @@ end
 
 function broadcast_to_size(arg::T, rsize) where {T<:Number}
     attr = MLIR.IR.DenseElementsAttribute(Base.fill(arg, Tuple(rsize)))
-    return arg = TracedRArray{T,length(rsize)}(
+    return TracedRArray{T,length(rsize)}(
         (), MLIR.IR.result(MLIR.Dialects.stablehlo.constant(; value=attr), 1), rsize
     )
 end
@@ -709,6 +709,11 @@ function broadcast_to_size(arg::TracedRNumber, rsize)
     return broadcast_to_size_internal(
         TracedRArray{eltype(arg),0}((), arg.mlir_data, ()), rsize
     )
+end
+
+function broadcast_to_size(arg::AnyTracedRArray{T, 0}, rsize) where {T}
+    arg = materialize_traced_array(arg)
+    return broadcast_to_size(TracedRNumber{T}((), arg.mlir_data), rsize)
 end
 
 function broadcast_to_size(arg::AnyTracedRArray, rsize)

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -193,20 +193,24 @@ function Base.ifelse(
     )
 end
 
-function Base.:&(x::TracedRNumber{Bool}, y::TracedRNumber{Bool})
-    return TracedRNumber{Bool}(
-        (), MLIR.IR.result(MLIR.Dialects.stablehlo.and(x.mlir_data, y.mlir_data), 1)
-    )
-end
-function Base.:|(x::TracedRNumber{Bool}, y::TracedRNumber{Bool})
-    return TracedRNumber{Bool}(
-        (), MLIR.IR.result(MLIR.Dialects.stablehlo.or(x.mlir_data, y.mlir_data), 1)
-    )
-end
-function Base.:!(x::TracedRNumber{Bool})
-    return TracedRNumber{Bool}(
-        (), MLIR.IR.result(MLIR.Dialects.stablehlo.not(x.mlir_data), 1)
-    )
+for (T1, T2) in zip((Bool, Integer), (Bool, Integer))
+    @eval begin
+        function Base.:&(x::TracedRNumber{<:$(T1)}, y::TracedRNumber{<:$(T2)})
+            return TracedRNumber{promote_type(eltype(x), eltype(y))}(
+                (), MLIR.IR.result(MLIR.Dialects.stablehlo.and(x.mlir_data, y.mlir_data), 1)
+            )
+        end
+        function Base.:|(x::TracedRNumber{<:$(T1)}, y::TracedRNumber{<:$(T2)})
+            return TracedRNumber{promote_type(eltype(x), eltype(y))}(
+                (), MLIR.IR.result(MLIR.Dialects.stablehlo.or(x.mlir_data, y.mlir_data), 1)
+            )
+        end
+        function Base.:!(x::TracedRNumber{<:$(T1)})
+            return TracedRNumber{eltype(x)}(
+                (), MLIR.IR.result(MLIR.Dialects.stablehlo.not(x.mlir_data), 1)
+            )
+        end
+    end
 end
 
 function Base.literal_pow(

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -557,3 +557,14 @@ end
     @test minimum(y) ≥ 0.0
     @test x_ra ≈ x
 end
+
+@testset "dynamic indexing" begin
+    x = randn(5, 3)
+    x_ra = Reactant.to_rarray(x)
+
+    idx = [1, 2, 3]
+    idx_ra = Reactant.to_rarray(idx)
+
+    y = @jit(getindex(x_ra, idx_ra, :))
+    @test y ≈ x[idx, :]
+end

--- a/test/nn/nnlib.jl
+++ b/test/nn/nnlib.jl
@@ -226,7 +226,6 @@ end
             6 4 3 5
             5 7 7 5
         ][:, :, 1:1]
-        
         y = @jit(NNlib.gather(Reactant.to_rarray(src), Reactant.to_rarray(index)))
         @test y ≈ output
         @test y isa ConcreteRArray{Float32,3}
@@ -273,7 +272,6 @@ end
         @test size(y) == (size(src)[1:(end - 1)]..., size(index)...)
     end
 
-
     @testset "gather tuple index" begin
         ## 2d src, 1d index of 2-tuples -> 1d output
         src = Float32[
@@ -287,33 +285,31 @@ end
         M = NNlib.typelength(eltype(index))
         Nsrc = ndims(src)
         @test y isa ConcreteRArray{Float32,1}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
         @test y ≈ output
 
         y = @jit(NNlib.gather(Reactant.to_rarray(src), index))
         @test y ≈ output
         @test y isa ConcreteRArray{Float32,1}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
         @test y ≈ output
 
         ## 3d src, 2d index of 2-tuples -> 3d output
         n1, nsrc, nidx = 2, 3, 6
         src = rand(Float32, n1, nsrc, nsrc)
-        index = [
-            (rand(1:nsrc), rand(1:nsrc)) for i = 1:nidx, j = 1:nidx
-        ]
+        index = [(rand(1:nsrc), rand(1:nsrc)) for i in 1:nidx, j in 1:nidx]
 
         y = @jit(NNlib.gather(Reactant.to_rarray(src), Reactant.to_rarray(index)))
         M = NNlib.typelength(eltype(index))
         Nsrc = ndims(src)
         @test y isa ConcreteRArray{Float32,3}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
 
         y = @jit(NNlib.gather(Reactant.to_rarray(src), index))
         M = NNlib.typelength(eltype(index))
         Nsrc = ndims(src)
         @test y isa ConcreteRArray{Float32,3}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
     end
 
     @testset "gather cartesian index" begin
@@ -329,31 +325,29 @@ end
         M = NNlib.typelength(eltype(index))
         Nsrc = ndims(src)
         @test y isa ConcreteRArray{Float32,1}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
         @test y ≈ output
 
         y = @jit(NNlib.gather(Reactant.to_rarray(src), index))
         @test y ≈ output
         @test y isa ConcreteRArray{Float32,1}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
 
         ## 3d src, 2d index of 2-tuples -> 3d output
         n1, nsrc, nidx = 2, 3, 6
         src = rand(Float32, n1, nsrc, nsrc)
-        index = [
-            CartesianIndex((rand(1:nsrc), rand(1:nsrc))) for i = 1:nidx, j = 1:nidx
-        ]
+        index = [CartesianIndex((rand(1:nsrc), rand(1:nsrc))) for i in 1:nidx, j in 1:nidx]
 
         y = @jit(NNlib.gather(Reactant.to_rarray(src), Reactant.to_rarray(index)))
         M = NNlib.typelength(eltype(index))
         Nsrc = ndims(src)
         @test y isa ConcreteRArray{Float32,3}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
 
         y = @jit(NNlib.gather(Reactant.to_rarray(src), index))
         M = NNlib.typelength(eltype(index))
         Nsrc = ndims(src)
         @test y isa ConcreteRArray{Float32,3}
-        @test size(y) == (size(src)[1:Nsrc-M]..., size(index)...)
+        @test size(y) == (size(src)[1:(Nsrc - M)]..., size(index)...)
     end
 end


### PR DESCRIPTION
ideally we should be using `stablehlo.gather`, but this at least lets the currently fallback work

## Features

- Add partial support for `gather!` and `gather`. These are not the most efficient implementations but at least they work now.
- Non-contiguous indexing throws an error instead of giving incorrect results. See #242
- fixes #243. We emit `stablehlo.dynamic_slice` now