### PR TITLE
[ReactantExtra] Bump XLA version

### DIFF
--- a/deps/ReactantExtra/.bazelrc
+++ b/deps/ReactantExtra/.bazelrc
@@ -25,7 +25,6 @@ build:cuda --repo_env=HERMETIC_CUDNN_VERSION="9.4.0"
 build:cuda --repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,compute_90"
 build:cuda --crosstool_top="@local_config_cuda//crosstool:toolchain"
 build:cuda --@local_config_cuda//:enable_cuda
-build:cuda --@xla//xla/python:jax_cuda_pip_rpaths=true
 # Default hermetic CUDA and CUDNN versions.
 build:cuda --@local_config_cuda//cuda:include_cuda_libs=true
 build:cuda --@local_config_cuda//:cuda_compiler=nvcc

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -697,7 +697,7 @@ extern "C" void InitializeRegistryAndPasses(MlirDialectRegistry creg) {
   prepareRegistry(registry);
 
   mlir::registerenzymePasses();
-  registerenzymexlaPasses();
+  enzyme::registerenzymexlaPasses();
 
   // Register the standard passes we want.
   mlir::registerCSEPass();

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-ENZYMEXLA_COMMIT = "6103feeaabf401ae6cb06d66b9ebc12b67b45fe5"
+ENZYMEXLA_COMMIT = "3b33e3373d20ca2e1005a30d2aced83024230977"
 ENZYMEXLA_SHA256 = ""
 
 http_archive(

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -136,7 +136,7 @@ http_archive(
 )
 
 # load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
-XLA_COMMIT = "4b9f0e2130d665ef9731154832af9a91155686d2"
+XLA_COMMIT = "5928fd05598201a844aaccfd3d12767f190b1ccf"
 XLA_SHA256 = ""
 
 http_archive(

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-ENZYMEXLA_COMMIT = "fd5517f2223adcf579c165a0387231ef4931f55b"
+ENZYMEXLA_COMMIT = "6103feeaabf401ae6cb06d66b9ebc12b67b45fe5"
 ENZYMEXLA_SHA256 = ""
 
 http_archive(

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -136,7 +136,7 @@ http_archive(
 )
 
 # load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
-XLA_COMMIT = "5928fd05598201a844aaccfd3d12767f190b1ccf"
+XLA_COMMIT = "7ad64b5df46daf1f84d8a80ec87ae5ddbb3f82b7"
 XLA_SHA256 = ""
 
 http_archive(


### PR DESCRIPTION
With previous commit I was running into [fun compilation errors on macOS](https://github.com/JuliaPackaging/Yggdrasil/pull/10313#issuecomment-2616420694).