### PR TITLE
Temporarily disable custom forward/backward diff rules in Enzyme-based interpreter

### DIFF
--- a/src/Interpreter.jl
+++ b/src/Interpreter.jl
@@ -118,8 +118,8 @@ function set_reactant_abi end
             ReactantCacheToken(),
             nothing,            #=mt=#
             world,
-            true,            #=forward_rules=#
-            true,            #=reverse_rules=#
+            false,            #=forward_rules=#
+            false,            #=reverse_rules=#
             true,            #=deferred_lower=#
             false,            #=broadcast_rewrite=#
             set_reactant_abi,


### PR DESCRIPTION
Let's see if this circumvents the compilation time issue while @vchuravy and @wsmoses fix the issue in Enzyme