### PR TITLE
fix: simplify Mesh implementation

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -585,7 +585,9 @@ function vendored_buildIntrinsicLoweringPipeline(
     return LLVM.add!(mpm, LLVM.AlwaysInlinerPass())
 end
 
-function vendored_buildScalarOptimizerPipeline(fpm, @nospecialize(job), opt_level; instcombine::Bool=false)
+function vendored_buildScalarOptimizerPipeline(
+    fpm, @nospecialize(job), opt_level; instcombine::Bool=false
+)
     if opt_level >= 2
         LLVM.add!(fpm, LLVM.Interop.AllocOptPass())
         LLVM.add!(fpm, LLVM.SROAPass())
@@ -597,9 +599,9 @@ function vendored_buildScalarOptimizerPipeline(fpm, @nospecialize(job), opt_leve
         LLVM.add!(fpm, LLVM.DCEPass())
         LLVM.add!(fpm, LLVM.IRCEPass())
         if instcombine
-        	LLVM.add!(fpm, LLVM.InstCombinePass())
+            LLVM.add!(fpm, LLVM.InstCombinePass())
         else
-	   LLVM.add!(fpm, LLVM.InstSimplifyPass())
+            LLVM.add!(fpm, LLVM.InstSimplifyPass())
         end
         LLVM.add!(fpm, LLVM.JumpThreadingPass())
     end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1178,7 +1178,7 @@ function codegen_flatten!(
 
                 push!(flatten_code, :($usbuf = $flatcode.data))
                 for j in 1:length(mesh)
-                    sbuf = Symbol(:sbuf_, i, "_", mesh.device_ids[j])
+                    sbuf = Symbol(:sbuf_, i, "_", mesh.logical_device_ids[j])
                     push!(flatten_names, sbuf)
                     push!(flatten_code, :($sbuf = XLA.synced_buffer(getindex($usbuf, $j))))
                 end
@@ -1188,10 +1188,10 @@ function codegen_flatten!(
                 )
                 push!(flatten_code, :($usbuf = $flatcode))
                 device_to_array_slices = XLA.sharding_to_concrete_array_indices(
-                    condensed_op_sharding, size(carg), mesh.device_ids
+                    condensed_op_sharding, size(carg), mesh.logical_device_ids
                 )
                 for j in 1:length(mesh)
-                    device_id = mesh.device_ids[j]
+                    device_id = mesh.logical_device_ids[j]
                     buf = Symbol(:buf_, i, :_, device_id)
                     slice = device_to_array_slices[j]
                     push!(
@@ -1548,7 +1548,7 @@ function compile_xla(f, args; client=nothing, kwargs...)
 
         # compile MLIR module to XLA executable
         global_device_ids = if mlir_fn_res.is_sharded
-            collect(Int64, mlir_fn_res.sharding_mesh.device_ids)
+            vec(mlir_fn_res.sharding_mesh.device_ids)
         else
             Int64[]
         end

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -350,7 +350,7 @@ function make_mlir_fn(
         # TODO: support multiple meshes
         if length(unique_meshes) > 1
             error("Currently we support using a single mesh")
-            sorted_devices = [m.sorted_device_ids for m in unique_meshes]
+            sorted_devices = [sort(vec(m.device_ids)) for m in unique_meshes]
             @assert allequal(sorted_devices) "All meshes must have the same device ids"
         end
         sharding_mesh = first(unique_meshes)


### PR DESCRIPTION
- `Mesh` no longer stores ntuples. It would be extremely suboptimal when scaling across 100s of nodes.
- Logical Device IDs are always ordered hence we store it as a `Base.OneTo(N)`