### PR TITLE
Feature: allow colon indexing of traced **vectors**

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -43,7 +43,7 @@ end
     @test y ≈ x
 
     x = Reactant.to_rarray(ones(3))
-    y = Reactant.to_rarray(2*ones(3))
+    y = Reactant.to_rarray(2 * ones(3))
     @jit(maskset!(y, x))
     @test y ≈ x
 end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -31,6 +31,23 @@ end
     # get_view_compiled = @compile get_view(x_concrete)
 end
 
+function maskset!(y, x)
+    y[:] = x
+    return nothing
+end
+
+@testset "setindex! with vectors & colon indexing" begin
+    x = Reactant.to_rarray([4.0])
+    y = Reactant.to_rarray([2.0])
+    @jit(maskset!(y, x))
+    @test y ≈ x
+
+    x = Reactant.to_rarray(ones(3))
+    y = Reactant.to_rarray(2*ones(3))
+    @jit(maskset!(y, x))
+    @test y ≈ x
+end
+
 function masking(x)
     y = similar(x)
     y[1:2, :] .= 0


### PR DESCRIPTION
## Description of the problem

In the case in which one wants to set inplace a vector (so its dimension is `(N,)`) into some target traced vector with the colon-index operator, there is an ambigüity between two function signatures:
```julia
Base.setindex!(a::TracedRArray{T,N}, v, ::Colon) where {T,N}
```
and
```julia
const N = 1
Base.setindex!(a::TracedRArray{T,N}, v, indices::Vararg{Any,N}) where {T,N}
```

## MWE
```julia
using Reactant

function ipop!(y, x)
    y[:] = x
end
x = Reactant.to_array([1.0, 2.0])
y = similar(x)
@jit ipop!(y, x)
```
> `ERROR: MethodError: setindex!(::Reactant.TracedRArray{Float64, 1}, ::Reactant.TracedRArray{Float64, 1}, ::Colon) is ambiguous.`
> 
> `Candidates:`
> `  setindex!(a::Reactant.TracedRArray{T, N}, v, ::Colon) where {T, N}`
> `    @ Reactant.TracedRArrayOverrides ~/.julia/packages/Reactant/B09Ss/src/TracedRArray.jl:271`
> `  setindex!(a::Reactant.TracedRArray{T, N}, v, indices::Vararg{Any, N}) where {T, N}`
> `    @ Reactant.TracedRArrayOverrides ~/.julia/packages/Reactant/B09Ss/src/TracedRArray.jl:295`

## Solution
I tested the solution in `test/indexing.jl`.
The function from the first signature is removed, and a check is added at the beginning of the second one to execute the same code as the deleted function.