### PR TITLE
feat: add support for the remaining wrapper types

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -41,6 +41,9 @@ function create_result(tocopy::T, path, result_stores) where {T}
     elems = Union{Symbol,Expr}[]
 
     for i in 1:fieldcount(T)
+        # If the field is undefined we don't set it. A common example for this is `du2`
+        # for Tridiagonal
+        isdefined(tocopy, i) || continue
         ev = create_result(getfield(tocopy, i), append_path(path, i), result_stores)
         push!(elems, ev)
     end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -105,7 +105,7 @@ function create_result(tocopy::D, path, result_stores) where {K,V,D<:AbstractDic
 end
 
 function create_result(
-    tocopy::Union{Integer,AbstractFloat,AbstractString,Nothing,Type,Symbol},
+    tocopy::Union{Integer,AbstractFloat,AbstractString,Nothing,Type,Symbol,Char},
     path,
     result_stores,
 )

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1447,12 +1447,12 @@ instead.
     #! format: off
     scatter_dimension_numbers = MLIR.API.stablehloScatterDimensionNumbersGet(
         MLIR.IR.context(),
-        0, Int64[],
-        N, collect(Int64, 0:(N - 1)),
-        0, Int64[],
-        0, Int64[],
-        N, collect(Int64, 0:(N - 1)),
-        1
+        Int64(0), Int64[],
+        Int64(N), collect(Int64, 0:(N - 1)),
+        Int64(0), Int64[],
+        Int64(0), Int64[],
+        Int64(N), collect(Int64, 0:(N - 1)),
+        Int64(1)
     )
     #! format: on
 

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1426,7 +1426,7 @@ specified by `scatter_indices` to the values in `updates`. If the indices are co
 is recommended to directly use [`MLIR.Dialects.stablehlo.dynamic_update_slice`](@ref)
 instead.
 """
-function scatter_setindex(
+@noinline function scatter_setindex(
     dest::TracedRArray{T,N},
     scatter_indices::TracedRArray{Int64,2},
     updates::TracedRArray{T,1},
@@ -1480,7 +1480,7 @@ Uses [`MLIR.Dialects.stablehlo.gather`](@ref) to get the values of `src` at the 
 specified by `gather_indices`. If the indices are contiguous it is recommended to directly
 use [`MLIR.Dialects.stablehlo.dynamic_slice`](@ref) instead.
 """
-function gather_getindex(
+@noinline function gather_getindex(
     src::TracedRArray{T,N}, gather_indices::TracedRArray{Int64,2}
 ) where {T,N}
     @assert size(gather_indices, 2) == N

--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -115,3 +115,28 @@ for randfun in (:rand, :randn, :randexp)
         # end
     end
 end
+
+# LinearAlgebra.jl overloads
+## `_mul!` goes through too many layers of abstractions and we aren't able to overload
+## without specializing on every possible combination of types
+@reactant_overlay @noinline function LinearAlgebra.mul!(
+    C::AbstractVector, A::AbstractMatrix, B::AbstractVector, α::Number, β::Number
+)
+    if any(Base.Fix2(isa, TracedRArray) ∘ ancestor, (C, A, B))
+        TracedLinearAlgebra.overloaded_mul!(C, A, B, α, β)
+    else
+        LinearAlgebra._mul!(C, A, B, α, β)
+    end
+    return C
+end
+
+@reactant_overlay @noinline function LinearAlgebra.mul!(
+    C::AbstractMatrix, A::AbstractMatrix, B::AbstractVecOrMat, α::Number, β::Number
+)
+    if any(Base.Fix2(isa, TracedRArray) ∘ ancestor, (C, A, B))
+        TracedLinearAlgebra.overloaded_mul!(C, A, B, α, β)
+    else
+        LinearAlgebra._mul!(C, A, B, α, β)
+    end
+    return C
+end

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -105,7 +105,7 @@ mutable struct TracedRArray{T,N} <: RArray{TracedRNumber{T},N}
     ) where {T,N}
         shape = Tuple(shape)
         if !isnothing(mlir_data)
-            @assert size(MLIR.IR.type(mlir_data)) == shape
+            @assert size(MLIR.IR.type(mlir_data)) == shape "Expected: $(shape), got: $(size(MLIR.IR.type(mlir_data)))"
         end
         return new{T,N}(paths, mlir_data, shape)
     end

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -119,7 +119,9 @@ const WrappedTracedRArray{T,N} = WrappedArray{
 const AnyTracedRArray{T,N} = Union{TracedRArray{T,N},WrappedTracedRArray{T,N}}
 const AnyTracedRVector{T} = AnyTracedRArray{T,1}
 const AnyTracedRMatrix{T} = Union{
-    AnyTracedRArray{T,2},LinearAlgebra.Diagonal{T,TracedRArray{T,1}}
+    AnyTracedRArray{T,2},
+    LinearAlgebra.Diagonal{TracedRNumber{T},TracedRArray{T,1}},
+    LinearAlgebra.Tridiagonal{TracedRNumber{T},TracedRArray{T,1}},
 }
 const AnyTracedRVecOrMat{T} = Union{AnyTracedRVector{T},AnyTracedRMatrix{T}}
 

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -123,11 +123,17 @@ const AnyTracedRMatrix{T} = Union{
 }
 const AnyTracedRVecOrMat{T} = Union{AnyTracedRVector{T},AnyTracedRMatrix{T}}
 
-function TracedRArray(data::MLIR.IR.Value)
+function TracedRArray{T}(data::MLIR.IR.Value) where {T}
     data_type = MLIR.IR.type(data)
-    return TracedRArray{eltype(MLIR.IR.julia_type(data_type)),ndims(data_type)}(
-        (), data, size(data_type)
-    )
+    if T == eltype(MLIR.IR.julia_type(data_type))
+        return TracedRArray{T,ndims(data_type)}((), data, size(data_type))
+    end
+    tdata = TracedRArray(data)
+    return Ops.convert(TracedRArray{T,ndims(data_type)}, tdata)
+end
+
+function TracedRArray(data::MLIR.IR.Value)
+    return TracedRArray{eltype(MLIR.IR.julia_type(MLIR.IR.type(data)))}(data)
 end
 
 struct XLAArray{T,N} <: RArray{T,N} end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -67,11 +67,11 @@ function Base.getindex(a::TracedRArray{T,N}, indices::Vararg{Any,N}) where {T,N}
         return i
     end
 
-    foreach(indices) do idxs
-        idxs isa Number && return nothing
+    for idxs in indices
+        idxs isa Number && continue
         contiguous = all(isone, diff(idxs))
         # XXX: We want to throw error even for dynamic indexing
-        if typeof(a) <: Bool
+        if typeof(contiguous) <: Bool
             contiguous || error("non-contiguous indexing is not supported")
         end
     end
@@ -99,16 +99,40 @@ function Base.getindex(a::WrappedTracedRArray, indices...)
     return getindex(ancestor(a), TracedUtils.get_ancestor_indices(a, indices...)...)
 end
 
-function Base.setindex!(
-    a::TracedRArray{T,N},
-    v,
-    indices::Vararg{Union{Base.AbstractUnitRange,Colon,Int,TracedRNumber{Int}},N},
-) where {T,N}
+function Base.setindex!(a::TracedRArray{T,N}, v, indices::Vararg{Any,N}) where {T,N}
     indices = map(enumerate(indices)) do (idx, i)
-        i isa Int ? (i:i) : (i isa Colon ? (1:size(a, idx)) : i)
+        i isa Colon && return 1:size(a, idx)
+        i isa CartesianIndex && return Tuple(i)
+        return i
     end
+
+    non_contiguous_setindex = false
+    for idxs in indices
+        idxs isa Number && continue
+        contiguous = all(isone, diff(idxs))
+        # XXX: We want to throw error even for dynamic indexing
+        if typeof(contiguous) <: Bool && !contiguous
+            non_contiguous_setindex = true
+            break
+        end
+    end
+
+    if non_contiguous_setindex
+        indices_tuples = collect(Iterators.product(indices...))
+        indices = Matrix{Int}(undef, (length(indices_tuples), 2))
+        for (i, idx) in enumerate(indices_tuples)
+            indices[i, 1] = idx[1] - 1
+            indices[i, 2] = idx[2] - 1
+        end
+        indices = TracedUtils.promote_to(TracedRArray{Int,2}, indices)
+        res = Ops.scatter_setindex(a, indices, Ops.reshape(v, length(v)))
+        a.mlir_data = res.mlir_data
+        return v
+    end
+
     v = TracedUtils.broadcast_to_size(v, length.(indices))
     v = TracedUtils.promote_to(TracedRArray{T,N}, v)
+
     indices = [
         (
             TracedUtils.promote_to(TracedRNumber{Int}, i isa Colon ? 1 : first(i)) - 1
@@ -124,11 +148,7 @@ function Base.setindex!(
     return v
 end
 
-function Base.setindex!(
-    a::AnyTracedRArray{T,N},
-    v,
-    indices::Vararg{Union{Base.AbstractUnitRange,Colon,Int,TracedRNumber{Int}},N},
-) where {T,N}
+function Base.setindex!(a::AnyTracedRArray{T,N}, v, indices::Vararg{Any,N}) where {T,N}
     ancestor_indices = TracedUtils.get_ancestor_indices(a, indices...)
     setindex!(ancestor(a), v, ancestor_indices...)
     return a

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -47,7 +47,7 @@ end
 function set_mlir_data!(
     x::WrappedReshapedArray{TracedRNumber{T},N,TracedRArray{T,M}}, data
 ) where {T,N,M}
-    res_mlir_data = Ops.reshape(TracedRArray(data), size(parent(x))...).mlir_data
+    res_mlir_data = Ops.reshape(TracedRArray{T}(data), size(parent(x))...).mlir_data
     set_mlir_data!(parent(x), res_mlir_data)
     return x
 end
@@ -55,12 +55,12 @@ end
 function set_mlir_data!(
     x::PermutedDimsArray{TracedRNumber{T},N,perm,iperm,TracedRArray{T,N}}, data
 ) where {T,N,perm,iperm}
-    parent(x).mlir_data = permutedims(TracedRArray(data), iperm).mlir_data
+    parent(x).mlir_data = permutedims(TracedRArray{T}(data), iperm).mlir_data
     return x
 end
 
 function set_mlir_data!(x::AnyTracedRArray, data)
-    setindex!(x, TracedRArray(data), axes(x)...)
+    setindex!(x, TracedRArray{T}(data), axes(x)...)
     return x
 end
 

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -59,7 +59,7 @@ function set_mlir_data!(
     return x
 end
 
-function set_mlir_data!(x::AnyTracedRArray, data)
+function set_mlir_data!(x::AnyTracedRArray{T}, data) where {T}
     setindex!(x, TracedRArray{T}(data), axes(x)...)
     return x
 end

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -259,30 +259,7 @@ function LinearAlgebra.diag(x::AnyTracedRArray{T,2}, k::Integer=0) where {T}
     #   <unknown>:0: note: see current operation: %0 = "tensor.empty"() : () -> tensor<0xf64>
     length(indices) ≤ 0 && return TracedUtils.promote_to(TracedRArray{T,1}, T[])
 
-    idxs = get_mlir_data(TracedUtils.promote_to(TracedRArray{Int,2}, indices))
-
-    #! format: off
-    dimension_numbers = MLIR.API.stablehloGatherDimensionNumbersGet(
-        MLIR.IR.context(),
-        Int64(0), Int64[],
-        Int64(2), Int64[0, 1],
-        Int64(0), Int64[],
-        Int64(0), Int64[],
-        Int64(2), Int64[0, 1],
-        Int64(1)
-    )
-    #! format: on
-
-    slice_sizes = get_mlir_data(
-        Reactant.TracedUtils.promote_to(TracedRArray{Int,1}, [1, 1])
-    )
-    res = MLIR.IR.result(
-        MLIR.Dialects.stablehlo.dynamic_gather(
-            get_mlir_data(y), idxs, slice_sizes; dimension_numbers
-        ),
-        1,
-    )
-    return TracedRArray{T,1}((), res, (diag_length,))
+    return Ops.gather_getindex(x, promote_to(TracedRArray{Int,2}, indices))
 end
 
 function LinearAlgebra._diagm(

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -34,7 +34,7 @@ function materialize_traced_array(
     return LinearAlgebra.diagm(parent(x))
 end
 
-function materialize_traced_array(x::Tridiagonal{T,TracedRArray{T,1}}) where {T}
+function TracedUtils.materialize_traced_array(x::Tridiagonal{T,TracedRArray{T,1}}) where {T}
     return diagm(-1 => x.dl, 0 => x.d, 1 => x.du)
 end
 
@@ -118,7 +118,7 @@ for (AT, dcomp, ocomp) in (
     (:UpperTriangular, "LE", "GT"),
     (:UnitUpperTriangular, "LT", "GE"),
 )
-    @eval function set_mlir_data!(
+    @eval function TracedUtils.set_mlir_data!(
         x::LinearAlgebra.$(AT){T,TracedRArray{T,2}}, data
     ) where {T}
         tdata = TracedRArray{T}(data)
@@ -136,7 +136,9 @@ for (AT, dcomp, ocomp) in (
     end
 end
 
-function set_mlir_data!(x::LinearAlgebra.Symmetric{T,TracedRArray{T,2}}, data) where {T}
+function TracedUtils.set_mlir_data!(
+    x::LinearAlgebra.Symmetric{T,TracedRArray{T,2}}, data
+) where {T}
     if x.uplo == 'L'
         set_mlir_data!(LinearAlgebra.LowerTriangular(parent(x)), data)
     else
@@ -145,7 +147,7 @@ function set_mlir_data!(x::LinearAlgebra.Symmetric{T,TracedRArray{T,2}}, data) w
     return x
 end
 
-function set_mlir_data!(x::Tridiagonal{T,TracedRArray{T,1}}, data) where {T}
+function TracedUtils.set_mlir_data!(x::Tridiagonal{T,TracedRArray{T,1}}, data) where {T}
     tdata = TracedRArray{T}(data)
     set_mlir_data!(x.dl, diag(tdata, -1).mlir_data)
     set_mlir_data!(x.d, diag(tdata, 0).mlir_data)
@@ -259,7 +261,7 @@ function LinearAlgebra.diag(x::AnyTracedRArray{T,2}, k::Integer=0) where {T}
     #   <unknown>:0: note: see current operation: %0 = "tensor.empty"() : () -> tensor<0xf64>
     length(indices) ≤ 0 && return TracedUtils.promote_to(TracedRArray{T,1}, T[])
 
-    return Ops.gather_getindex(x, promote_to(TracedRArray{Int,2}, indices))
+    return Ops.gather_getindex(x, TracedUtils.promote_to(TracedRArray{Int,2}, indices))
 end
 
 function LinearAlgebra._diagm(

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -34,7 +34,9 @@ function TracedUtils.materialize_traced_array(
     return diagm(parent(x))
 end
 
-function TracedUtils.materialize_traced_array(x::Tridiagonal{T,TracedRArray{T,1}}) where {T}
+function TracedUtils.materialize_traced_array(
+    x::Tridiagonal{TracedRNumber{T},TracedRArray{T,1}}
+) where {T}
     return diagm(-1 => x.dl, 0 => x.d, 1 => x.du)
 end
 
@@ -162,7 +164,7 @@ function TracedUtils.set_mlir_data!(
 end
 
 # Core functions
-function LinearAlgebra.mul!(
+function overloaded_mul!(
     @nospecialize(C::TracedRArray{T,1}),
     @nospecialize(A::AnyTracedRMatrix),
     @nospecialize(B::AnyTracedRVector),
@@ -171,23 +173,23 @@ function LinearAlgebra.mul!(
 ) where {T}
     # TODO: The reshape operations are not getting optimized, we should directly call dot_general
     rC = Ops.reshape(C, length(C), 1)
-    mul!(rC, A, reshape(B, :, 1), α, β)
+    overloaded_mul!(rC, A, reshape(B, :, 1), α, β)
     C.mlir_data = get_mlir_data(vec(rC))
     return C
 end
 
-function LinearAlgebra.mul!(
+function overloaded_mul!(
     @nospecialize(C::TracedRArray{T,2}),
     @nospecialize(A::AnyTracedRMatrix),
     @nospecialize(B::AnyTracedRVector),
     α::Number=true,
     β::Number=false,
 ) where {T}
-    mul!(C, A, reshape(B, :, 1), α, β)
+    overloaded_mul!(C, A, reshape(B, :, 1), α, β)
     return C
 end
 
-function LinearAlgebra.mul!(
+function overloaded_mul!(
     @nospecialize(C::TracedRArray{T,2}),
     @nospecialize(A::AnyTracedRMatrix),
     @nospecialize(B::AnyTracedRMatrix),

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -442,6 +442,26 @@ end
     @test @allowscalar all(isone, x_ra_array[4, :])
 end
 
+function non_contiguous_setindex!(x)
+    x[[1, 3, 2], [1, 2, 3, 4]] .= 1.0
+    return x
+end
+
+@testset "non-contiguous setindex!" begin
+    x = rand(6, 6)
+    x_ra = Reactant.to_rarray(x)
+
+    y = @jit(non_contiguous_setindex!(x_ra))
+    y = Array(y)
+    x_ra = Array(x_ra)
+    @test all(isone, y[1:3, 1:4])
+    @test all(isone, x_ra[1:3, 1:4])
+    @test !all(isone, y[4:end, :])
+    @test !all(isone, x_ra[4:end, :])
+    @test !all(isone, y[:, 5:end])
+    @test !all(isone, x_ra[:, 5:end])
+end
+
 tuple_byref(x) = (; a=(; b=x))
 tuple_byref2(x) = abs2.(x), tuple_byref2(x)
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -737,3 +737,57 @@ end
     @test res[1] isa ConcreteRArray{Float64,2}
     @test res[2] isa ConcreteRNumber{Float64}
 end
+
+@testset "non-contiguous indexing" begin
+    x = rand(4, 4, 3)
+    x_ra = Reactant.to_rarray(x)
+
+    non_contiguous_indexing1(x) = x[[1, 3, 2], :, :]
+    non_contiguous_indexing2(x) = x[:, [1, 2, 1, 3], [1, 3]]
+
+    @test @jit(non_contiguous_indexing1(x_ra)) ≈ non_contiguous_indexing1(x)
+    @test @jit(non_contiguous_indexing2(x_ra)) ≈ non_contiguous_indexing2(x)
+
+    x = rand(4, 2)
+    x_ra = Reactant.to_rarray(x)
+
+    non_contiguous_indexing1(x) = x[[1, 3, 2], :]
+    non_contiguous_indexing2(x) = x[:, [1, 2, 2]]
+
+    @test @jit(non_contiguous_indexing1(x_ra)) ≈ non_contiguous_indexing1(x)
+    @test @jit(non_contiguous_indexing2(x_ra)) ≈ non_contiguous_indexing2(x)
+
+    x = rand(4, 4, 3)
+    x_ra = Reactant.to_rarray(x)
+
+    non_contiguous_indexing1!(x) = x[[1, 3, 2], :, :] .= 2
+    non_contiguous_indexing2!(x) = x[:, [1, 2, 1, 3], [1, 3]] .= 2
+
+    @jit(non_contiguous_indexing1!(x_ra))
+    non_contiguous_indexing1!(x)
+    @test x_ra ≈ x
+
+    x = rand(4, 4, 3)
+    x_ra = Reactant.to_rarray(x)
+
+    @jit(non_contiguous_indexing2!(x_ra))
+    non_contiguous_indexing2!(x)
+    @test x_ra ≈ x
+
+    x = rand(4, 2)
+    x_ra = Reactant.to_rarray(x)
+
+    non_contiguous_indexing1!(x) = x[[1, 3, 2], :] .= 2
+    non_contiguous_indexing2!(x) = x[:, [1, 2, 2]] .= 2
+
+    @jit(non_contiguous_indexing1!(x_ra))
+    non_contiguous_indexing1!(x)
+    @test x_ra ≈ x
+
+    x = rand(4, 2)
+    x_ra = Reactant.to_rarray(x)
+
+    @jit(non_contiguous_indexing2!(x_ra))
+    non_contiguous_indexing2!(x)
+    @test x_ra ≈ x
+end

--- a/test/integration/linear_algebra.jl
+++ b/test/integration/linear_algebra.jl
@@ -130,6 +130,17 @@ end
     @test @jit(diagm(4, 5, x_ra)) ≈ diagm(4, 5, x)
     @test @jit(diagm(6, 6, x_ra)) ≈ diagm(6, 6, x)
     @test_throws DimensionMismatch @jit(diagm(3, 3, x_ra))
+
+    x1 = rand(3)
+    x2 = rand(3)
+    x3 = rand(2)
+    x_ra1 = Reactant.to_rarray(x1)
+    x_ra2 = Reactant.to_rarray(x2)
+    x_ra3 = Reactant.to_rarray(x3)
+
+    @test @jit(diagm(1 => x_ra1)) ≈ diagm(1 => x1)
+    @test @jit(diagm(1 => x_ra1, -1 => x_ra3)) ≈ diagm(1 => x1, -1 => x3)
+    @test @jit(diagm(1 => x_ra1, 1 => x_ra2)) ≈ diagm(1 => x1, 1 => x2)
 end
 
 # TODO: Currently Diagonal(x) * x goes down the generic matmul path but it should clearly be

--- a/test/integration/linear_algebra.jl
+++ b/test/integration/linear_algebra.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra, Reactant
+using LinearAlgebra, Reactant, Test
 
 function muladd2(A, x, b)
     C = similar(A, promote_type(eltype(A), eltype(b)), size(A, 1), size(x, 2))
@@ -143,13 +143,29 @@ end
     @test @jit(diagm(1 => x_ra1, 1 => x_ra2)) ≈ diagm(1 => x1, 1 => x2)
 end
 
-# TODO: Currently Diagonal(x) * x goes down the generic matmul path but it should clearly be
-#       optimized
+# TODO: Currently <Wrapper Type>(x) * x goes down the generic matmul path but it should
+#       clearly be optimized
 mul_diagonal(x) = Diagonal(x) * x
+mul_tridiagonal(x) = Tridiagonal(x) * x
+mul_unit_lower_triangular(x) = UnitLowerTriangular(x) * x
+mul_unit_upper_triangular(x) = UnitUpperTriangular(x) * x
+mul_lower_triangular(x) = LowerTriangular(x) * x
+mul_upper_triangular(x) = UpperTriangular(x) * x
+mul_symmetric(x) = Symmetric(x) * x
 
-@testset "mul_diagonal" begin
-    x = rand(4)
+@testset "Wrapper Types Matrix Multiplication" begin
+    x = rand(4, 4)
     x_ra = Reactant.to_rarray(x)
 
-    @test @jit(mul_diagonal(x_ra)) ≈ mul_diagonal(x)
+    @testset "$(wrapper_type)" for (wrapper_type, fn) in [
+        (Diagonal, mul_diagonal),
+        (Tridiagonal, mul_tridiagonal),
+        (UnitLowerTriangular, mul_unit_lower_triangular),
+        (UnitUpperTriangular, mul_unit_upper_triangular),
+        (LowerTriangular, mul_lower_triangular),
+        (UpperTriangular, mul_upper_triangular),
+        (Symmetric, mul_symmetric),
+    ]
+        @test @jit(fn(x_ra)) ≈ fn(x)
+    end
 end

--- a/test/wrapped_arrays.jl
+++ b/test/wrapped_arrays.jl
@@ -172,3 +172,33 @@ end
         @test all(iszero, y_res)
     end
 end
+
+function lower_triangular_write(x)
+    y = LowerTriangular(copy(x))
+    @. y *= 2
+    return y
+end
+
+function upper_triangular_write(x)
+    y = UpperTriangular(copy(x))
+    @. y *= 2
+    return y
+end
+
+function tridiagonal_write(x)
+    y = Tridiagonal(copy(x))
+    @. y *= 2
+    return y
+end
+
+@testset "Broadcasted Multiply and Alloate" begin
+    @testset "$(aType)" for (aType, fn) in [
+        ("LowerTriangular", lower_triangular_write),
+        ("UpperTriangular", upper_triangular_write),
+        ("Tridiagonal", tridiagonal_write),
+    ]
+        x = rand(4, 4)
+        x_ra = Reactant.to_rarray(x)
+        @test @jit(fn(x_ra)) ≈ fn(x)
+    end
+end


### PR DESCRIPTION
we need this before linear algebra stuff because most of them end up using these wrappers as return types.

fixes #345 #242 

## Added Wrapper Types

- Symmetric
- UnitLowerTriangular
- LowerTriangular
- UnitUpperTriangular
- UpperTriangular
- Tridiagonal

## Updated Linear Algebra Support

- `diagm` extended for key value pair version and now we use scatter

## New Addition to `Ops`

1. `scatter_setindex`
2. `gather_getindex`

Not calling them `scatter` / `gather` since they are a significantly restrictive subset of the corresponding stablehlo versions but these are also a very common pattern.

## Fixes / Refactor

1. Non-contiguous indexing for both setindex and getindex
