### PR TITLE
fix `backtrace` calls on debug mode

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -41,7 +41,7 @@ end
 
 @noinline function mlir_stacktrace(name, file, line)::MLIR.IR.Location
     # calling `stacktrace` can add a lot of time overhead, so let's avoid adding debug info if not used
-    if DEBUG_MODE[]
+    if !DEBUG_MODE[]
         return MLIR.IR.Location(name, MLIR.IR.Location(file, line, 0))
     end
 


### PR DESCRIPTION
ups