### PR TITLE
[CI] Format generated files twice to work around JuliaFormatter bug

### DIFF
--- a/.github/workflows/benchmark_aggregate.yml
+++ b/.github/workflows/benchmark_aggregate.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   benchmark:
-    if: ${{ !contains(github.event.head_commit.message, '[skip benchmarks]') }}
+    if: ${{ !contains(github.event.head_commit.message, '[skip benchmarks]') && ! github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/regenerate-mlir-bindings.yml
+++ b/.github/workflows/regenerate-mlir-bindings.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  make:
+  mlir-bindings:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,7 +40,8 @@ jobs:
         working-directory: ./deps/ReactantExtra
         env:
           JULIA_DEPOT_PATH: ${{ runner.temp }}/julia_depot
-      - run: |
+      - name: Make generated files writable
+          run: |
           chmod -R u+rw ./src/mlir/Dialects/
           chmod u+rw ./src/mlir/libMLIR_h.jl
           git config core.fileMode false
@@ -48,6 +49,9 @@ jobs:
         shell: julia --color=yes {0}
         run: |
           using JuliaFormatter
+          format("./src/mlir/Dialects/")
+          format("./src/mlir/libMLIR_h.jl")
+          # Format twice to work around <https://github.com/domluna/JuliaFormatter.jl/issues/897>.
           format("./src/mlir/Dialects/")
           format("./src/mlir/libMLIR_h.jl")
       - name: Create Pull Request


### PR DESCRIPTION
While we evaluate a move to Runic, this should resolve the problem that the formatting job and bindings generation job conflict with each other due to an [upstream bug in JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl/issues/897).