### PR TITLE
[GHA] Some improvement to CI setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
           - '1.11'
           # - 'nightly'
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           # `ubuntu-22.04-arm` is considered more stable than `ubuntu-24.04-arm`:
           # <https://github.com/orgs/community/discussions/148648#discussioncomment-12099554>.
           - ubuntu-22.04-arm
@@ -58,41 +58,41 @@ jobs:
           - false
         libReactant: [packaged]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: x64
             libReactant: packaged
             version: '1.10'
             assertions: true
             test_group: core
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: x64
             libReactant: packaged
             version: '1.10'
             assertions: true
             test_group: neural_networks
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: x64
             libReactant: packaged
             version: '1.10'
             assertions: true
             test_group: integration
-          # - os: ubuntu-20.04
+          # - os: ubuntu-24.04
           #   arch: x86
           #   libReactant: packaged
           #   version: '1.10'
           #   test_group: core
-          # - os: ubuntu-20.04
+          # - os: ubuntu-24.04
           #   arch: x86
           #   libReactant: packaged
           #   version: '1.10'
           #   test_group: neural_networks
-          # - os: ubuntu-20.04
+          # - os: ubuntu-24.04
           #   arch: x86
           #   libReactant: packaged
           #   version: '1.10'
           #   test_group: integration
         exclude:
-          - os: ubuntu-20.04 # this is x86_64, exclude foreign architecture
+          - os: ubuntu-24.04 # this is x86_64, exclude foreign architecture
             arch: aarch64
           - os: ubuntu-22.04-arm # this is aarch64, exclude foreign architecture
             arch: x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,9 @@ jobs:
           # - 'nightly'
         os:
           - ubuntu-20.04
-          - ubuntu-24.04-arm
+          # `ubuntu-22.04-arm` is considered more stable than `ubuntu-24.04-arm`:
+          # <https://github.com/orgs/community/discussions/148648#discussioncomment-12099554>.
+          - ubuntu-22.04-arm
           - macOS-latest
         test_group:
           - core
@@ -92,7 +94,7 @@ jobs:
         exclude:
           - os: ubuntu-20.04 # this is x86_64, exclude foreign architecture
             arch: aarch64
-          - os: ubuntu-24.04-arm # this is aarch64, exclude foreign architecture
+          - os: ubuntu-22.04-arm # this is aarch64, exclude foreign architecture
             arch: x64
     steps:
       - uses: actions/checkout@v4
@@ -130,7 +132,7 @@ jobs:
           julia --color=yes --project=deps -e 'using Pkg; Pkg.instantiate()'
           SDKROOT=`xcrun --show-sdk-path` julia --color=yes --project=deps deps/build_local.jl
           cp LocalPreferences.toml test/
-      - name: "Install Dependencies and Run Tests"
+      - name: "Install Dependencies"
         run: |
           import Pkg
           Pkg.Registry.update()
@@ -140,6 +142,15 @@ jobs:
               push!(dev_pks, Pkg.PackageSpec(; path))
           end
           Pkg.develop(dev_pks)
+        shell: julia --color=yes --code-coverage=user --depwarn=yes --project=. {0}
+        # Only in Julia v1.10 we need to install `ReactantCore` manually.
+        if: ${{ matrix.version == '1.10' }}
+        env:
+          JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
+      - name: "Run Tests"
+        run: |
+          import Pkg
+          Pkg.Registry.update()
           Pkg.test(; coverage="user")
         shell: julia --color=yes --code-coverage=user --depwarn=yes --project=. {0}
         id: run_tests


### PR DESCRIPTION
* Run tests on ubuntu-22.04-arm instead of ubuntu-24.04-arm: the former is considered more stable than the latter and doesn't randomly fail on the `actions/checkout` workflow.
* Manually install packages only in Julia v1.10, to avoid unnecessary double steps.