### PR TITLE
Simplify process to builds docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,24 +143,22 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v2
-      - run: |
+      - name: Instantiate docs environment
+        run: |
           julia --color=yes --project=docs -e '
             using Pkg
-            Pkg.develop([
-              PackageSpec(path=pwd()),
-              PackageSpec("Reactant_jll"),
-              PackageSpec(path="lib/ReactantCore")
-            ])
             Pkg.instantiate()'
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
-      - run: |
+      - name: Run doctests
+        run: |
           julia --color=yes --project=docs -e '
             using Documenter: DocMeta, doctest
             using Reactant
             DocMeta.setdocmeta!(Reactant, :DocTestSetup, :(using Reactant); recursive=true)
             doctest(Reactant)'
-      - run: julia --color=yes --project=docs docs/make.jl
+      - name: Build documentation
+        run: julia --color=yes --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,7 +2,13 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterVitepress = "4710194d-e776-4893-9690-8d956a29c365"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+ReactantCore = "a3311ec8-5e00-46d5-b541-4f83e724a433"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Documenter = "1.4.1"
+
+[sources]
+Reactant = {path = ".."}
+ReactantCore = {path = "../lib/ReactantCore"}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,3 @@
-pushfirst!(LOAD_PATH, joinpath(@__DIR__, ".."))
-pushfirst!(LOAD_PATH, joinpath(@__DIR__, "../lib/ReactantCore/"))
-
 using Reactant, ReactantCore
 using Documenter, DocumenterVitepress
 


### PR DESCRIPTION
Use `[sources]` section of `docs/Project.toml` instead of messing with `LOAD_PATH`.  Same as https://github.com/EnzymeAD/Enzyme.jl/pull/2265.