### PR TITLE
linearize aliased kernel args

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -507,7 +507,6 @@ Reactant.@reactant_overlay @noinline function (func::LLVMFunc{F,tt})(
             if p[1] !== kernelargsym
                 continue
             end
-                        
             # Get the allocation corresponding to which arg we're doing
             alloc = allocs[p[2]][1]
 
@@ -533,11 +532,9 @@ Reactant.@reactant_overlay @noinline function (func::LLVMFunc{F,tt})(
                     ),
                 ),
             )
-            
         end
         argidx += 1
     end
-        
     MLIR.IR.block!(wrapbody) do
         for arg in allocs
             if arg === nothing

--- a/test/integration/cuda.jl
+++ b/test/integration/cuda.jl
@@ -116,9 +116,8 @@ tuplef2(a) = @cuda threads=1 tuplef2!((5, a))
         @code_hlo optimize = :before_kernel tuplef2(A)
     end
 end
-end
 
-struct MyStruct{T, B}
+struct MyStruct{T,B}
     b::B
     A::T
 end
@@ -127,19 +126,19 @@ function aliased!(tup)
     tup[1].A[] = 2
     return nothing
 end
-aliased(s) = @cuda threads=1 aliased!((s, s))
+aliased(s) = @cuda threads = 1 aliased!((s, s))
 
 @static if !Sys.isapple()
-@testset "Aliasing arguments" begin
-    a = ConcreteRArray(fill(1))
+    @testset "Aliasing arguments" begin
+        a = ConcreteRArray(fill(1))
 
-    s = MyStruct(10, A)
-    
-    if CUDA.functional()
-        @jit aliased((s, s))
-        @test all(Array(A) == 2)
-    else
-        @code_hlo optimize=:before_kernel aliased(s);
+        s = MyStruct(10, A)
+
+        if CUDA.functional()
+            @jit aliased((s, s))
+            @test all(Array(A) == 2)
+        else
+            @code_hlo optimize = :before_kernel aliased(s)
+        end
     end
-end
 end

--- a/test/integration/cuda.jl
+++ b/test/integration/cuda.jl
@@ -115,7 +115,6 @@ tuplef2(a) = @cuda threads = 1 tuplef2!((5, a))
             @code_hlo optimize = :before_kernel tuplef2(A)
         end
     end
-    
     A = ConcreteRArray(fill(1))
     if CUDA.functional()
         @jit tuplef2(A)

--- a/test/integration/cuda.jl
+++ b/test/integration/cuda.jl
@@ -129,18 +129,17 @@ end
 function aliased!(tup)
     x, y = tup
     x[2][1] *= y[2][1]
-   return nothing
+    return nothing
 end
 
 function aliased(s)
     tup = (s, s)
     @cuda threads = 1 aliased!(tup)
-    nothing
+    return nothing
 end
 
 @static if !Sys.isapple()
     @testset "Aliasing arguments" begin
-
         a = ConcreteRArray([3])
 
         s = (10, a)


### PR DESCRIPTION
Can't test end-to-end but the HLO contains the stores.
```julia
using Reactant, CUDA

A = ConcreteRArray(fill(1))

struct MyStruct{T, B}
    b::B
    A::T
end

function f!(tup)
    tup[1].A[] = 2
    return nothing
end

s = MyStruct(10, A)

f(s) = @cuda threads=1 f!((s, s))
@code_hlo optimize=false f(s);
```