### PR TITLE
add `Ops.convolution`

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -138,6 +138,49 @@ extern "C" MlirAttribute mlirComplexAttrDoubleGetChecked(MlirLocation loc,
 // wrap(complex::NumberAttr::getTypeID()); }
 #pragma endregion
 
+
+#include "stablehlo/dialect/TypeInference.h"
+
+
+typedef struct {
+    MlirAttribute windowStrides;
+    MlirAttribute padding;
+    MlirAttribute lhsDilation;
+    MlirAttribute rhsDilation;
+    MlirAttribute windowReversal;
+    MlirAttribute dimensionNumber;
+    int64_t featureGroupCount;
+    int64_t batchGroupCount;
+} ConvolutionParams;
+
+
+extern "C" MlirType
+inferConvolutionOp(MlirLocation location, MlirType lhsType, MlirType rhsType, ConvolutionParams *cp) {
+  auto windowStrides = dyn_cast<DenseI64ArrayAttr>(unwrap(cp->windowStrides));
+  auto lhsDilation = dyn_cast<DenseI64ArrayAttr>(unwrap(cp->lhsDilation));
+  auto rhsDilation = dyn_cast<DenseI64ArrayAttr>(unwrap(cp->rhsDilation));
+  auto windowReversal = dyn_cast<DenseBoolArrayAttr>(unwrap(cp->windowReversal));
+  
+  std::optional<DenseIntElementsAttr> padding_mlir = dyn_cast_if_present<DenseIntElementsAttr>(unwrap(cp->padding));
+  auto dn_mlir = cast<stablehlo::ConvDimensionNumbersAttr>(unwrap(cp->dimensionNumber));
+  auto lhsType_ = dyn_cast<RankedTensorType>(unwrap(lhsType));
+
+  SmallVector<ShapedTypeComponents> inferredReturnShapes;
+  auto result = mlir::hlo::inferConvolutionOp(
+      unwrap(location), lhsType_, unwrap(rhsType), windowStrides, padding_mlir,
+      lhsDilation, rhsDilation, windowReversal, dn_mlir.getInputBatchDimension(),
+      dn_mlir.getInputFeatureDimension(), dn_mlir.getInputSpatialDimensions(),
+      dn_mlir.getKernelInputFeatureDimension(),
+      dn_mlir.getKernelOutputFeatureDimension(),
+      dn_mlir.getKernelSpatialDimensions(), dn_mlir.getOutputBatchDimension(),
+      dn_mlir.getOutputFeatureDimension(), dn_mlir.getOutputSpatialDimensions(),
+      cp->featureGroupCount, cp->batchGroupCount, nullptr, inferredReturnShapes);
+  if (result.failed())
+    return MlirType();
+  return wrap(RankedTensorType::get(inferredReturnShapes[0].getDims(),
+                                    lhsType_.getElementType()));
+}
+
 // auxiliar functions
 #pragma region utils
 template <typename T> const char *cstr_from_string(T text) {

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -580,11 +580,32 @@ mutable struct ConvolutionParams
     batchGroupCount::Int64
 end
 
-function inferConvolutionOp(loc::Location, lhsType::MLIR.IR.Type, rhsType::MLIR.IR.Type, windowStrides::MLIR.IR.Attribute, padding::MLIR.IR.Attribute, lhsDilation::MLIR.IR.Attribute, rhsDilation::MLIR.IR.Attribute, windowReversal::MLIR.IR.Attribute, dimensionNumber::MLIR.IR.Attribute, featureGroupCount::Int, batchGroupCount::Int)
-    cp = ConvolutionParams(windowStrides, padding, lhsDilation, rhsDilation, windowReversal, dimensionNumber, featureGroupCount, batchGroupCount)
+function inferConvolutionOp(
+    loc::Location,
+    lhsType::MLIR.IR.Type,
+    rhsType::MLIR.IR.Type,
+    windowStrides::MLIR.IR.Attribute,
+    padding::MLIR.IR.Attribute,
+    lhsDilation::MLIR.IR.Attribute,
+    rhsDilation::MLIR.IR.Attribute,
+    windowReversal::MLIR.IR.Attribute,
+    dimensionNumber::MLIR.IR.Attribute,
+    featureGroupCount::Int,
+    batchGroupCount::Int,
+)
+    cp = ConvolutionParams(
+        windowStrides,
+        padding,
+        lhsDilation,
+        rhsDilation,
+        windowReversal,
+        dimensionNumber,
+        featureGroupCount,
+        batchGroupCount,
+    )
     @ccall mlir_c.inferConvolutionOp(
-        loc::MlirLocation, lhsType::MlirType, rhsType::MlirType,
-        cp::Ref{ConvolutionParams})::MlirType
+        loc::MlirLocation, lhsType::MlirType, rhsType::MlirType, cp::Ref{ConvolutionParams}
+    )::MlirType
 end
 
 function convolution(
@@ -639,14 +660,6 @@ function convolution(
         ),
     )
     return TracedRArray{T,N}((), res, size(output_type))
-end
-
-x = Reactant.to_rarray(randn(Float64, 224, 224, 1, 1))
-ker = Reactant.to_rarray(randn(Float64, 10, 10, 1, 1))
-
-function v(x, ker)
-    pp = dimension_number(4, 3, 2, 3, 4)
-    return convolution(x, ker, pp; padding=[1 2; 3 4])
 end
 
 @noinline function dot_general(


### PR DESCRIPTION
Add convolution using StableHLO infer function, missing tests. Add a structure because I find a limit with `ccall`:

```
extern "C" void f(long a, long b, long c, long d,long e, MlirAttribute dn) {
	auto pp = unwrap(dn);
	pp.dump();
}

extern "C" void f_bad(long a, long b, long c, long d,long e,long f, MlirAttribute dn) {
	auto pp = unwrap(dn);
	pp.dump();
}
```
The second one causes sigfault. 
@wsmoses do you think this approach is viable?