### PR TITLE
Disable verifier in main pass manager pipeline

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -308,7 +308,7 @@ function compile_mlir!(mod, f, args; optimize::Union{Bool,Symbol}=true)
             ),
         )
     elseif optimize === :only_enzyme
-        run_pass_pipeline!(mod, join(["enzyme-batch"]))
+        run_pass_pipeline!(mod, "enzyme-batch")
         run_pass_pipeline!(mod, "enzyme,arith-raise{stablehlo=true}"; enable_verifier=false)
         run_pass_pipeline!(
             mod,
@@ -336,11 +336,7 @@ function compile_mlir!(mod, f, args; optimize::Union{Bool,Symbol}=true)
         run_pass_pipeline!(mod, join([opt_passes, "enzyme-batch", opt_passes]))
         run_pass_pipeline!(mod, "enzyme,arith-raise{stablehlo=true}"; enable_verifier=false)
         run_pass_pipeline!(
-            mod,
-            join(
-                ["canonicalize", "remove-unnecessary-enzyme-ops", "enzyme-simplify-math"],
-                ',',
-            ),
+            mod, "canonicalize,remove-unnecessary-enzyme-ops,enzyme-simplify-math"
         )
     elseif optimize !== :none
         error("Invalid optimize option: $(Meta.quot(optimize))")

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -250,6 +250,7 @@ function run_pass_pipeline!(mod, pass_pipeline; enable_verifier=true)
     opm = MLIR.IR.OpPassManager(pm)
     MLIR.IR.add_pipeline!(opm, pass_pipeline)
     MLIR.IR.run!(pm, mod)
+    MLIR.IR.verifyall(mod; debug=false)
     return mod
 end
 
@@ -260,7 +261,7 @@ function run_pass_pipeline_on_source(source, pass_pipeline; enable_verifier=true
     MLIR.IR.context!(ctx) do
         mod = parse(MLIR.IR.Module, source)
         run_pass_pipeline!(mod, pass_pipeline; enable_verifier)
-        MLIR.IR.verifyall(mod)
+        MLIR.IR.verifyall(MLIR.IR.Operation(mod), debug=true)
         Text(repr(mod))
     end
 end

--- a/src/mlir/IR/Pass.jl
+++ b/src/mlir/IR/Pass.jl
@@ -40,8 +40,17 @@ Base.convert(::Core.Type{API.MlirPassManager}, pass::PassManager) = pass.pass
 
 Enable mlir-print-ir-after-all.
 """
-function enable_ir_printing!(pm)
-    API.mlirPassManagerEnableIRPrinting(pm)
+function enable_ir_printing!(
+    pm;
+    before_all=false,
+    after_all=false,
+    module_scope=false,
+    after_only_on_change=false,
+    after_only_on_failure=false,
+)
+    API.mlirPassManagerEnableIRPrinting(
+        pm, before_all, after_all, module_scope, after_only_on_change, after_only_on_failure
+    )
     return pm
 end
 


### PR DESCRIPTION
This is similar to the Enzyme-JAX lit tests where the verifier is disabled between passes for some complex-related test cases.
