### PR TITLE
Support tracing of `rem` with only one operand being a `ConcreteRNumber`

### DIFF
--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -97,10 +97,20 @@ for (jlop, hloop) in (
     (:(Base.mod), :remainder),
     (:(Base.rem), :remainder),
 )
-    @eval function $(jlop)(
-        @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::TracedRNumber{T})
-    ) where {T}
-        return Ops.$(hloop)(lhs, rhs)
+    @eval begin
+        function $(jlop)(
+            @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::TracedRNumber{T})
+        ) where {T}
+            return Ops.$(hloop)(lhs, rhs)
+        end
+
+        function $(jlop)(@nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs)) where {T}
+            return Ops.$(hloop)(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
+        end
+
+        function $(jlop)(@nospecialize(lhs), @nospecialize(rhs::TracedRNumber{T})) where {T}
+            return Ops.$(hloop)(TracedUtils.promote_to(TracedRNumber{T}, lhs), rhs)
+        end
     end
 end
 

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -97,25 +97,23 @@ for (jlop, hloop) in (
     (:(Base.mod), :remainder),
     (:(Base.rem), :remainder),
 )
-    @eval begin
-        function $(jlop)(
-            @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::TracedRNumber{T})
-        ) where {T}
-            return Ops.$(hloop)(lhs, rhs)
-        end
-
-        function $(jlop)(
-            @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::Number)
-        ) where {T}
-            return Ops.$(hloop)(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
-        end
-
-        function $(jlop)(
-            @nospecialize(lhs::Number), @nospecialize(rhs::TracedRNumber{T})
-        ) where {T}
-            return Ops.$(hloop)(TracedUtils.promote_to(TracedRNumber{T}, lhs), rhs)
-        end
+    @eval function $(jlop)(
+        @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::TracedRNumber{T})
+    ) where {T}
+        return Ops.$(hloop)(lhs, rhs)
     end
+end
+
+function Base.rem(
+    @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::Number)
+) where {T}
+    return Ops.remainder(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
+end
+
+function Base.rem(
+    @nospecialize(lhs::Number), @nospecialize(rhs::TracedRNumber{T})
+) where {T}
+    return Ops.remainder(TracedUtils.promote_to(TracedRNumber{T}, lhs), rhs)
 end
 
 function Base.div(@nospecialize(lhs::TracedRNumber{T}), rhs) where {T<:Integer}

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -104,11 +104,15 @@ for (jlop, hloop) in (
             return Ops.$(hloop)(lhs, rhs)
         end
 
-        function $(jlop)(@nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs)) where {T}
+        function $(jlop)(
+            @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::Number)
+        ) where {T}
             return Ops.$(hloop)(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
         end
 
-        function $(jlop)(@nospecialize(lhs), @nospecialize(rhs::TracedRNumber{T})) where {T}
+        function $(jlop)(
+            @nospecialize(lhs::Number), @nospecialize(rhs::TracedRNumber{T})
+        ) where {T}
             return Ops.$(hloop)(TracedUtils.promote_to(TracedRNumber{T}, lhs), rhs)
         end
     end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -825,13 +825,22 @@ end
     @test !isfinite(Reactant.to_rarray(Inf; track_numbers=Number))
 end
 
-@testset "rem" begin
+@testset "mod and rem" begin
     a = [-1.1, 7.7, -3.3, 9.9, -5.5]
     b = [6.6, -2.2, -8.8, 4.4, -10.1]
-    expected = rem.(a, b)
-    @test Reactant.@jit(rem.(Reactant.to_rarray(a), Reactant.to_rarray(b))) ≈ expected
-    @test Reactant.@jit(rem.(a, Reactant.to_rarray(b))) ≈ expected
-    @test Reactant.@jit(rem.(Reactant.to_rarray(a), b)) ≈ expected
+
+    # Currently broken because `mod` is JIT-ed to an HLO operator with same semantic as
+    # Julia's `rem`, rather than `mod`.
+    expected_mod = mod.(a, b)
+    @test_broken Reactant.@jit(mod.(Reactant.to_rarray(a), Reactant.to_rarray(b))) ≈
+        expected_mod
+    @test_broken Reactant.@jit(mod.(a, Reactant.to_rarray(b))) ≈ expected_mod
+    @test_broken Reactant.@jit(mod.(Reactant.to_rarray(a), b)) ≈ expected_mod
+
+    expected_rem = rem.(a, b)
+    @test Reactant.@jit(rem.(Reactant.to_rarray(a), Reactant.to_rarray(b))) ≈ expected_rem
+    @test Reactant.@jit(rem.(a, Reactant.to_rarray(b))) ≈ expected_rem
+    @test Reactant.@jit(rem.(Reactant.to_rarray(a), b)) ≈ expected_rem
 end
 
 @testset "reduce integers" begin

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -825,6 +825,15 @@ end
     @test !isfinite(Reactant.to_rarray(Inf; track_numbers=Number))
 end
 
+@testset "rem" begin
+    a = [-1.1, 7.7, -3.3, 9.9, -5.5]
+    b = [6.6, -2.2, -8.8, 4.4, -10.1]
+    expected = rem.(a, b)
+    @test Reactant.@jit(rem.(Reactant.to_rarray(a), Reactant.to_rarray(b))) ≈ expected
+    @test Reactant.@jit(rem.(a, Reactant.to_rarray(b))) ≈ expected
+    @test Reactant.@jit(rem.(Reactant.to_rarray(a), b)) ≈ expected
+end
+
 @testset "reduce integers" begin
     x = rand(Bool, 100)
     x_ra = Reactant.to_rarray(x)


### PR DESCRIPTION
This should help with https://github.com/CliMA/Oceananigans.jl/pull/4096#issuecomment-2661293409.  ~Opening as a draft until I figure out where to test these new methods.~ ***Edit***: tests added.