### PR TITLE
Make v and hcat with numbers work.

### DIFF
--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -202,6 +202,7 @@ end
 # StdLib Overloads
 include("stdlibs/LinearAlgebra.jl")
 include("stdlibs/Random.jl")
+include("stdlibs/Base.jl")
 
 # Other Integrations
 include("Enzyme.jl")

--- a/src/stdlibs/Base.jl
+++ b/src/stdlibs/Base.jl
@@ -1,4 +1,4 @@
-@inline Base.vcat(a::Number, b::RArray) =
+@inline Base.vcat(a::Number, b::Union{AnyConcreteRArray, AnyTracedRArray}) =
     @allowscalar(vcat(fill!(similar(b, typeof(a), (1, size(b)[2:end]...)), a), b))
-@inline Base.hcat(a::Number, b::RArray) =
+@inline Base.hcat(a::Number, b::Union{AnyConcreteRArray, AnyTracedRArray}) =
     @allowscalar(hcat(fill!(similar(b, typeof(a), (size(b)[1:end-1]..., 1)), a), b))

--- a/src/stdlibs/Base.jl
+++ b/src/stdlibs/Base.jl
@@ -1,0 +1,4 @@
+@inline Base.vcat(a::Number, b::RArray) =
+    @allowscalar(vcat(fill!(similar(b, typeof(a), (1, size(b)[2:end]...)), a), b))
+@inline Base.hcat(a::Number, b::RArray) =
+    @allowscalar(hcat(fill!(similar(b, typeof(a), (size(b)[1:end-1]..., 1)), a), b))

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -368,6 +368,17 @@ end
         @test y == test_typed_hvncat(x)
         @test eltype(y) === Int
     end
+
+    @testset "Number and RArray" begin
+        a = 1.0
+        b = Reactant.to_rarray(ones(3))
+        c = Reactant.to_rarray(ones(1, 3))
+        @test size(vcat(a, b)) == (4,)
+        @test size(hcat(a, b')) == (1, 4)
+        @test size(hcat(a, c)) == (1, 4)
+        @test size(vcat(a, c')) == (4, 1)
+    end
+
 end
 
 @testset "repeat" begin

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -369,28 +369,32 @@ end
         @test eltype(y) === Int
     end
 
-    @testset "Number and RArray" begin
-        a = 1.0
-        b = Reactant.to_rarray(ones(3))
-        c = Reactant.to_rarray(ones(1, 3))
-        
+    @testset "Number and RArray" for a in [randn(Float32), randn(Float64)]
+        typeof_a = typeof(a)
+        _b = randn(typeof_a, 3)
+        _c = randn(typeof_a, 1, 3)
+        b = Reactant.to_rarray(_b)
+        c = Reactant.to_rarray(_c)
+    
         # vcat test        
         y = @jit vcat(a, b)
-        @test size(y) == (4,)
-        @test eltype(y) === Float64
+        @test y == Reactant.to_rarray(vcat(a, _b))
+        @test y isa ConcreteRArray{typeof_a,1}
+    
         ## vcat test - adjoint
         y1 = @jit vcat(a, c')
-        @test size(y1) == (4, 1)
-        @test eltype(y1) === Float64
-        
+        @test y1 == Reactant.to_rarray(vcat(a, _c'))
+        @test y1 isa ConcreteRArray{typeof_a,2}
+    
         # hcat test
         z = @jit hcat(a, c)
-        @test size(z) == (1, 4)
-        @test eltype(z) === Float64
+        @test z == Reactant.to_rarray(hcat(a, _c))
+        @test z isa ConcreteRArray{typeof_a,2}
+    
         ## hcat test - adjoint
         z1 = @jit hcat(a, b')
-        @test size(z1) == (1, 4)
-        @test eltype(z1) === Float64
+        @test z1 == Reactant.to_rarray(hcat(a, _b')) # ConcreteRArray(hcat(a, _b')) does not work.
+        @test z1 isa ConcreteRArray{typeof_a,2}
     end
 end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -369,31 +369,31 @@ end
         @test eltype(y) === Int
     end
 
-    @testset "Number and RArray" for a in [2.0f0, 2.0e0]
+    @testset "Number and RArray" for a in [1.0f0, 1.0e0]
         typeof_a = typeof(a)
-        _b = randn(typeof_a, 3)
-        _c = randn(typeof_a, 1, 3)
+        _b = [2.0, 3.0, 4.0] .|> typeof_a
+        _c = [2.0 3.0 4.0] .|> typeof_a
         b = Reactant.to_rarray(_b)
         c = Reactant.to_rarray(_c)
     
         # vcat test        
         y = @jit vcat(a, b)
-        @test y == Reactant.to_rarray(vcat(a, _b))
+        @test y == vcat(a, _b)
         @test y isa ConcreteRArray{typeof_a,1}
     
         ## vcat test - adjoint
         y1 = @jit vcat(a, c')
-        @test y1 == Reactant.to_rarray(vcat(a, _c'))
+        @test y1 == vcat(a, _c')
         @test y1 isa ConcreteRArray{typeof_a,2}
     
         # hcat test
         z = @jit hcat(a, c)
-        @test z == Reactant.to_rarray(hcat(a, _c))
+        @test z == hcat(a, _c)
         @test z isa ConcreteRArray{typeof_a,2}
     
         ## hcat test - adjoint
         z1 = @jit hcat(a, b')
-        @test z1 == Reactant.to_rarray(hcat(a, _b')) # ConcreteRArray(hcat(a, _b')) does not work.
+        @test z1 == hcat(a, _b')
         @test z1 isa ConcreteRArray{typeof_a,2}
     end
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -369,7 +369,7 @@ end
         @test eltype(y) === Int
     end
 
-    @testset "Number and RArray" for a in [randn(Float32), randn(Float64)]
+    @testset "Number and RArray" for a in [2.0f0, 2.0e0]
         typeof_a = typeof(a)
         _b = randn(typeof_a, 3)
         _c = randn(typeof_a, 1, 3)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -373,12 +373,25 @@ end
         a = 1.0
         b = Reactant.to_rarray(ones(3))
         c = Reactant.to_rarray(ones(1, 3))
-        @test size(vcat(a, b)) == (4,)
-        @test size(hcat(a, b')) == (1, 4)
-        @test size(hcat(a, c)) == (1, 4)
-        @test size(vcat(a, c')) == (4, 1)
+        
+        # vcat test        
+        y = @jit vcat(a, b)
+        @test size(y) == (4,)
+        @test eltype(y) === Float64
+        ## vcat test - adjoint
+        y1 = @jit vcat(a, c')
+        @test size(y1) == (4, 1)
+        @test eltype(y1) === Float64
+        
+        # hcat test
+        z = @jit hcat(a, c)
+        @test size(z) == (1, 4)
+        @test eltype(z) === Float64
+        ## hcat test - adjoint
+        z1 = @jit hcat(a, b')
+        @test size(z1) == (1, 4)
+        @test eltype(z1) === Float64
     end
-
 end
 
 @testset "repeat" begin


### PR DESCRIPTION
Concatenating a number with an RArray does not result in an RArray.

This PR addresses this issue, based on https://github.com/JuliaGPU/GPUArrays.jl/pull/379/files.

The GPU backend encounters a scalar index error when the `@allowscalar` is not used, while the CPU backend functions correctly without it.

(Fixes https://github.com/EnzymeAD/Reactant.jl/issues/511)