### PR TITLE
fix `YaoBlocks.mat` for rotation gates with `TracedRNumber` parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,12 +23,14 @@ AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+YaoBlocks = "418bc28f-b43b-5e0b-a6e7-61bbc1a2c1df"
 
 [extensions]
 ReactantAbstractFFTsExt = "AbstractFFTs"
 ReactantArrayInterfaceExt = "ArrayInterface"
 ReactantNNlibExt = "NNlib"
 ReactantStatisticsExt = "Statistics"
+ReactantYaoBlocksExt = "YaoBlocks"
 
 [compat]
 AbstractFFTs = "1.5"

--- a/ext/ReactantYaoBlocksExt.jl
+++ b/ext/ReactantYaoBlocksExt.jl
@@ -1,0 +1,34 @@
+module ReactantYaoBlocksExt
+
+function YaoBlocks.mat(
+    ::Type{T}, R::RotationGate{D,Reactant.TracedRNumber{S},<:XGate}
+) where {D,T,S}
+    M = Reactant.broadcast_to_size(zero(T), (2, 2))
+    M[1, 1] = cos(R.theta / 2)
+    M[2, 2] = cos(R.theta / 2)
+    M[1, 2] = -im * sin(R.theta / 2)
+    M[2, 1] = -im * sin(R.theta / 2)
+    return M
+end
+
+function YaoBlocks.mat(
+    ::Type{T}, R::RotationGate{D,Reactant.TracedRNumber{S},<:YGate}
+) where {D,T,S}
+    M = Reactant.broadcast_to_size(zero(T), (2, 2))
+    M[1, 1] = cos(R.theta / 2)
+    M[2, 2] = cos(R.theta / 2)
+    M[1, 2] = -sin(R.theta / 2)
+    M[2, 1] = sin(R.theta / 2)
+    return M
+end
+
+function YaoBlocks.mat(
+    ::Type{T}, R::RotationGate{D,Reactant.TracedRNumber{S},<:ZGate}
+) where {D,T,S}
+    M = Reactant.broadcast_to_size(zero(T), (2, 2))
+    M[1, 1] = exp(-im * R.theta / 2)
+    M[2, 2] = exp(im * R.theta / 2)
+    return M
+end
+
+end

--- a/ext/ReactantYaoBlocksExt.jl
+++ b/ext/ReactantYaoBlocksExt.jl
@@ -1,5 +1,8 @@
 module ReactantYaoBlocksExt
 
+using Reactant
+using YaoBlocks
+
 function YaoBlocks.mat(
     ::Type{T}, R::RotationGate{D,Reactant.TracedRNumber{S},<:XGate}
 ) where {D,T,S}


### PR DESCRIPTION
we run into some problems when trying to use a quantum circuit from Yao but whose parameters are traced by Reactant. specially, the LuxurySparse (which Yao uses a lot) arrays are quite problematic when used 

in the future, it might be better to use MLIR's sparse tensor types, but for now this is more than ok.

@wsmoses i know we discussed about creating this package extension here or in YaoBlocks.jl, but right now i'm on a rush and this is faster to get merged. also, in the future some changes in Reactant might fix the problems we had with the sparse arrays and thus, it might make sense to have it here for fast iteration. i'm pro moving it to YaoBlocks (if @Rogger-Luo is ok with it) once Reactant stabilizes.

CC @Todorbsc