### PR TITLE
Define outer `repeat` method for `TracedRArray`

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -800,3 +800,27 @@ function LinearAlgebra.norm(x::TracedRArray{T,N}, p::Real=2) where {T,N}
     isinf(p) && return maximum(abs, x)
     return mapreduce(Base.Fix2(^, p), +, x)^(1 / p)
 end
+
+# outer repeat
+function Base.repeat(x::AnyTracedRArray{T,N}, counts::Vararg{Int,M}) where {T,N,M}
+    P = max(N, M) # potentially padded
+
+    # (d1, d2, ..., dP) -> (d1, 1, d2, 1, ..., dP, 1)
+    interleaved_size = ones(Int, 2P)
+    interleaved_size[1:2:2N] .= size(x)
+
+    x_interleaved = reshape(x, interleaved_size...)
+
+    # (d1, 1, d2, 1, ..., dP, 1) -> (d1, r1, d2, r2, ..., dP, rP)
+    broadcast_target_size = interleaved_size
+    broadcast_target_size[2:2:2M] .= counts
+
+    x_broadcasted = broadcast_to_size(x_interleaved, broadcast_target_size)
+
+    # (d1, r1, d2, r2, ..., dP, rP) -> (d1*r1, d2*r2, ..., dP*rP)
+    final_size = vec(prod(reshape(broadcast_target_size, 2, :), dims=1))
+
+    x_final = reshape(x_broadcasted, final_size...)
+
+    return x_final
+end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -728,6 +728,9 @@ for (minT, maxT) in Iterators.product((Number, TracedRNumber), (Number, TracedRN
     end
 end
 
+Base.all(f::Function, x::AnyTracedRArray) = mapreduce(f, &, x)
+Base.any(f::Function, x::AnyTracedRArray) = mapreduce(f, |, x)
+
 # outer repeat
 function Base.repeat(x::AnyTracedRArray{T,N}, counts::Vararg{Int,M}) where {T,N,M}
     P = max(N, M) # potentially padded

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -365,7 +365,7 @@ end
 end
 
 @testset "repeat" begin
-    for (size, counts) in Iterators.product(
+    @testset for (size, counts) in Iterators.product(
         [(2,), (2,3), (2,3,4), (2,3,4,5)],
         [(), (1,), (2,), (2,1), (1,2), (2,2), (2,2,2), (1,1,1,1,1)]
     )

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -364,6 +364,16 @@ end
     end
 end
 
+@testset "repeat" begin
+    for (size, counts) in Iterators.product(
+        [(2,), (2,3), (2,3,4), (2,3,4,5)],
+        [(), (1,), (2,), (2,1), (1,2), (2,2), (2,2,2), (1,1,1,1,1)]
+    )
+        x = rand(size...)
+        @test (@jit repeat(Reactant.to_rarray(x), counts...)) == repeat(x, counts...)
+    end
+end
+
 function update_on_copy(x)
     y = x[1:2, 2:4, :]
     y[1:1, 1:1, :] = ones(1, 1, 3)


### PR DESCRIPTION
Closes #360 

This PR leverages `broadcast_to_size` to define outer repeating (the default for `Base.repeat`) of traced arrays.

I'm new here, so I may have missed something, but this looks promising:
```julia
julia> @code_hlo repeat(rand(2,3) |> Reactant.to_rarray, 5, 7, 11)
module {
  func.func @main(%arg0: tensor<3x2xf64>) -> tensor<11x21x10xf64> {
    %0 = stablehlo.reshape %arg0 : (tensor<3x2xf64>) -> tensor<1x1x1x3x1x2xf64>
    %1 = stablehlo.transpose %0, dims = [5, 4, 3, 2, 1, 0] : (tensor<1x1x1x3x1x2xf64>) -> tensor<2x1x3x1x1x1xf64>
    %2 = stablehlo.broadcast_in_dim %1, dims = [0, 1, 2, 3, 4, 5] : (tensor<2x1x3x1x1x1xf64>) -> tensor<2x5x3x7x1x11xf64>
    %3 = stablehlo.transpose %2, dims = [5, 4, 3, 2, 1, 0] : (tensor<2x5x3x7x1x11xf64>) -> tensor<11x1x7x3x5x2xf64>
    %4 = stablehlo.reshape %3 : (tensor<11x1x7x3x5x2xf64>) -> tensor<11x21x10xf64>
    return %4 : tensor<11x21x10xf64>
  }
}
```

Here's a testset (wasn't sure where to put it) that takes a few cases and compares the results to the generic method from Base, which passes for me.
```julia
@testset "repeat" begin
    for A_size in [(2,), (2,3), (2,3,4), (2,3,4,5)]
        for counts in [(), (1,), (2,), (2,1), (1,2), (2,2), (2,2,2), (1,1,1,1,1)]
            A = rand(A_size...)
            A_ra = Reactant.to_rarray(A)
            @test (@jit repeat(A_ra, counts...)) == repeat(A, counts...)
        end
    end
end
```
