### PR TITLE
fix `create_result(::Array)` for non-vectors

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -59,6 +59,7 @@ function create_result(tocopy::Array{T,N}, path, result_stores) where {T,N}
     for (i, v) in enumerate(tocopy)
         push!(elems, create_result(v, append_path(path, i), result_stores))
     end
+    # TODO is there a way to not call `reshape` here? what expr is used for array literals?
     return :(reshape($T[$(elems...)], $(size(tocopy))...))
 end
 

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -59,7 +59,7 @@ function create_result(tocopy::Array{T,N}, path, result_stores) where {T,N}
     for (i, v) in enumerate(tocopy)
         push!(elems, create_result(v, append_path(path, i), result_stores))
     end
-    return :($T[$(elems...)])
+    return :(reshape($T[$(elems...)], $(size(tocopy))...))
 end
 
 function create_result(tocopy::Tuple, path, result_stores)

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -14,17 +14,6 @@ Base.sum(x::NamedTuple{(:a,),Tuple{T}}) where {T<:Reactant.TracedRArray} = (; a=
             @test isapprox(res.a, sum(x.a))
         end
 
-        @testset "ConcreteRArray" begin
-            x = [1 2; 3 4; 5 6]
-            x2 = Reactant.to_rarray(x)
-
-            f = Reactant.compile((x2,)) do _
-                x2
-            end
-
-            @test f(x2) == x2
-        end
-
         @testset "Array" begin
             x = [1 2; 3 4; 5 6]
             x2 = Reactant.to_rarray(x)

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -13,6 +13,29 @@ Base.sum(x::NamedTuple{(:a,),Tuple{T}}) where {T<:Reactant.TracedRArray} = (; a=
             @test res isa @NamedTuple{a::Reactant.ConcreteRNumber{Float64}}
             @test isapprox(res.a, sum(x.a))
         end
+
+        @testset "ConcreteRArray" begin
+            x = [1 2; 3 4; 5 6]
+            x2 = Reactant.to_rarray(x)
+
+            f = Reactant.compile((x2,)) do _
+                x2
+            end
+
+            @test f(x2) == x2
+        end
+
+        @testset "Array" begin
+            x = [1 2; 3 4; 5 6]
+            x2 = Reactant.to_rarray(x)
+
+            # TODO remove `x2` when #196 is fixed
+            f = Reactant.compile((x2,)) do _
+                x
+            end
+
+            @test f(x2) ≈ x
+        end
     end
 
     @testset "world-age" begin


### PR DESCRIPTION
there's a problem when returning a compiled function returns an `Array` in which the values are vectorized

```julia
julia> x = [1 2; 3 4; 5 6]
3×2 Matrix{Int64}:
 1  2
 3  4
 5  6

julia> x2 = Reactant.to_rarray(x)
3×2 ConcreteRArray{Int64, 2}:
 1  2
 3  4
 5  6

julia> g = Reactant.compile((x2,)) do _
                       x
                   end
Reactant.Compiler.Thunk{Symbol("###5_reactant#61915")}()

julia> g(x2)
6-element Vector{Int64}:
 1
 3
 5
 2
 4
 6
```

this PR solves it by adding a `reshape` in the `Expr` returned by `create_result(::Array)`, but the optimal implementation would be to use array literals (which i don't know how to write using `Expr`)

CC @Todorbsc