### PR TITLE
test for traced_type where array isn't captured by type param

### DIFF
--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -98,10 +98,10 @@ function traced_type(::Type{T}, seen, mode) where {T}
     if T isa UnionAll
         aT = Base.argument_datatype(T)
         if isnothing(aT)
-            throw("Unhandled type $T")
+            throw(TracedTypeError("Unhandled type $T"))
         end
         if isnothing(Base.datatype_fieldcount(aT))
-            throw("Unhandled type $T")
+            throw(TracedTypeError("Unhandled type $T"))
         end
     end
 
@@ -111,7 +111,7 @@ function traced_type(::Type{T}, seen, mode) where {T}
 
     # if abstract it must be by reference
     if Base.isabstracttype(T)
-        throw("Unhandled abstract type $T")
+        throw(TracedTypeError("Unhandled abstract type $T"))
     end
 
     if !(Base.isconcretetype(T) || T isa UnionAll)
@@ -148,7 +148,11 @@ function traced_type(::Type{T}, seen, mode) where {T}
         end
     end
 
-    TT2 = Core.apply_type(T.name.wrapper, subParms...)
+    if T isa UnionAll
+        TT2 = Core.apply_type(T.name.wrapper, subParms...)
+    else
+        TT2 = T
+    end
     seen3 = (Val(T), Val(TT2), seen...)
     if fieldcount(T) == fieldcount(TT2)
         legal = true
@@ -167,7 +171,7 @@ function traced_type(::Type{T}, seen, mode) where {T}
     end
 
     name = Symbol[]
-    throw(error("Cannot convert type $T, best attempt $TT2 failed"))
+    throw(NoFieldMatchError(T, TT2))
 end
 
 function traced_type(::Type{T}, seen, ::Val{mode}) where {T<:ConcreteRArray,mode}
@@ -223,6 +227,28 @@ function traced_type(::Type{Val{T}}, seen, mode) where {T}
         return Val{T}
     end
     throw("Val type $(Val{T}) cannot be traced")
+end
+
+abstract type TracedTypeException <: Exception end
+
+struct TracedTypeError <: TracedTypeException
+    msg::String
+end
+function Base.showerror(io::IO, err::TracedTypeError)
+    print(io, "TracedTypeError: ")
+    return print(io, err.msg)
+end
+
+struct NoFieldMatchError <: TracedTypeException
+    origty
+    besteffort
+end
+function Base.showerror(io::IO, err::NoFieldMatchError)
+    print(io, "NoFieldMatchError: ")
+    return print(
+        io,
+        "Cannot convert type $(err.origty), best attempt $(err.besteffort) failed.\nThis could be because the type does not capture the fieldtypes that should be converted in its type parameters.",
+    )
 end
 
 append_path(path, i) = (path..., i)

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -148,7 +148,7 @@ function traced_type(::Type{T}, seen, mode) where {T}
         end
     end
 
-    if T isa UnionAll
+    if !isempty(subParms)
         TT2 = Core.apply_type(T.name.wrapper, subParms...)
     else
         TT2 = T

--- a/test/tracing.jl
+++ b/test/tracing.jl
@@ -1,5 +1,12 @@
 using Reactant
-using Reactant: traced_type, ConcreteRArray, TracedRArray, ConcreteToTraced, ArrayToConcrete
+using Reactant:
+    traced_type,
+    ConcreteRArray,
+    TracedRArray,
+    ConcreteToTraced,
+    ArrayToConcrete,
+    NoFieldMatchError,
+    TracedTypeError
 using Test
 
 @testset "Tracing" begin
@@ -99,12 +106,16 @@ using Test
                 )
             end
         end
-        @testset "mode = ArrayToConcrete" begin
+        @testset "traced_type exceptions" begin
+            @test_throws TracedTypeError Reactant.traced_type(
+                Real, Reactant.OrderedIdDict(), Val(Reactant.ArrayToConcrete)
+            )
+
             struct Node
                 x::Vector{Float64}
                 y::Union{Nothing,Node}
             end
-            @test_throws TypeError traced_type(
+            @test_throws NoFieldMatchError traced_type(
                 Node, Reactant.OrderedIdDict(), Val(ArrayToConcrete)
             )
         end

--- a/test/tracing.jl
+++ b/test/tracing.jl
@@ -1,5 +1,5 @@
 using Reactant
-using Reactant: traced_type, ConcreteRArray, TracedRArray, ConcreteToTraced
+using Reactant: traced_type, ConcreteRArray, TracedRArray, ConcreteToTraced, ArrayToConcrete
 using Test
 
 @testset "Tracing" begin
@@ -98,6 +98,15 @@ using Test
                     type, Reactant.OrderedIdDict(), Val(ConcreteToTraced)
                 )
             end
+        end
+        @testset "mode = ArrayToConcrete" begin
+            struct Node
+                x::Vector{Float64}
+                y::Union{Nothing,Node}
+            end
+            @test_throws TypeError traced_type(
+                Node, Reactant.OrderedIdDict(), Val(ArrayToConcrete)
+            )
         end
     end
 


### PR DESCRIPTION
Test to check that:
1. `traced_type` for `ArrayToConcrete` fails if there are array-typed fields whos type isn't captured by the type parameter list
2. The error isn't a stackoverflow because recursion is properly handled.