### PR TITLE
Inference cache

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -354,7 +354,7 @@ function call_with_reactant_generator(
 
     ir, any_changed = rewrite_insts!(ir, interp)
     src = ccall(:jl_new_code_info_uninit, Ref{CC.CodeInfo}, ())
-    src.slotnames = fill(:none, length(ir.argtypes)+1)
+    src.slotnames = fill(:none, length(ir.argtypes) + 1)
     src.slotflags = fill(zero(UInt8), length(ir.argtypes))
     src.slottypes = copy(ir.argtypes)
     src.rettype = rt
@@ -459,7 +459,7 @@ function call_with_reactant_generator(
             )
             push!(overdubbed_codelocs, code_info.codelocs[1])
         end
-    end    
+    end
 
     # ocva = method.isva
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -259,6 +259,29 @@ end
 
 const DEBUG_INTERP = Ref(false)
 
+# Rewrite type unstable calls to recurse into call_with_reactant to ensure
+# they continue to use our interpreter. Reset the derived return type
+# to Any if our interpreter would change the return type of any result.
+# Also rewrite invoke (type stable call) to be :call, since otherwise apparently
+# screws up type inference after this (TODO this should be fixed).
+function rewrite_insts!(ir, interp)
+    any_changed = false
+    for (i, inst) in enumerate(ir.stmts)
+        @static if VERSION < v"1.11"
+            changed, next = rewrite_inst(inst[:inst], ir, interp)
+            Core.Compiler.setindex!(ir.stmts[i], next, :inst)
+        else
+            changed, next = rewrite_inst(inst[:stmt], ir, interp)
+            Core.Compiler.setindex!(ir.stmts[i], next, :stmt)
+        end
+        if changed
+            any_changed = true
+            Core.Compiler.setindex!(ir.stmts[i], Any, :type)
+        end
+    end
+    return ir, any_changed
+end
+
 # Generator function which ensures that all calls to the function are executed within the ReactantInterpreter
 # In particular this entails two pieces:
 #   1) We enforce the use of the ReactantInterpreter method table when generating the original methodinstance
@@ -321,85 +344,17 @@ function call_with_reactant_generator(
         match.spec_types,
         match.sparams,
     )
+    method = mi.def
 
-    cached = CC.get(CC.code_cache(interp), mi, nothing)
-    if !isnothing(cached)
-        Core.println("Found cached code instance for $mi")
-        method = mi.def
-        if cached isa CC.CodeInstance
-            src = Base._uncompressed_ir(cached, cached.inferred)
-            rt = cached.rettype
-        # elseif cached isa Core.CodeInfo
-        #     Core.println("How to get the return type?")
-        #     src =  cached
-        else
-            throw(ArgumentError("Invalid cached code instance for $mi: $(typeof(cached))"))
-        end
-    else
-        result = Core.Compiler.InferenceResult(mi, Core.Compiler.typeinf_lattice(interp))
-        frame = Core.Compiler.InferenceState(result, VERSION < v"1.11-" ? :local : :no, interp) #=cache_mode=#
-        @assert frame !== nothing
-        Core.Compiler.typeinf(interp, frame)
-        @assert Core.Compiler.is_inferred(frame)
-    
-        method = match.method
-    
-        # The original julia code (on 1.11+) has the potential constprop, for now
-        # we assume this outermost function does not constprop, for ease.
-        #if Core.Compiler.result_is_constabi(interp, frame.result)
-        #    rt = frame.result.result::Core.Compiler.Const
-        #    src = Core.Compiler.codeinfo_for_const(interp, frame.linfo, rt.val)
-        #else
-        #
-        opt = Core.Compiler.OptimizationState(frame, interp)
-    
-        if DEBUG_INTERP[]
-            safe_print("opt.src", opt.src)
-        end
-    
-        caller = frame.result
-        @static if VERSION < v"1.11-"
-            ir = Core.Compiler.run_passes(opt.src, opt, caller)
-        else
-            ir = Core.Compiler.run_passes_ipo_safe(opt.src, opt, caller)
-            @static if VERSION < v"1.12-"
-            else
-                Core.Compiler.ipo_dataflow_analysis!(interp, ir, caller)
-            end
-        end
-    
-        if DEBUG_INTERP[]
-            safe_print("ir1", ir)
-        end
+    ir, rt = CC.typeinf_ircode(interp, mi, nothing)
 
-        # Rewrite type unstable calls to recurse into call_with_reactant to ensure
-        # they continue to use our interpreter. Reset the derived return type
-        # to Any if our interpreter would change the return type of any result.
-        # Also rewrite invoke (type stable call) to be :call, since otherwise apparently
-        # screws up type inference after this (TODO this should be fixed).
-        any_changed = false
-        for (i, inst) in enumerate(ir.stmts)
-            @static if VERSION < v"1.11"
-                changed, next = rewrite_inst(inst[:inst], ir, interp)
-                Core.Compiler.setindex!(ir.stmts[i], next, :inst)
-            else
-                changed, next = rewrite_inst(inst[:stmt], ir, interp)
-                Core.Compiler.setindex!(ir.stmts[i], next, :stmt)
-            end
-            if changed
-                any_changed = true
-                Core.Compiler.setindex!(ir.stmts[i], Any, :type)
-            end
-        end
-
-        Core.Compiler.finish(interp, opt, ir, caller)
-
-        rt = Base.Experimental.compute_ir_rettype(ir)
-        src = Core.Compiler.ir_to_codeinf!(opt)
-
-        result.src = src
-        CC.cache_result!(interp, result)
-    end
+    ir, any_changed = rewrite_insts!(ir, interp)
+    src = ccall(:jl_new_code_info_uninit, Ref{CC.CodeInfo}, ())
+    src.slotnames = fill(:none, length(ir.argtypes)+1)
+    src.slotflags = fill(zero(UInt8), length(ir.argtypes))
+    src.slottypes = copy(ir.argtypes)
+    src.rettype = rt
+    src = CC.ir_to_codeinf!(src, ir)
 
     if DEBUG_INTERP[]
         safe_print("src", src)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -294,7 +294,6 @@ function call_with_reactant_generator(
 )
     @nospecialize
     args = redub_arguments
-    Core.println("in call_with_reactant_generator: ", redub_arguments)
     if DEBUG_INTERP[]
         safe_print("args", args)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -346,7 +346,11 @@ function call_with_reactant_generator(
     )
     method = mi.def
 
-    ir, rt = CC.typeinf_ircode(interp, mi, nothing)
+    @static if VERSION < v"1.11"
+        ir, rt = CC.typeinf_ircode(interp, method, mi.specTypes, mi.sparam_vals, nothing)
+    else
+        ir, rt = CC.typeinf_ircode(interp, mi, nothing)
+    end
 
     ir, any_changed = rewrite_insts!(ir, interp)
     src = ccall(:jl_new_code_info_uninit, Ref{CC.CodeInfo}, ())


### PR DESCRIPTION
~~This doesn't work yet! It only caches the top level codeinfo, some other absint method needs to be overwritten to do it properly.
Only tested on Julia 1.11~~
CI passes, and it seems like the cicache is being filled, I don't have a good test to show improvements though.
```julia
f(a, b) = a .* b
a = rand(10)
b = rand(10)

a_ra = Reactant.to_rarray(a)
b_ra = Reactant.to_rarray(b)

g(a, b) = @noinline f(a, b)

@code_hlo(g(a, b))

result = CC.get(CC.code_cache(Reactant.ReactantInterpreter()), Base.method_instance(f, Tuple{Vector{Float64}, Vector{Float64}}), nothing)

```