### PR TITLE
fix: preserve IOContext for printing

### DIFF
--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -184,8 +184,10 @@ function Base.show(io::IO, X::ConcreteRScalar{T}) where {T}
         println(io, "<Empty buffer>")
         return nothing
     end
-    str = sprint(show, to_number(X))
-    return print(io, "$(typeof(X))($(str))")
+    print(io, "$(typeof(X))(")
+    show(io, to_number(X))
+    print(io, ")")
+    return
 end
 
 function Base.print_array(io::IO, X::ConcreteRArray)
@@ -201,8 +203,10 @@ function Base.show(io::IO, X::ConcreteRArray)
         println(io, "<Empty buffer>")
         return nothing
     end
-    str = sprint(show, convert(Array, X))
-    return print(io, "$(typeof(X))($(str))")
+    print(io, "$(typeof(X))(")
+    show(io, convert(Array, X))
+    print(io, ")")
+    return
 end
 
 function Base.getindex(a::ConcreteRArray{T}, args::Vararg{Int,N}) where {T,N}

--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -187,7 +187,7 @@ function Base.show(io::IO, X::ConcreteRScalar{T}) where {T}
     print(io, "$(typeof(X))(")
     show(io, to_number(X))
     print(io, ")")
-    return
+    return nothing
 end
 
 function Base.print_array(io::IO, X::ConcreteRArray)
@@ -206,7 +206,7 @@ function Base.show(io::IO, X::ConcreteRArray)
     print(io, "$(typeof(X))(")
     show(io, convert(Array, X))
     print(io, ")")
-    return
+    return nothing
 end
 
 function Base.getindex(a::ConcreteRArray{T}, args::Vararg{Int,N}) where {T,N}


### PR DESCRIPTION
```julia
julia> (ConcreteRArray(rand(100)),) # BEFORE
(ConcreteRArray{Float64, 1}([0.2535878726439841, 0.30146547100371024, 0.10047529184554504, 0.14394571836180303, 0.7447120689993926, 0.052444279563234164, 0.5068276912166574, 0.8361486344452231, 0.3206392318691902, 0.8738208419377047, 0.829888160187986, 0.05448133909341113, 0.7150961022795176, 0.8815815979446093, 0.4021192558958505, 0.6242368917575722, 0.31725390184551217, 0.43709239292231505, 0.7729125669613391, 0.12977819409489444, 0.7637736543714921, 0.3491923403480377, 0.935230455126192, 0.23266180405040526, 0.6383365404589012, 0.9025904181965533, 0.8012484503917107, 0.9301741523727763, 0.02594794780136722, 0.4410470553806616, 0.3048766390000852, 0.3083245690448847, 0.9388067728964168, 0.492918692961102, 0.4820793663137074, 0.6618275346940578, 0.9321929255621805, 0.8413227176405979, 0.3118742759655724, 0.4226117162420375, 0.9482393129125843, 0.7232844855885698, 0.5664503086944864, 0.2114433907152925, 0.3849344256170072, 0.3855113843903031, 0.877962493380178, 0.46809952088347584, 0.8925546301514238, 0.12960595265456154, 0.692891492863308, 0.20526324905857563, 0.41124740903559, 0.033687191074503686, 0.5512249257428721, 0.8954285221810515, 0.7521303311737615, 0.6341733800846323, 0.4768903387981358, 0.7801741209442079, 0.16611821502534818, 0.7338985629939161, 0.17589900224067068, 0.352784897540835, 0.6280768212850262, 0.5513708551220478, 0.06173392508936182, 0.15895705296577434, 0.09754323260979558, 0.5705634186930401, 0.006758193312647376, 0.4783233887685505, 0.9664757740692618, 0.7481971874215915, 0.3142307795737178, 0.8673650570126012, 0.14668298134618785, 8.424234379855733e-6, 0.967296402023709, 0.7934524224046455, 0.891070274172195, 0.2589749969318508, 0.5696194324110857, 0.8360516736880639, 0.31712129780629283, 0.11060763045108646, 0.9449088013438124, 0.30653100302144465, 0.3007403340023953, 0.27397717087676166, 0.8532792975902778, 0.23155432215728744, 0.905167287966142, 0.4837125966687499, 0.5649560088113514, 0.03642701172483476, 0.6532126603299033, 0.5242748884284982, 0.355648396894789, 0.15253151775993345]),)

julia> (ConcreteRArray(rand(100)),) # AFTER
(ConcreteRArray{Float64, 1}([0.4414621206458623, 0.3859450898061578, 0.9433997746536037, 0.20863917388019815, 0.2835246520091672, 0.17485714909824324, 0.7808705798094372, 0.32853632563396706, 0.8469291611775501, 0.0845735612428381  …  0.7535824550156768, 0.3461881150066184, 0.17222684059387106, 0.6507497645131313, 0.6998291285618986, 0.648474580839183, 0.4679741979873945, 0.6507217002038168, 0.11059125297955785, 0.45958358551074674]),)
```