### PR TITLE
implement `collect` for `TracedRArray`

### DIFF
--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -26,7 +26,7 @@ function ConcreteRNumber(
     return ConcreteRNumber{T}(crarray.data)
 end
 
-Base.collect(x::ConcreteRNumber{T}) where {T} = ConcreteRNumber{T,0}(copy(x).data, ())
+Base.collect(x::ConcreteRNumber{T}) where {T} = ConcreteRArray{T,0}(copy(x).data, ())
 
 Base.size(::ConcreteRNumber) = ()
 Base.real(x::ConcreteRNumber{<:Real}) = x

--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -26,6 +26,8 @@ function ConcreteRNumber(
     return ConcreteRNumber{T}(crarray.data)
 end
 
+Base.collect(x::ConcreteRNumber{T}) where {T} = ConcreteRNumber{T,0}(copy(x).data, ())
+
 Base.size(::ConcreteRNumber) = ()
 Base.real(x::ConcreteRNumber{<:Real}) = x
 function Base.rtoldefault(::Type{ConcreteRNumber{T}}) where {T}

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -55,6 +55,8 @@ end
 abstract type RArray{T<:ReactantPrimitive,N} <: AbstractArray{T,N} end
 abstract type RNumber{T<:ReactantPrimitive} <: Number end
 
+Base.collect(A::RArray) = copy(A)
+
 function Base.reshape(A::RArray, dims::Tuple{Vararg{Union{Int,Colon}}})
     return reshape(A, Base._reshape_uncolon(A, dims))
 end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -160,7 +160,6 @@ Base.Tuple(x::TracedRArray) = ntuple(Base.Fix1(Base.getindex, x), length(x))
 Base.size(x::TracedRArray) = x.shape
 
 Base.copy(A::TracedRArray{T,N}) where {T,N} = TracedRArray{T,N}((), A.mlir_data, size(A))
-Base.collect(A::TracedRArray) = copy(A)
 
 # TODO is there a way to create an unitialized `tensor`? does it show an advantage? maybe `fill`?
 function Base.similar(::TracedRArray, ::Type{T}, dims::Dims{N}) where {T,N}

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -160,6 +160,7 @@ Base.Tuple(x::TracedRArray) = ntuple(Base.Fix1(Base.getindex, x), length(x))
 Base.size(x::TracedRArray) = x.shape
 
 Base.copy(A::TracedRArray{T,N}) where {T,N} = TracedRArray{T,N}((), A.mlir_data, size(A))
+Base.collect(A::TracedRArray) = copy(A)
 
 # TODO is there a way to create an unitialized `tensor`? does it show an advantage? maybe `fill`?
 function Base.similar(::TracedRArray, ::Type{T}, dims::Dims{N}) where {T,N}

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -22,6 +22,7 @@ Base.getindex(a::TracedRNumber{T}) where {T} = a
 
 Base.zero(::TracedRNumber{T}) where {T} = promote_to(TracedRNumber{T}, zero(T))
 Base.one(::TracedRNumber{T}) where {T} = promote_to(TracedRNumber{T}, one(T))
+Base.collect(::TracedRNumber{T}) where {T} = TracedRArray{T,0}((), a.mlir_data, ())
 
 Base.eps(::Type{TracedRNumber{T}}) where {T} = promote_to(TracedRNumber{T}, eps(T))
 

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -22,7 +22,7 @@ Base.getindex(a::TracedRNumber{T}) where {T} = a
 
 Base.zero(::TracedRNumber{T}) where {T} = promote_to(TracedRNumber{T}, zero(T))
 Base.one(::TracedRNumber{T}) where {T} = promote_to(TracedRNumber{T}, one(T))
-Base.collect(::TracedRNumber{T}) where {T} = TracedRArray{T,0}((), a.mlir_data, ())
+Base.collect(x::TracedRNumber{T}) where {T} = TracedRArray{T,0}((), x.mlir_data, ())
 
 Base.eps(::Type{TracedRNumber{T}}) where {T} = promote_to(TracedRNumber{T}, eps(T))
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -593,3 +593,35 @@ end
     @test y_ca2 ≈ x_res
     @test y_ca2 isa ConcreteRArray
 end
+
+@testset "collect" begin
+    x = randn(2, 3)
+    x_ra = Reactant.to_rarray(x)
+
+    @testset "ConcreteRArray" begin
+        y = collect(x_ra)
+        @test y == x
+        @test y !== x_ra
+    end
+
+    @testset "TracedRArray" begin
+        y = @jit(collect(x_ra))
+        @test y == x
+        @test y !== x_ra
+    end
+
+    x = 5
+    x_ra = ConcreteRNumber(x)
+
+    @testset "ConcreteRNumber" begin
+        y = collect(x_ra)
+        @test y isa ConcreteRArray{Int,0}
+        @test y == x
+    end
+
+    @testset "TracedRArray" begin
+        y = @jit(collect(x_ra))
+        @test y isa ConcreteRArray{Int,0}
+        @test y == x
+    end
+end


### PR DESCRIPTION
we had an issue in which some inner function was calling `collect` on a `TracedRArray`, which would error.

this PR implements `collect(::TracedRArray)` as just a copy of the `TracedRArray`