### PR TITLE
Fix tracedarray

### DIFF
--- a/src/Interpreter.jl
+++ b/src/Interpreter.jl
@@ -164,7 +164,7 @@ const enzyme_constnoneed = 5
 @inline act_from_type(::Enzyme.BatchDuplicatedNoNeed, reverse, needs_primal=true) =
     reverse ? enzyme_out : enzyme_dupnoneed
 @inline act_from_type(::Enzyme.Active, reverse, needs_primal=true) =
-    act_from_tuple(Enzyme.Active, reverse, needs_primal)
+    act_from_type(Enzyme.Active, reverse, needs_primal)
 @inline act_from_type(::Type{<:Enzyme.Const}, reverse, needs_primal) =
     if needs_primal
         enzyme_const

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -29,7 +29,7 @@ function TracedRArray{T,N}(rhs::TracedRArray{T0,N}) where {T,T0,N}
             (),
             MLIR.IR.result(
                 MLIR.Dialects.stablehlo.convert(
-                    rhs.mlir_data; result=mlir_type(TracedRArray{T0,N}, size(rhs))
+                    rhs.mlir_data; result=mlir_type(TracedRArray{T,N}, size(rhs))
                 ),
                 1,
             ),

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -887,5 +887,5 @@ Base.any(f::Function, x::TracedRArray) = mapreduce(f, |, x)
 # LinearAlgebra defines norm with some conditionals which cannot be traced directly
 function LinearAlgebra.norm(x::TracedRArray{T,N}, p::Real=2) where {T,N}
     isinf(p) && return maximum(abs, x)
-    return mapreduce(Base.Fix2(^, p), +, x) ^ (1 / p)
+    return mapreduce(Base.Fix2(^, p), +, x)^(1 / p)
 end


### PR DESCRIPTION
@avik-pal I tried to get the following code working in reactant. I fixed some stuff with tracedarray array conversion, but eventually hit some componentarray stuff that you might be able to help with.

```julia
using Enzyme, Lux, Random, ComponentArrays, LinearAlgebra
n = 100
x_batch = randn(2, n)
y_batch = randn(2, n)
model = Chain(Parallel(vcat, Dense(2, 1, tanh), Dense(2, 1, tanh)), Dense(2, 1, tanh))
rng = Random.default_rng()
Random.seed!(rng, 0)
ps, st = Lux.setup(Xoshiro(0), model);

nnfunc(x, y, psarray, st) = first(model((x, y), ComponentArray(psarray), st))[1]
function batcherror(xb, yb, psarray, st)
    val = zeros(n)
    for k = 1:n
        z = xb[:, k]
        dz = typeof(z)(zeros(2))
        dy = typeof(z)(zeros(2))
        Enzyme.autodiff(Enzyme.Reverse, nnfunc, Active, Duplicated(z, dz), Duplicated(yb[:, k], dy), Const(psarray), Const(st))
        val[k] = norm(dz)
    end
    return sum(val)
end

function func(x_batch, y_batch, psarr, st)
    Enzyme.autodiff(Enzyme.Reverse,batcherror,Active,Const(x_batch),Const(y_batch),Active(psarr),Const(st))
end

using Reactant
psarr = Reactant.to_rarray(getdata(ps))
x_batch = Reactant.to_rarray(x_batch)
y_batch = Reactant.to_rarray(y_batch)

f2 = Reactant.@compile func(x_batch, y_batch, psarr, st)

f2(x_batch, y_batch, psarr, st)
```

```julia
julia> f2 = Reactant.@compile func(x_batch, y_batch, psarr, st)
ERROR: Scalar indexing is disallowed.
Invocation of getindex(::TracedRArray, ::Vararg{Int, N}) resulted in scalar indexing of a GPU array.
This is typically caused by calling an iterating implementation of a method.
Such implementations *do not* execute on the GPU, but very slowly on the CPU,
and therefore should be avoided.

If you want to allow scalar iteration, use `allowscalar` or `@allowscalar`
to enable scalar iteration globally or for the operations in question.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] errorscalar(op::String)
    @ GPUArraysCore ~/.julia/packages/GPUArraysCore/GMsgk/src/GPUArraysCore.jl:155
  [3] _assertscalar(op::String, behavior::GPUArraysCore.ScalarIndexing)
    @ GPUArraysCore ~/.julia/packages/GPUArraysCore/GMsgk/src/GPUArraysCore.jl:128
  [4] assertscalar(op::String)
    @ GPUArraysCore ~/.julia/packages/GPUArraysCore/GMsgk/src/GPUArraysCore.jl:116
  [5] getindex(::Reactant.TracedRArray{Float32, 2}, ::Int64, ::Int64)
    @ Reactant ~/git/Reactant.jl/src/TracedRArray.jl:86
  [6] _getindex
    @ ./abstractarray.jl:1341 [inlined]
  [7] getindex
    @ ./abstractarray.jl:1291 [inlined]
  [8] iterate
    @ ./abstractarray.jl:1217 [inlined]
  [9] iterate
    @ ./abstractarray.jl:1215 [inlined]
 [10] _zip_iterate_some
    @ ./iterators.jl:428 [inlined]
 [11] _zip_iterate_some
    @ ./iterators.jl:430 [inlined]
 [12] _zip_iterate_all
    @ ./iterators.jl:420 [inlined]
 [13] iterate
    @ ./iterators.jl:410 [inlined]
 [14] _append!(a::Vector{Float32}, ::Base.HasShape{2}, iter::Reactant.TracedRArray{Float32, 2})
    @ Base ./array.jl:1197
 [15] append!
    @ ./array.jl:1187 [inlined]
 [16] make_idx(data::Vector{Float32}, x::Reactant.TracedRArray{Float32, 2}, last_val::Int64)
    @ ComponentArrays ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:197
 [17] #28
    @ ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:172 [inlined]
 [18] (::ComponentArrays.var"#28#29"{Vector{Float32}, Base.RefValue{Int64}})(::Pair{Symbol, Reactant.TracedRArray{Float32}})
    @ ComponentArrays ./none:0
 [19] iterate
    @ ./generator.jl:47 [inlined]
 [20] merge(a::@NamedTuple{}, itr::Base.Generator{@Kwargs{weight::Reactant.TracedRArray{Float32, 2}, bias::Reactant.TracedRArray{Float32, 1}}, ComponentArrays.var"#28#29"{Vector{Float32}, Base.RefValue{Int64}}})
    @ Base ./namedtuple.jl:361
 [21] make_idx(data::Vector{Float32}, nt::@NamedTuple{weight::Reactant.TracedRArray{Float32, 2}, bias::Reactant.TracedRArray{Float32, 1}}, last_val::Int64)
    @ ComponentArrays ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:170
--- the last 5 lines are repeated 1 more time ---
 [27] #28
    @ ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:172 [inlined]
 [28] (::ComponentArrays.var"#28#29"{Vector{Float32}, Base.RefValue{Int64}})(::Pair{Symbol, NamedTuple})
    @ ComponentArrays ./none:0
 [29] iterate(::Base.Generator{@Kwargs{layer_1::@NamedTuple{…}, layer_2::@NamedTuple{…}}, ComponentArrays.var"#28#29"{Vector{…}, Base.RefValue{…}}})
    @ Base ./generator.jl:47
 [30] merge(a::@NamedTuple{}, itr::Base.Generator{@Kwargs{layer_1::@NamedTuple{…}, layer_2::@NamedTuple{…}}, ComponentArrays.var"#28#29"{Vector{…}, Base.RefValue{…}}})
    @ Base ./namedtuple.jl:361
 [31] make_idx(data::Vector{Float32}, nt::@NamedTuple{layer_1::@NamedTuple{…}, layer_2::@NamedTuple{…}}, last_val::Int64)
    @ ComponentArrays ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:170
 [32] make_carray_args(A::Type{Vector}, nt::@NamedTuple{layer_1::@NamedTuple{layer_1::@NamedTuple{…}, layer_2::@NamedTuple{…}}, layer_2::@NamedTuple{weight::Reactant.TracedRArray{…}, bias::Reactant.TracedRArray{…}}})
    @ ComponentArrays ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:162
 [33] make_carray_args(nt::@NamedTuple{layer_1::@NamedTuple{layer_1::@NamedTuple{…}, layer_2::@NamedTuple{…}}, layer_2::@NamedTuple{weight::Reactant.TracedRArray{…}, bias::Reactant.TracedRArray{…}}})
    @ ComponentArrays ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:155
 [34] ComponentArray(nt::@NamedTuple{layer_1::@NamedTuple{layer_1::@NamedTuple{…}, layer_2::@NamedTuple{…}}, layer_2::@NamedTuple{weight::Reactant.TracedRArray{…}, bias::Reactant.TracedRArray{…}}})
    @ ComponentArrays ~/.julia/packages/ComponentArrays/7tm5j/src/componentarray.jl:72
 [35] nnfunc
    @ ./REPL[9]:1 [inlined]
 [36] (::Tuple{})(none::Reactant.TracedRArray{…}, none::Reactant.TracedRArray{…}, none::@NamedTuple{…}, none::@NamedTuple{…})
    @ Base.Experimental ./<missing>:0
 [37] (::Reactant.var"#32#42"{Bool, Bool, typeof(nnfunc), Tuple{…}, Vector{…}, Tuple{…}})()
    @ Reactant ~/git/Reactant.jl/src/utils.jl:157
 [38] block!(f::Reactant.var"#32#42"{Bool, Bool, typeof(nnfunc), Tuple{…}, Vector{…}, Tuple{…}}, blk::Reactant.MLIR.IR.Block)
    @ Reactant.MLIR.IR ~/git/Reactant.jl/src/mlir/IR/Block.jl:201
 [39] make_mlir_fn(f::Function, args::Tuple{…}, kwargs::Tuple{}, name::String, concretein::Bool; toscalar::Bool, return_dialect::Symbol, no_args_in_result::Bool, construct_function_without_args::Bool, do_transpose::Bool)
    @ Reactant ~/git/Reactant.jl/src/utils.jl:120
 [40] make_mlir_fn
    @ ~/git/Reactant.jl/src/utils.jl:40 [inlined]
 [41] overload_autodiff(::ReverseMode{…}, ::Const{…}, ::Type{…}, ::Duplicated{…}, ::Duplicated{…}, ::Const{…}, ::Const{…})
    @ Reactant ~/git/Reactant.jl/src/Interpreter.jl:373
 [42] autodiff_deferred
    @ ~/git/Reactant.jl/src/Interpreter.jl:623 [inlined]
 [43] autodiff
    @ ~/.julia/packages/Enzyme/RTS5U/src/Enzyme.jl:512 [inlined]
 [44] batcherror
    @ ./REPL[10]:7 [inlined]
 [45] (::Tuple{})(none::Reactant.TracedRArray{…}, none::Reactant.TracedRArray{…}, none::@NamedTuple{…}, none::@NamedTuple{…})
    @ Base.Experimental ./<missing>:0
 [46] (::Reactant.var"#32#42"{Bool, Bool, typeof(batcherror), Tuple{…}, Vector{…}, Tuple{…}})()
    @ Reactant ~/git/Reactant.jl/src/utils.jl:157
 [47] block!(f::Reactant.var"#32#42"{Bool, Bool, typeof(batcherror), Tuple{…}, Vector{…}, Tuple{…}}, blk::Reactant.MLIR.IR.Block)
    @ Reactant.MLIR.IR ~/git/Reactant.jl/src/mlir/IR/Block.jl:201
 [48] make_mlir_fn(f::Function, args::Tuple{…}, kwargs::Tuple{}, name::String, concretein::Bool; toscalar::Bool, return_dialect::Symbol, no_args_in_result::Bool, construct_function_without_args::Bool, do_transpose::Bool)
    @ Reactant ~/git/Reactant.jl/src/utils.jl:120
 [49] make_mlir_fn
    @ ~/git/Reactant.jl/src/utils.jl:40 [inlined]
 [50] overload_autodiff(::ReverseMode{…}, ::Const{…}, ::Type{…}, ::Const{…}, ::Const{…}, ::Active{…}, ::Const{…})
    @ Reactant ~/git/Reactant.jl/src/Interpreter.jl:373
 [51] autodiff_deferred
    @ ~/git/Reactant.jl/src/Interpreter.jl:623 [inlined]
 [52] autodiff
    @ ~/.julia/packages/Enzyme/RTS5U/src/Enzyme.jl:512 [inlined]
 [53] func
    @ ./REPL[11]:2 [inlined]
 [54] (::Tuple{})(none::Reactant.TracedRArray{…}, none::Reactant.TracedRArray{…}, none::@NamedTuple{…}, none::@NamedTuple{…})
    @ Base.Experimental ./<missing>:0
 [55] (::Reactant.var"#32#42"{Bool, Bool, typeof(func), Tuple{…}, Vector{…}, Tuple{…}})()
    @ Reactant ~/git/Reactant.jl/src/utils.jl:157
 [56] block!(f::Reactant.var"#32#42"{Bool, Bool, typeof(func), Tuple{…}, Vector{…}, Tuple{…}}, blk::Reactant.MLIR.IR.Block)
    @ Reactant.MLIR.IR ~/git/Reactant.jl/src/mlir/IR/Block.jl:201
 [57] make_mlir_fn(f::Function, args::Tuple{…}, kwargs::Tuple{}, name::String, concretein::Bool; toscalar::Bool, return_dialect::Symbol, no_args_in_result::Bool, construct_function_without_args::Bool, do_transpose::Bool)
    @ Reactant ~/git/Reactant.jl/src/utils.jl:120
 [58] make_mlir_fn
    @ ~/git/Reactant.jl/src/utils.jl:40 [inlined]
 [59] #10
    @ ~/git/Reactant.jl/src/Compiler.jl:286 [inlined]
 [60] block!(f::Reactant.Compiler.var"#10#15"{typeof(func), Tuple{ConcreteRArray{…}, ConcreteRArray{…}, @NamedTuple{…}, @NamedTuple{…}}}, blk::Reactant.MLIR.IR.Block)
    @ Reactant.MLIR.IR ~/git/Reactant.jl/src/mlir/IR/Block.jl:201
 [61] #9
    @ ~/git/Reactant.jl/src/Compiler.jl:285 [inlined]
 [62] mmodule!(f::Reactant.Compiler.var"#9#14"{Reactant.MLIR.IR.Module, typeof(func), Tuple{ConcreteRArray{…}, ConcreteRArray{…}, @NamedTuple{…}, @NamedTuple{…}}}, blk::Reactant.MLIR.IR.Module)
    @ Reactant.MLIR.IR ~/git/Reactant.jl/src/mlir/IR/Module.jl:92
 [63] compile_mlir!(mod::Reactant.MLIR.IR.Module, f::Function, args::Tuple{ConcreteRArray{…}, ConcreteRArray{…}, @NamedTuple{…}, @NamedTuple{…}}; optimize::Bool)
    @ Reactant.Compiler ~/git/Reactant.jl/src/Compiler.jl:282
 [64] compile_mlir!
    @ ~/git/Reactant.jl/src/Compiler.jl:281 [inlined]
 [65] (::Reactant.Compiler.var"#34#36"{Bool, typeof(func), Tuple{ConcreteRArray{…}, ConcreteRArray{…}, @NamedTuple{…}, @NamedTuple{…}}})()
    @ Reactant.Compiler ~/git/Reactant.jl/src/Compiler.jl:689
 [66] context!(f::Reactant.Compiler.var"#34#36"{Bool, typeof(func), Tuple{ConcreteRArray{…}, ConcreteRArray{…}, @NamedTuple{…}, @NamedTuple{…}}}, ctx::Reactant.MLIR.IR.Context)
    @ Reactant.MLIR.IR ~/git/Reactant.jl/src/mlir/IR/Context.jl:76
 [67] compile_xla(f::Function, args::Tuple{ConcreteRArray{…}, ConcreteRArray{…}, @NamedTuple{…}, @NamedTuple{…}}; client::Nothing, optimize::Bool)
    @ Reactant.Compiler ~/git/Reactant.jl/src/Compiler.jl:686
 [68] compile_xla
    @ ~/git/Reactant.jl/src/Compiler.jl:681 [inlined]
 [69] compile(f::Function, args::Tuple{ConcreteRArray{…}, ConcreteRArray{…}, @NamedTuple{…}, @NamedTuple{…}}; client::Nothing, optimize::Bool, sync::Bool)
    @ Reactant.Compiler ~/git/Reactant.jl/src/Compiler.jl:713
Some type information was truncated. Use `show(err)` to see complete types.
```