### PR TITLE
generate EnzymeXLA dialect bindings

### DIFF
--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -625,6 +625,7 @@ gentbl_cc_library(
     ],
     td_file = "@enzyme_ad//src/enzyme_ad/jax:Dialect/EnzymeXLAOps.td",
     deps = [
+        "@enzyme//:EnzymeDialectTdFiles",
         "@enzyme_ad//src/enzyme_ad/jax:EnzymeXLADialectTdFiles",
     ],
     tblgen = "//:mlir-jl-tblgen",

--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -617,6 +617,20 @@ gentbl_cc_library(
 )
 
 gentbl_cc_library(
+    name = "EnzymeXLAJLIncGen",
+    tbl_outs = [(
+            ["--generator=jl-op-defs", "--disable-module-wrap=0"],
+            "EnzymeXLA.jl"
+        )
+    ],
+    td_file = "@enzyme_ad//src/enzyme_ad/jax:Dialect/EnzymeXLAOps.td",
+    deps = [
+        "@enzyme_ad//src/enzyme_ad/jax:EnzymeXLADialectTdFiles",
+    ],
+    tblgen = "//:mlir-jl-tblgen",
+)
+
+gentbl_cc_library(
     name = "StableHLOJLIncGen",
     tbl_outs = [(
             ["--generator=jl-op-defs", "--disable-module-wrap=0"],

--- a/deps/ReactantExtra/make-bindings.jl
+++ b/deps/ReactantExtra/make-bindings.jl
@@ -19,6 +19,7 @@ for file in [
     "Affine.jl",
     "Func.jl",
     "Enzyme.jl",
+    "EnzymeXLA.jl",
     "StableHLO.jl",
     "CHLO.jl",
     "VHLO.jl",


### PR DESCRIPTION
@wsmoses i'm getting this error

```
external/enzyme_ad/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td:12:9: error: could not find include file 'Enzyme/MLIR/Dialect/Dialect.td'
include "Enzyme/MLIR/Dialect/Dialect.td"
        ^
external/enzyme_ad/src/enzyme_ad/jax/Dialect/EnzymeXLAOps.td:12:9: error: Unexpected token at top level
include "Enzyme/MLIR/Dialect/Dialect.td"
```