### PR TITLE
[ReactantExtra] Stop removing references to `hardware_interference_size`

### DIFF
--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -51,15 +51,6 @@ load("@enzyme_ad//:workspace.bzl", "JAX_COMMIT", "JAX_SHA256", "ENZYME_COMMIT", 
 
 XLA_PATCHES = XLA_PATCHES + [
 """
-sed -i.bak0 "s/__cpp_lib_hardware_interference_size/HW_INTERFERENCE_SIZE/g" xla/backends/cpu/runtime/thunk_executor.h
-""",
-"""
-sed -i.bak0 "s/__cpp_lib_hardware_interference_size/HW_INTERFERENCE_SIZE/g" xla/backends/cpu/runtime/work_queue.h
-""",
-"""
-sed -i.bak0 "s/__cpp_lib_hardware_interference_size/HW_INTERFERENCE_SIZE/g" xla/tsl/concurrency/async_value_ref.h
-""",
-"""
 sed -i.bak0 "s/patch_cmds = \\[/patch_cmds = \\[\\\"find . -type f -name config.bzl -exec sed -i.bak0 's\\/HAVE_LINK_H=1\\/HAVE_LINK_H=0\\/g' {} +\\\",/g" third_party/llvm/workspace.bzl
 """,
 """


### PR DESCRIPTION
We used to do that because in older macOS SDKs this variable was not available, but with https://github.com/JuliaPackaging/Yggdrasil/pull/10473 we switched to a newer SDK (11.3) and this hack isn't necessary anymore.

I verified locally that I could build successfully for both x86_64-darwin and aarch64-darwin in BinaryBuilder.  Opening as draft waiting for https://github.com/JuliaPackaging/Yggdrasil/pull/10473 to be merged.