### PR TITLE
feat: define aos_to_soa

### DIFF
--- a/ext/ReactantArrayInterfaceExt.jl
+++ b/ext/ReactantArrayInterfaceExt.jl
@@ -1,9 +1,19 @@
 module ReactantArrayInterfaceExt
 
 using ArrayInterface: ArrayInterface
-using Reactant: RArray
+using Reactant: Reactant, RArray, ConcreteRArray, ConcreteRNumber, TracedRNumber, TracedRArray
 
 ArrayInterface.can_setindex(::Type{<:RArray}) = false
 ArrayInterface.fast_scalar_indexing(::Type{<:RArray}) = false
+
+function ArrayInterface.aos_to_soa(x::AbstractArray{<:ConcreteRNumber{T}}) where {T}
+    x_c = ConcreteRArray(zeros(T, size(x)))
+    x_c .= x
+    return x_c
+end
+
+function ArrayInterface.aos_to_soa(x::AbstractArray{<:TracedRNumber{T}}) where {T}
+    return reshape(vcat(x...), size(x))
+end
 
 end

--- a/ext/ReactantArrayInterfaceExt.jl
+++ b/ext/ReactantArrayInterfaceExt.jl
@@ -1,7 +1,8 @@
 module ReactantArrayInterfaceExt
 
 using ArrayInterface: ArrayInterface
-using Reactant: Reactant, RArray, ConcreteRArray, ConcreteRNumber, TracedRNumber, TracedRArray
+using Reactant:
+    Reactant, RArray, ConcreteRArray, ConcreteRNumber, TracedRNumber, TracedRArray
 
 ArrayInterface.can_setindex(::Type{<:RArray}) = false
 ArrayInterface.fast_scalar_indexing(::Type{<:RArray}) = false

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -15,6 +15,8 @@ import ..Reactant:
     TracedType
 
 @inline traced_getfield(@nospecialize(obj), field) = Base.getfield(obj, field)
+@inline traced_getfield(@nospecialize(obj::AbstractArray), field) =
+    Base.getindex(obj, field)
 
 function create_result(tocopy::T, path, result_stores) where {T}
     if !isstructtype(typeof(tocopy))

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -15,8 +15,9 @@ import ..Reactant:
     TracedType
 
 @inline traced_getfield(@nospecialize(obj), field) = Base.getfield(obj, field)
-@inline traced_getfield(@nospecialize(obj::AbstractArray), field) =
-    Base.getindex(obj, field)
+@inline traced_getfield(
+    @nospecialize(obj::AbstractArray{<:Union{ConcreteRNumber,ConcreteRArray}}), field
+) = Base.getindex(obj, field)
 
 function create_result(tocopy::T, path, result_stores) where {T}
     if !isstructtype(typeof(tocopy))

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -178,6 +178,16 @@ function traced_type(::Type{T}, seen, mode) where {T}
     throw(NoFieldMatchError(T, TT2))
 end
 
+function traced_type(::Type{<:ConcreteRNumber{T}}, seen, ::Val{mode}) where {T,mode}
+    if mode == ConcreteToTraced
+        return TracedRNumber{T}
+    elseif mode == TracedToConcrete
+        return ConcreteRNumber{T}
+    else
+        throw("Abstract RNumber cannot be made concrete")
+    end
+end
+
 function traced_type(::Type{T}, seen, ::Val{mode}) where {T<:ConcreteRArray,mode}
     if mode == ConcreteToTraced
         @inline base_typet(TV::TT) where {TT<:UnionAll} =

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -579,6 +579,11 @@ end
     x_res = collect(reshape(1.0:4.0, 2, 1, 2))
     x_ca = ConcreteRNumber.(x_res)
 
-    @test @allowscalar ArrayInterface.aos_to_soa(x_ca) ≈ x_res
-    @test @jit(ArrayInterface.aos_to_soa(x_ca)) ≈ x_res
+    y_ca1 = @allowscalar ArrayInterface.aos_to_soa(x_ca)
+    @test y_ca1 ≈ x_res
+    @test y_ca1 isa ConcreteRArray
+
+    y_ca2 = @jit(ArrayInterface.aos_to_soa(x_ca))
+    @test y_ca2 ≈ x_res
+    @test y_ca2 isa ConcreteRArray
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -572,3 +572,13 @@ end
     y = @jit(fn(x_ra, idx_ra))
     @test y ≈ x[idx, :]
 end
+
+@testset "aos_to_soa" begin
+    using ArrayInterface
+
+    x_res = collect(reshape(1.0:4.0, 2, 1, 2))
+    x_ca = ConcreteRNumber.(x_res)
+
+    @test @allowscalar ArrayInterface.aos_to_soa(x_ca) ≈ x_res
+    @test @jit(ArrayInterface.aos_to_soa(x_ca)) ≈ x_res
+end


### PR DESCRIPTION
Allows for a hook to ensure that we never end up propagating Array of Traced Values.

Related example for Tracker.jl where propagating Array{<:TrackedReal} leads to terrible performance https://github.com/LuxDL/Lux.jl/blob/cb0900f5350541a45e01af9ef12cc3d3e8df65d3/lib/LuxCore/ext/LuxCoreArrayInterfaceTrackerExt.jl#L8-L16