### PR TITLE
avoid excessive inlining by moving `YaoBlocks.mat` to `func.func` defs

### DIFF
--- a/ext/ReactantYaoBlocksExt.jl
+++ b/ext/ReactantYaoBlocksExt.jl
@@ -1,11 +1,97 @@
 module ReactantYaoBlocksExt
 
 using Reactant
+using Reactant: TracedRArray, TracedRNumber
+using Reactant.MLIR: IR
+using Reactant.MLIR.Dialects: func
 using YaoBlocks
 
-function YaoBlocks.mat(
-    ::Type{T}, R::RotationGate{D,Reactant.TracedRNumber{S},<:XGate}
-) where {D,T,S}
+function module_top()
+    if !haskey(task_local_storage(), :mlir_module)
+        error("No MLIR module is active")
+    end
+    return first(task_local_storage(:mlir_module))
+end
+
+function symname(name, ::Type{ParamType}, ::Type{OutElType}) where {ParamType,OutElType}
+    return name * "_" * string(ParamType) * "_" * string(OutElType)
+end
+
+function codegen!(
+    ::Val{:ry}, ::Type{ParamType}, ::Type{OutElType}
+) where {ParamType,OutElType}
+    in_tys = [IR.TensorType((), IR.Type(ParamType))]
+    out_tys = [IR.TensorType((2, 2), IR.Type(OutElType))]
+
+    f = func.func_(;
+        sym_name=symname("ry", ParamType, OutElType),
+        function_type=IR.FunctionType(in_tys, out_tys),
+        body=IR.Region(),
+    )
+
+    fbody = IR.Block(in_tys, [IR.Location()])
+    push!(IR.region(f, 1), fbody)
+
+    IR.block!(fbody) do
+        θ = TracedRNumber{ParamType}((), IR.argument(fbody, 1))
+        M = Reactant.broadcast_to_size(zero(T), (2, 2))
+        c = cos(θ / 2)
+        s = sin(θ / 2)
+        M[1, 1] = c
+        M[2, 2] = c
+        M[1, 2] = -s
+        M[2, 1] = s
+        func.return_([M.mlir_data])
+    end
+
+    return f
+end
+
+function codegen!(
+    ::Val{:rz}, ::Type{ParamType}, ::Type{OutElType}
+) where {ParamType,OutElType}
+    in_tys = [IR.TensorType((), IR.Type(ParamType))]
+    out_tys = [IR.TensorType((2, 2), IR.Type(OutElType))]
+
+    mod = module_top()
+    IR.block!(IR.body(mod)) do
+        f = func.func_(;
+            sym_name=symname("rz", ParamType, OutElType),
+            function_type=IR.FunctionType(in_tys, out_tys),
+            body=IR.Region(),
+        )
+
+        fbody = IR.Block(in_tys, [IR.Location()])
+        push!(IR.region(f, 1), fbody)
+
+        IR.block!(fbody) do
+            θ = TracedRNumber{ParamType}((), IR.argument(fbody, 1))
+            M = Reactant.broadcast_to_size(zero(OutElType), (2, 2))
+            x = exp(im * θ / 2)
+            M[1, 1] = conj(x)
+            M[2, 2] = x
+            func.return_([M.mlir_data])
+        end
+
+        return f
+    end
+end
+
+function hasfunc(name, ::Type{ParamType}, ::Type{OutElType}) where {ParamType,OutElType}
+    it = IR.OperationIterator(IR.body(module_top()))
+    return any(it) do op
+        IR.name(op) == "func.func" || return false
+
+        String(IR.attr(op, 2).named_attribute.name) == "sym_name" ||
+            error("expected sym_name attribute")
+
+        _symname = String(IR.Attribute(IR.attr(op, 2).named_attribute.attribute))
+        _symname == symname(name, ParamType, OutElType) || return false
+        return true
+    end
+end
+
+function YaoBlocks.mat(::Type{T}, R::RotationGate{D,TracedRNumber{S},<:XGate}) where {D,T,S}
     M = Reactant.broadcast_to_size(zero(T), (2, 2))
     c = cos(R.theta / 2)
     s = -im * sin(R.theta / 2)
@@ -16,27 +102,30 @@ function YaoBlocks.mat(
     return M
 end
 
-function YaoBlocks.mat(
-    ::Type{T}, R::RotationGate{D,Reactant.TracedRNumber{S},<:YGate}
-) where {D,T,S}
-    M = Reactant.broadcast_to_size(zero(T), (2, 2))
-    c = cos(R.theta / 2)
-    s = sin(R.theta / 2)
-    M[1, 1] = c
-    M[2, 2] = c
-    M[1, 2] = -s
-    M[2, 1] = s
-    return M
+function YaoBlocks.mat(::Type{T}, R::RotationGate{D,TracedRNumber{S},<:YGate}) where {D,T,S}
+    hasfunc("ry", S, T) || codegen!(Val(:ry), S, T)
+
+    res = IR.result(
+        func.call(
+            [R.theta.mlir_data];
+            result_0=[IR.TensorType((2, 2), IR.Type(T))],
+            callee=symname("ry", S, T),
+        ),
+    )
+    return TracedRArray{T,2}((), res, (2, 2))
 end
 
-function YaoBlocks.mat(
-    ::Type{T}, R::RotationGate{D,Reactant.TracedRNumber{S},<:ZGate}
-) where {D,T,S}
-    M = Reactant.broadcast_to_size(zero(T), (2, 2))
-    x = exp(im * R.theta / 2)
-    M[1, 1] = conj(x)
-    M[2, 2] = x
-    return M
+function YaoBlocks.mat(::Type{T}, R::RotationGate{D,TracedRNumber{S},<:ZGate}) where {D,T,S}
+    hasfunc("rz", S, T) || codegen!(Val(:rz), S, T)
+
+    op = func.call(
+        [R.theta.mlir_data];
+        result_0=[IR.TensorType((2, 2), IR.Type(T))],
+        callee=symname("rz", S, T),
+    )
+
+    res = IR.result(op)
+    return TracedRArray{T,2}((), res, (2, 2))
 end
 
 end

--- a/src/mlir/IR/Operation.jl
+++ b/src/mlir/IR/Operation.jl
@@ -211,7 +211,7 @@ rmattr!(operation::Operation, name) =
     API.mlirOperationRemoveAttributeByName(operation, name)
 
 function lose_ownership!(operation::Operation)
-    @assert operation.owned
+    # @assert operation.owned
     @atomic operation.owned = false
     return operation
 end


### PR DESCRIPTION
this is the MWE i'm working with

```julia
using Reactant
using YaoBlocks

θ = ConcreteRNumber(rand())

f(x) = mat(ComplexF64, Rz(x))

@code_hlo optimize = false f(θ)
```

on `@code_hlo optimize=false` seems to work well
```mlir
#= /Users/mofeing/Developer/fujitsu/rz.jl:11 =# @code_hlo(optimize = false, f(θ)) = "builtin.module"() ({
  "func.func"() <{function_type = (tensor<f64>) -> tensor<2x2xcomplex<f64>>, sym_name = "rz_Float64_ComplexF64"}> ({
  ^bb0(%arg1: tensor<f64>):
    %4 = "stablehlo.constant"() <{value = dense<(0.000000e+00,0.000000e+00)> : tensor<2x2xcomplex<f64>>}> : () -> tensor<2x2xcomplex<f64>>
    %5 = "stablehlo.constant"() <{value = dense<(0.000000e+00,1.000000e+00)> : tensor<complex<f64>>}> : () -> tensor<complex<f64>>
    %6 = "stablehlo.convert"(%arg1) : (tensor<f64>) -> tensor<complex<f64>>
    %7 = "stablehlo.multiply"(%5, %6) : (tensor<complex<f64>>, tensor<complex<f64>>) -> tensor<complex<f64>>
    %8 = "stablehlo.constant"() <{value = dense<(2.000000e+00,0.000000e+00)> : tensor<complex<f64>>}> : () -> tensor<complex<f64>>
    %9 = "stablehlo.divide"(%7, %8) : (tensor<complex<f64>>, tensor<complex<f64>>) -> tensor<complex<f64>>
    %10 = "stablehlo.exponential"(%9) : (tensor<complex<f64>>) -> tensor<complex<f64>>
    %11 = "chlo.conj"(%10) : (tensor<complex<f64>>) -> tensor<complex<f64>>
    %12 = "stablehlo.broadcast_in_dim"(%11) <{broadcast_dimensions = array<i64>}> : (tensor<complex<f64>>) -> tensor<1x1xcomplex<f64>>
    %13 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
    %14 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
    %15 = "stablehlo.subtract"(%13, %14) : (tensor<i64>, tensor<i64>) -> tensor<i64>
    %16 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
    %17 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
    %18 = "stablehlo.subtract"(%16, %17) : (tensor<i64>, tensor<i64>) -> tensor<i64>
    %19 = "stablehlo.dynamic_update_slice"(%4, %12, %15, %18) : (tensor<2x2xcomplex<f64>>, tensor<1x1xcomplex<f64>>, tensor<i64>, tensor<i64>) -> tensor<2x2xcomplex<f64>>
    %20 = "stablehlo.broadcast_in_dim"(%10) <{broadcast_dimensions = array<i64>}> : (tensor<complex<f64>>) -> tensor<1x1xcomplex<f64>>
    %21 = "stablehlo.constant"() <{value = dense<2> : tensor<i64>}> : () -> tensor<i64>
    %22 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
    %23 = "stablehlo.subtract"(%21, %22) : (tensor<i64>, tensor<i64>) -> tensor<i64>
    %24 = "stablehlo.constant"() <{value = dense<2> : tensor<i64>}> : () -> tensor<i64>
    %25 = "stablehlo.constant"() <{value = dense<1> : tensor<i64>}> : () -> tensor<i64>
    %26 = "stablehlo.subtract"(%24, %25) : (tensor<i64>, tensor<i64>) -> tensor<i64>
    %27 = "stablehlo.dynamic_update_slice"(%19, %20, %23, %26) : (tensor<2x2xcomplex<f64>>, tensor<1x1xcomplex<f64>>, tensor<i64>, tensor<i64>) -> tensor<2x2xcomplex<f64>>
    "func.return"(%27) : (tensor<2x2xcomplex<f64>>) -> ()
  }) : () -> ()
  "func.func"() <{function_type = (tensor<f64>) -> (tensor<2x2xcomplex<f64>>, tensor<f64>), sym_name = "main"}> ({
  ^bb0(%arg0: tensor<f64>):
    %0 = "stablehlo.transpose"(%arg0) <{permutation = array<i64>}> : (tensor<f64>) -> tensor<f64>
    %1 = "func.call"(%0) : (tensor<f64>) -> tensor<2x2xcomplex<f64>>
    %2 = "stablehlo.transpose"(%1) <{permutation = array<i64: 1, 0>}> : (tensor<2x2xcomplex<f64>>) -> tensor<2x2xcomplex<f64>>
    %3 = "stablehlo.transpose"(%0) <{permutation = array<i64>}> : (tensor<f64>) -> tensor<f64>
    "func.return"(%2, %3) : (tensor<2x2xcomplex<f64>>, tensor<f64>) -> ()
  }) : () -> ()
}) : () -> ()
```

but when i do `optimize=true`, it segfaults
```
[69071] signal 11 (2): Segmentation fault: 11
in expression starting at /Users/mofeing/Developer/fujitsu/rz.jl:12
_ZNK4mlir13SymbolRefAttr16getRootReferenceEv at /Users/mofeing/.julia/artifacts/0b9afde9c36d7e3732aedb550a7b040a67ec37d2/lib/libReactantExtra.dylib (unknown line)
_ZL18lookupSymbolInImplPN4mlir9OperationENS_13SymbolRefAttrERN4llvm15SmallVectorImplIS1_EENS3_12function_refIFS1_S1_NS_10StringAttrEEEE at /Users/mofeing/.julia/artifacts/0b9afde9c36d7e3732aedb550a7b040a67ec37d2/lib/libReactantExtra.dylib (unknown line)
Allocations: 42523755 (Pool: 42523097; Big: 658); GC: 26
fish: Job 1, 'julia --project=vqe rz.jl' terminated by signal SIGSEGV (Address boundary error)
```