### PR TITLE
fix: don't print "Module"

### DIFF
--- a/src/mlir/IR/Module.jl
+++ b/src/mlir/IR/Module.jl
@@ -55,7 +55,6 @@ Views the module as a generic operation.
 Operation(module_::Module) = Operation(API.mlirModuleGetOperation(module_), false)
 
 function Base.show(io::IO, module_::Module)
-    println(io, "Module:")
     return show(io, Operation(module_))
 end
 

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -66,6 +66,15 @@ Base.sum(x::NamedTuple{(:a,),Tuple{T}}) where {T<:Reactant.TracedRArray} = (; a=
     # end
 end
 
+@testset "Module export" begin
+    f(x) = sin.(cos.(x))
+    x_ra = Reactant.to_rarray(rand(3))
+
+    hlo_code = @code_hlo f(x_ra)
+    @test !startswith(string(hlo_code), "Module")
+    @test startswith(string(hlo_code), "module {")
+end
+
 @testset "Bool attributes" begin
     x_ra = Reactant.to_rarray(false; track_numbers=(Number,))
     @test @jit(iszero(x_ra)) == true


### PR DESCRIPTION
Messes exporting stablehlo see https://github.com/LuxDL/Lux.jl/pull/1088/files#r1845238905