### PR TITLE
[ReactantCUDAExt] Skip precompile load on Julia v1.11.3

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -952,12 +952,14 @@ function __init__()
     return nothing
 end
 
-@static if !Sys.isapple() && Sys.ARCH != :aarch64
+# In Julia v1.11.3 precompiling this module caches bad code:
+# <https://github.com/EnzymeAD/Reactant.jl/issues/614>.
+@static if !Sys.isapple()
     Reactant.PrecompileTools.@setup_workload begin
         Reactant.initialize_dialect()
         client = Reactant.XLA.CPUClient(; checkcount=false)
         Reactant.PrecompileTools.@compile_workload begin
-            @static if Reactant.precompilation_supported()
+            @static if Reactant.precompilation_supported() && VERSION != v"1.11.3"
                 function square_kernel!(x)
                     i = CUDA.threadIdx().x
                     x[i] *= x[i]

--- a/test/integration/cuda.jl
+++ b/test/integration/cuda.jl
@@ -17,9 +17,6 @@ function square!(x, y)
     return nothing
 end
 
-# https://github.com/EnzymeAD/Reactant.jl/issues/614
-const skip_non_cuda_tests = true
-
 @static if !Sys.isapple()
     @testset "Square Kernel" begin
         oA = collect(1:1:64)


### PR DESCRIPTION
Implementing suggestion at https://github.com/EnzymeAD/Reactant.jl/pull/674#issuecomment-2629092644

Close #674.