### PR TITLE
gensym in `@code_hlo`

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -390,8 +390,6 @@ macro code_hlo(args...)
     )
     return esc(:($(compile_expr);
     $(first)($(compiled))))
-
-    return esc(first(compile_call_expr(__module__, compile_mlir, default_options, args...)))
 end
 
 """

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -385,13 +385,11 @@ end
 """
 macro code_hlo(args...)
     default_options = Dict{Symbol,Any}(:optimize => true)
-    compile_expr, (; compiled) = compile_call_expr(__module__, compile_mlir, default_options, args...)
-    return esc(
-        :(
-            $(compile_expr);
-            $(first)($(compiled))
-        )
+    compile_expr, (; compiled) = compile_call_expr(
+        __module__, compile_mlir, default_options, args...
     )
+    return esc(:($(compile_expr);
+    $(first)($(compiled))))
 
     return esc(first(compile_call_expr(__module__, compile_mlir, default_options, args...)))
 end
@@ -411,7 +409,9 @@ end
 """
 macro jit(args...)
     default_options = Dict{Symbol,Any}(:optimize => true, :sync => false)
-    compile_expr, (; compiled, args) = compile_call_expr(__module__, compile, default_options, args...)
+    compile_expr, (; compiled, args) = compile_call_expr(
+        __module__, compile, default_options, args...
+    )
     #! format: off
     return esc(
         :(
@@ -463,9 +463,7 @@ function compile_call_expr(mod, compiler, options, args...)
         $(f_symbol) = $(fname)
         $(args_symbol) = $(args_rhs)
         $(compiled_symbol) = $(compiler)(
-            $(f_symbol),
-            $(args_symbol);
-            $(Expr.(:kw, keys(options), values(options))...)
+            $(f_symbol), $(args_symbol); $(Expr.(:kw, keys(options), values(options))...)
         )
     end,
     (; compiled=compiled_symbol, args=args_symbol)


### PR DESCRIPTION
I missed the `@code_hlo` in my previous pr (#274).
I've now deduplicated the code for `@compile`, `@jit`, and `@code_hlo`.
Option kwargs passed to `@code_hlo` where handled slightly differently compared to the other two macros, now they're handled the same but maybe someone should check whether `@code_hlo` kwarg handling does what it's supposed to do.