### PR TITLE
fix: include files if they end with .jl

### DIFF
--- a/src/mlir/Dialects.jl
+++ b/src/mlir/Dialects.jl
@@ -17,6 +17,7 @@ function operandsegmentsizes(segments)
 end
 
 for file in readdir(joinpath(@__DIR__, "Dialects"))
+    endswith(file, ".jl") || continue
     include(joinpath(@__DIR__, "Dialects", file))
 end
 


### PR DESCRIPTION
https://github.com/LuxDL/Lux.jl/actions/runs/12326671368/job/34407753923?pr=1133#step:7:61 lol look me a few days to figure out what was happening. If coverage is enabled we have .cov files generated which will screw up the import of the file.