### PR TITLE
chore: specify sources for local dev

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,3 +53,6 @@ julia = "1.10"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+
+[sources]
+ReactantCore = { path = "lib/ReactantCore" }


### PR DESCRIPTION
Makes sure that we auto-use the subdirectory package during development. Has no effect when the Project is not directly loaded (and no end user is affected)