### PR TITLE
[GHA] Add `paths` settings for workflow triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,28 @@
 name: CI
+
 on:
   pull_request:
+    paths:
+      - '.github/workflows/CI.yml'
+      - 'deps/**'
+      - 'ext/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
   push:
     branches:
       - main
       - release-*
     tags: '*'
+    paths:
+      - '.github/workflows/CI.yml'
+      - 'deps/**'
+      - 'ext/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
 
 concurrency:
   # Skip intermediate builds: always.
@@ -134,31 +151,3 @@ jobs:
         if: steps.run_tests.outcome == 'success'
         with:
           files: lcov.info
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v2
-      - name: Instantiate docs environment
-        run: |
-          julia --color=yes --project=docs -e '
-            using Pkg
-            Pkg.instantiate()'
-        env:
-          JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
-      - name: Run doctests
-        run: |
-          julia --color=yes --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using Reactant
-            DocMeta.setdocmeta!(Reactant, :DocTestSetup, :(using Reactant); recursive=true)
-            doctest(Reactant)'
-      - name: Build documentation
-        run: julia --color=yes --project=docs docs/make.jl
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/Documenter.yaml
+++ b/.github/workflows/Documenter.yaml
@@ -1,0 +1,54 @@
+name: Documentation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/Documenter.yml'
+      - 'docs/**'
+      - 'lib/**'
+      - 'src/**'
+  push:
+    branches:
+      - main
+    tags: '*'
+    paths:
+      - '.github/workflows/Documenter.yml'
+      - 'docs/**'
+      - 'lib/**'
+      - 'src/**'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - name: Instantiate docs environment
+        run: |
+          julia --color=yes --project=docs -e '
+            using Pkg
+            Pkg.instantiate()'
+        env:
+          JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
+      - name: Run doctests
+        run: |
+          julia --color=yes --project=docs -e '
+            using Documenter: DocMeta, doctest
+            using Reactant
+            DocMeta.setdocmeta!(Reactant, :DocTestSetup, :(using Reactant); recursive=true)
+            doctest(Reactant)'
+      - name: Build documentation
+        run: julia --color=yes --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/benchmark_aggregate.yml
+++ b/.github/workflows/benchmark_aggregate.yml
@@ -1,4 +1,5 @@
 name: Benchmarks
+
 permissions:
   contents: write # contents permission to update benchmark contents in gh-pages branch
   statuses: read
@@ -7,10 +8,21 @@ permissions:
 
 on:
   pull_request:
-
+    paths:
+      - '.github/workflows/benchmark_aggregate.yml'
+      - 'ext/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'Project.toml'
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/benchmark_aggregate.yml'
+      - 'ext/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'Project.toml'
 
 jobs:
   benchmark:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -1,11 +1,24 @@
 name: Downgrade
+
 on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/downgrade.yml'
+      - 'ext/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'Project.toml'
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/downgrade.yml'
+      - 'ext/**'
+      - 'lib/**'
+      - 'src/**'
+      - 'Project.toml'
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,10 +1,17 @@
 name: Format Suggestions
+
 on:
   push:
     branches:
       - main
     tags: '*'
+    paths:
+      - '.github/workflows/format-check.yml'
+      - '**/*.jl'
   pull_request:
+    paths:
+      - '.github/workflows/format-check.yml'
+      - '**/*.jl'
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Restrict running different workflows based on the touched files.  This should _slightly_ reduce CI workload.