### PR TITLE
make `similar` return empty tensors.

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -84,6 +84,45 @@ end
     return TracedRNumber{T}((), res.mlir_data)
 end
 
+for (T, mlir_func) in (
+    (Bool, :mlirDenseElementsAttrBoolSplatGet),
+    (UInt8, :mlirDenseElementsAttrUInt8SplatGet),
+    (Int8, :mlirDenseElementsAttrInt8SplatGet),
+    (UInt32, :mlirDenseElementsAttrUInt32SplatGet),
+    (Int32, :mlirDenseElementsAttrInt32SplatGet),
+    (UInt64, :mlirDenseElementsAttrUInt64SplatGet),
+    (Int64, :mlirDenseElementsAttrInt64SplatGet),
+    (Float32, :mlirDenseElementsAttrFloatSplatGet),
+    (Float64, :mlirDenseElementsAttrDoubleSplatGet),
+)
+    @eval begin
+        @noinline function fill(
+            number::$T,
+            shape::Vector{Int};
+            location=mlir_stacktrace("fill", @__FILE__, @__LINE__),
+        )
+            tt = MLIR.IR.TensorType(shape, MLIR.IR.Type($T); location=location)
+
+            splatattr = MLIR.API.$mlir_func(tt, number)
+            cst_op = stablehlo.constant(; output=tt, value=splatattr, location=location)
+            cst = MLIR.IR.result(cst_op)
+            ta = TracedRArray{$T,length(shape)}((), cst, shape)
+            return ta
+        end
+    end
+end
+
+@noinline function fill(
+    element::T, shape::Vector{Int}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)
+) where {T}
+    tt = MLIR.IR.TensorType(shape, MLIR.IR.Type(T))
+    splatattr = MLIR.API.mlirDenseElementsAttrSplatGet(tt, MLIR.IR.Attribute(element))
+    cst_op = stablehlo.constant(; output=tt, value=splatattr, location=location)
+    cst = MLIR.IR.result(cst_op)
+    ta = TracedRArray{T,length(shape)}((), cst, shape)
+    return ta
+end
+
 # unary elementwise ops
 for (dialect, op) in [
     (:stablehlo, :abs),
@@ -332,50 +371,6 @@ end
     )
     return TracedRArray{T,N}((), res, size(x))
 end
-
-# for (typ, apicall) in (
-#     (Bool, :mlirDenseElementsAttrBoolSplatGet),
-#     (UInt8, :mlirDenseElementsAttrUInt8SplatGet),
-#     (Int8, :mlirDenseElementsAttrInt8SplatGet),
-#     (UInt32, :mlirDenseElementsAttrUInt32SplatGet),
-#     (Int32, :mlirDenseElementsAttrInt32SplatGet),
-#     (UInt64, :mlirDenseElementsAttrUInt64SplatGet),
-#     (Int64, :mlirDenseElementsAttrInt64SplatGet),
-#     (Float32, :mlirDenseElementsAttrFloatSplatGet),
-#     (Float64, :mlirDenseElementsAttrDoubleSplatGet),
-#     )
-#     @eval begin
-#         @noinline function Base.fill(
-#             number::$typ,
-#             shape::Vector{Int};
-#             location=mlir_stacktrace("fill", @__FILE__, @__LINE__),
-#         )
-#             value = $(:(MLIR.API.$apicall))(MLIR.IR.TensorType([1, 2], IR.Type(Int)), number)
-#             # output = mlir_type(TracedRArray{$typ,length(shape)}, shape)
-#             # res = MLIR.IR.result(stablehlo.constant(; output, value, location))
-#             # return TracedRArray{$typ,length(shape)}((), res, shape)
-#             # return value
-#         end
-
-
-#     end
-# end
-
-@noinline function fill(
-    number::Int,
-    shape::Vector{Int};
-    location=mlir_stacktrace("fill", @__FILE__, @__LINE__),
-)
-    out_ty = MLIR.IR.VectorType(length(shape), shape, MLIR.IR.Type(Int))
-    splatattr = MLIR.API.mlirDenseElementsAttrInt64SplatGet(MLIR.IR.VectorType(length(shape), shape, MLIR.IR.Type(Int)), number)
-    cst_op = stablehlo.constant(; output=out_ty, value=splatattr, location=location)
-    cst = MLIR.IR.result(cst_op)
-    ta = TracedRArray{Int, length(shape)}((), cst, shape)
-    @warn cst_op
-    @warn ta
-    return ta
-end
-
 
 @noinline function transpose(
     x::TracedRArray{T,N},

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -402,9 +402,9 @@ end
 @noinline function pad(
     x::TracedRArray{T,N},
     padding_value::TracedRNumber{T};
-    low=fill(0, N),
-    high=fill(0, N),
-    interior=fill(0, N),
+    low=Base.fill(0, N),
+    high=Base.fill(0, N),
+    interior=Base.fill(0, N),
     location=mlir_stacktrace("pad", @__FILE__, @__LINE__),
 ) where {T,N}
     rsize = size(x) .+ low .+ high .+ max.(size(x) .- 1, 0) .* interior
@@ -1108,7 +1108,7 @@ end
     op = chlo.top_k(x.mlir_data; values, indices, k, location)
     indices = add(
         TracedRArray{Int32,N}((), MLIR.IR.result(op, 2), rsize),
-        constant(fill(Int32(1), Tuple(rsize))),
+        fill(Int32(1), Tuple(rsize)),
     ) # return the 1-indexed index
     indices = convert(TracedRArray{Int64,N}, indices) # julia indexes with Int64 generally
     values = TracedRArray{T,N}((), MLIR.IR.result(op, 1), rsize)
@@ -1212,7 +1212,7 @@ end
     (; output_state, output) = rng_bit_generator(uT, seed, shape; algorithm, location)
     output = divide(
         convert(TracedRArray{T,ndims(output)}, output),
-        constant(fill(T(typemax(uT)), Tuple(shape)); location),
+        fill(T(typemax(uT)), Tuple(shape); location),
     )
     return (; output_state, output)
 end
@@ -1252,11 +1252,11 @@ fields:
     rand_uniform = res.output
     seed = res.output_state
     scaled_uniform = subtract(
-        multiply(rand_uniform, constant(fill(T(2), size(rand_uniform)))),
-        constant(fill(T(1), size(rand_uniform))),
+        multiply(rand_uniform, fill(T(2), size(rand_uniform))),
+        fill(T(1), size(rand_uniform)),
     )
     probit = erf_inv(scaled_uniform)
-    rand_normal = multiply(probit, constant(fill(Base.sqrt(T(2)), size(rand_uniform))))
+    rand_normal = multiply(probit, fill(Base.sqrt(T(2)), size(rand_uniform)))
     return (; output_state=seed, output=rand_normal)
 end
 
@@ -1622,7 +1622,7 @@ use [`MLIR.Dialects.stablehlo.dynamic_slice`](@ref) instead.
                     src.mlir_data,
                     gather_indices.mlir_data;
                     dimension_numbers,
-                    slice_sizes=fill(Int64(1), N),
+                    slice_sizes=Base.fill(Int64(1), N),
                     indices_are_sorted=false,
                 ),
                 1,

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -84,12 +84,26 @@ end
     return TracedRNumber{T}((), res.mlir_data)
 end
 
-fill(v, dims::Base.DimOrInd...; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)) = fill(v, dims; location)
-function fill(v, dims::NTuple{N,Union{Integer,Base.OneTo}}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)) where {N}
+function fill(
+    v, dims::Base.DimOrInd...; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)
+)
+    return fill(v, dims; location)
+end
+function fill(
+    v,
+    dims::NTuple{N,Union{Integer,Base.OneTo}};
+    location=mlir_stacktrace("fill", @__FILE__, @__LINE__),
+) where {N}
     return fill(v, map(Base.to_dim, dims); location)
 end
-fill(v, dims::NTuple{N,Integer}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)) where {N} = fill(v, collect(dims); location)
-fill(v, ::Tuple{}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)) = fill(v, Int[]; location)
+function fill(
+    v, dims::NTuple{N,Integer}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)
+) where {N}
+    return fill(v, collect(dims); location)
+end
+function fill(v, ::Tuple{}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__))
+    return fill(v, Int[]; location)
+end
 
 for (T, mlir_func) in (
     (Bool, :mlirDenseElementsAttrBoolSplatGet),
@@ -120,10 +134,11 @@ for (T, mlir_func) in (
 end
 
 _fill_element_attr(x) = MLIR.IR.Attribute(x)
-_fill_element_attr(x::Complex) = MLIR.IR.Attribute([
-    MLIR.IR.Attribute(Base.real(x)),
-    MLIR.IR.Attribute(Base.imag(x)),
-])
+function _fill_element_attr(x::Complex)
+    return MLIR.IR.Attribute([
+        MLIR.IR.Attribute(Base.real(x)), MLIR.IR.Attribute(Base.imag(x))
+    ])
+end
 
 @noinline function fill(
     element::T, shape::Vector{Int}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -85,9 +85,11 @@ end
 end
 
 fill(v, dims::Base.DimOrInd...) = fill(v, dims)
-fill(v, dims::NTuple{N, Union{Integer, Base.OneTo}}) where {N} = fill(v, map(Base.to_dim, dims))
-fill(v, dims::NTuple{N, Integer}) where {N} = fill(v, collect(dims))
-fill(v, dims::Tuple{}) = fill(v, Int[])
+function fill(v, dims::NTuple{N,Union{Integer,Base.OneTo}}) where {N}
+    return fill(v, map(Base.to_dim, dims))
+end
+fill(v, dims::NTuple{N,Integer}) where {N} = fill(v, collect(dims))
+fill(v, ::Tuple{}) = fill(v, Int[])
 
 for (T, mlir_func) in (
     (Bool, :mlirDenseElementsAttrBoolSplatGet),
@@ -120,7 +122,6 @@ end
 @noinline function fill(
     element::T, shape::Vector{Int}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)
 ) where {T}
-    Core.println("fill: element type: $T, shape: $shape")
     tt = MLIR.IR.TensorType(shape, MLIR.IR.Type(T))
     splatattr = MLIR.API.mlirDenseElementsAttrSplatGet(tt, MLIR.IR.Attribute(element))
     cst_op = stablehlo.constant(; output=tt, value=splatattr, location=location)

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -105,6 +105,10 @@ function fill(v, ::Tuple{}; location=mlir_stacktrace("fill", @__FILE__, @__LINE_
     return fill(v, Int[]; location)
 end
 
+function fill(number::TracedRNumber{T}, shape::Vector{Int}; location) where T
+    Base.fill(number, Tuple(shape))
+end
+
 for (T, mlir_func) in (
     (Bool, :mlirDenseElementsAttrBoolSplatGet),
     (UInt8, :mlirDenseElementsAttrUInt8SplatGet),

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -105,8 +105,8 @@ function fill(v, ::Tuple{}; location=mlir_stacktrace("fill", @__FILE__, @__LINE_
     return fill(v, Int[]; location)
 end
 
-function fill(number::TracedRNumber{T}, shape::Vector{Int}; location) where T
-    Base.fill(number, Tuple(shape))
+function fill(number::TracedRNumber{T}, shape::Vector{Int}; location) where {T}
+    return Base.fill(number, Tuple(shape))
 end
 
 for (T, mlir_func) in (

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -84,6 +84,11 @@ end
     return TracedRNumber{T}((), res.mlir_data)
 end
 
+fill(v, dims::Base.DimOrInd...) = fill(v, dims)
+fill(v, dims::NTuple{N, Union{Integer, Base.OneTo}}) where {N} = fill(v, map(Base.to_dim, dims))
+fill(v, dims::NTuple{N, Integer}) where {N} = fill(v, collect(dims))
+fill(v, dims::Tuple{}) = fill(v, Int[])
+
 for (T, mlir_func) in (
     (Bool, :mlirDenseElementsAttrBoolSplatGet),
     (UInt8, :mlirDenseElementsAttrUInt8SplatGet),
@@ -115,6 +120,7 @@ end
 @noinline function fill(
     element::T, shape::Vector{Int}; location=mlir_stacktrace("fill", @__FILE__, @__LINE__)
 ) where {T}
+    Core.println("fill: element type: $T, shape: $shape")
     tt = MLIR.IR.TensorType(shape, MLIR.IR.Type(T))
     splatattr = MLIR.API.mlirDenseElementsAttrSplatGet(tt, MLIR.IR.Attribute(element))
     cst_op = stablehlo.constant(; output=tt, value=splatattr, location=location)

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -373,9 +373,8 @@ Base.collect(x::TracedRArray) = copy(x) # XXX: Is this correct?
 
 Base.copy(A::TracedRArray{T,N}) where {T,N} = TracedRArray{T,N}((), A.mlir_data, size(A))
 
-# TODO is there a way to create an unitialized `tensor`? does it show an advantage? maybe `fill`?
 function Base.similar(::TracedRArray, ::Type{T}, dims::Dims{N}) where {T,N}
-    return Ops.constant(zeros(unwrapped_eltype(T), dims))
+    return Ops.fill(zero(unwrapped_eltype(T)), dims)
 end
 
 function Base.show(io::IOty, X::TracedRArray{T,N}) where {T,N,IOty<:Union{IO,IOContext}}

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -997,12 +997,12 @@ function Base.findmin(f, x::AnyTracedRArray; dims::Union{Integer,Nothing}=nothin
     # Compute linear indices
     strds = strides(x)
     iotas = [Ops.iota(Int64, [size(indices)...]; iota_dimension=i) for i in 1:ndims(x)]
-    iotas[dims] = Ops.subtract(indices, Ops.constant(fill(Int64(1), size(indices))))
-    linear_indices = Ops.constant(fill(Int64(1), size(indices)))
+    iotas[dims] = Ops.subtract(indices, Ops.fill(Int64(1), size(indices)))
+    linear_indices = Ops.fill(Int64(1), size(indices))
     for d in eachindex(iotas)
         linear_indices = Ops.add(
             linear_indices,
-            Ops.multiply(iotas[d], Ops.constant(fill(Int64(strds[d]), size(iotas[d])))),
+            Ops.multiply(iotas[d], Ops.fill(Int64(strds[d]), size(iotas[d]))),
         )
     end
 
@@ -1026,12 +1026,12 @@ function Base.findmax(f, x::AnyTracedRArray; dims::Union{Integer,Nothing}=nothin
     # Compute linear indices
     strds = strides(x)
     iotas = [Ops.iota(Int64, [size(indices)...]; iota_dimension=i) for i in 1:ndims(x)]
-    iotas[dims] = Ops.subtract(indices, Ops.constant(fill(Int64(1), size(indices))))
-    linear_indices = Ops.constant(fill(Int64(1), size(indices)))
+    iotas[dims] = Ops.subtract(indices, Ops.fill(Int64(1), size(indices)))
+    linear_indices = Ops.fill(Int64(1), size(indices))
     for d in eachindex(iotas)
         linear_indices = Ops.add(
             linear_indices,
-            Ops.multiply(iotas[d], Ops.constant(fill(Int64(strds[d]), size(iotas[d])))),
+            Ops.multiply(iotas[d], Ops.fill(Int64(strds[d]), size(iotas[d]))),
         )
     end
 

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -79,7 +79,7 @@ function TracedUtils.promote_to(::Type{TracedRNumber{T}}, rhs) where {T}
         )
     end
     rhs isa Number &&
-        return TracedUtils.promote_to(TracedRNumber{T}, Ops.constant(fill(T(rhs))))
+        return TracedUtils.promote_to(TracedRNumber{T}, Ops.fill(T(rhs)))
     return TracedUtils.promote_to(TracedRNumber{T}, Ops.constant(collect(rhs)))
 end
 

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -78,8 +78,7 @@ function TracedUtils.promote_to(::Type{TracedRNumber{T}}, rhs) where {T}
             TracedRNumber{Reactant.unwrapped_eltype(rhs)}((), rhs.mlir_data),
         )
     end
-    rhs isa Number &&
-        return TracedUtils.promote_to(TracedRNumber{T}, Ops.fill(T(rhs)))
+    rhs isa Number && return TracedUtils.promote_to(TracedRNumber{T}, Ops.fill(T(rhs)))
     return TracedUtils.promote_to(TracedRNumber{T}, Ops.constant(collect(rhs)))
 end
 

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -303,7 +303,7 @@ function LinearAlgebra._diagm(
         (size(scatter_indices, 1),),
     )
     return Ops.scatter_setindex(
-        Ops.constant(fill(zero(T), (m, n))), scatter_indices, values
+        Ops.fill(zero(T), (m, n)), scatter_indices, values
     )
 end
 

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -302,9 +302,7 @@ function LinearAlgebra._diagm(
         MLIR.IR.result(MLIR.Dialects.stablehlo.concatenate(concat_inputs; dimension=0), 1),
         (size(scatter_indices, 1),),
     )
-    return Ops.scatter_setindex(
-        Ops.fill(zero(T), (m, n)), scatter_indices, values
-    )
+    return Ops.scatter_setindex(Ops.fill(zero(T), (m, n)), scatter_indices, values)
 end
 
 # Common Utilities


### PR DESCRIPTION
(Instead of creating a dummy traced array containing no mlir_data)
https://github.com/EnzymeAD/Reactant.jl/pull/523#issuecomment-2606965530