### PR TITLE
add check for null in `show(::Operation)`. 

### DIFF
--- a/src/mlir/IR/Operation.jl
+++ b/src/mlir/IR/Operation.jl
@@ -217,6 +217,10 @@ function lose_ownership!(operation::Operation)
 end
 
 function Base.show(io::IO, operation::Operation)
+    if mlirIsNull(operation.operation)
+        return write(io, "Operation(NULL)")
+    end
+
     c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
 
     buffer = IOBuffer()


### PR DESCRIPTION
`Operation` can't be constructed with null, but since it is mutable, the operation field can be ([and is](https://github.com/EnzymeAD/Reactant.jl/blob/6f7b25f49fb92f014ada6eba1ec6d25603fa59c0/src/Compiler.jl#L359C1-L359C51)) sometimes replaced with `C_NULL`.
I ran into this when running through the code using a debugger. Past the point where the operation contains null, the program segfaults because the debugging interface tries to show all live variables.