### PR TITLE
adding dot, cross, adjoint! to linear algebra

### DIFF
--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -397,4 +397,35 @@ function LinearAlgebra._kron!(C::AnyTracedRMatrix, A::AnyTracedRMatrix, B::AnyTr
     return C
 end
 
+function LinearAlgebra.dot(x::TracedRArray{T}, y::TracedRArray{T}) where {T}
+    lx = length(x)
+    if lx != length(y)
+         throw(DimensionMismatch(lazy"first array has length $(lx) which does not match the length of the second, $(length(y))."))
+    end
+    
+    if T <: Complex
+        return Ops.dot_general(Ops.conj(x), y; contracting_dimensions = [[1], [1]]) 
+    else
+        return Ops.dot_general(x, y; contracting_dimensions = [[1], [1]]) 
+    end
+end
+
+function LinearAlgebra.cross(a::AnyTracedRVector{T}, b::AnyTracedRVector{T}) where{T}
+    if !(length(a) == length(b) == 3)
+         throw(DimensionMismatch("cross product is only defined for vectors of length 3"))
+    end
+    a = materialize_traced_array(a)
+    b = materialize_traced_array(b)
+
+    a1, a2, a3 = a
+    b1, b2, b3 = b
+   
+    c = [a2*b3-a3*b2, a3*b1-a1*b3, a1*b2-a2*b1]
+    c = TracedUtils.promote_to(TracedRArray{T, 1}, c)
+
+    return TracedRNumber{T}((), c.mlir_data) 
+end
+
+
+
 end

--- a/test/integration/linear_algebra.jl
+++ b/test/integration/linear_algebra.jl
@@ -183,3 +183,57 @@ end
         end
     end
 end
+
+@testset "dot" begin
+    a = [1, 2, 3, 4]
+    b = [-2, 5, 6, 7]
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+
+    @test @jit dot(a_ra, b_ra) ≈ dot(a, b)
+
+    a = rand(4)
+    b = rand(4)
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+    
+    @test @jit dot(a_ra, b_ra) ≈ dot(a, b)
+
+    a = rand(Complex{Float64}, 4)
+    b = rand(Complex{Float64}, 4)
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+    ab_ra = @jit dot(a_ra, b_ra)
+    ab = dot(a,b)
+    
+    @test ab_ra ≈ ab 
+    
+    # I found this strange. If in dot_generat I did not apply Ops.conj,
+    # calling the line below still gives test passed while the one above does not
+    # @test @jit dot(a_ra, b_ra) ≈ dot(a, b)
+end
+
+
+@testset "cross" begin
+    a = [1, 2, 3]
+    b = [-2, 5, 7]
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+
+    @test @jit cross(a_ra, b_ra) ≈ cross(a, b)
+
+    a = rand(3)
+    b = rand(3)
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+    
+    @test @jit dot(a_ra, b_ra) ≈ dot(a, b)
+
+    a = rand(Complex{Float64}, 3)
+    b = rand(Complex{Float64}, 3)
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+
+    @test @jit cross(a_ra, b_ra) ≈ cross(a,b)
+end    
+

--- a/test/integration/linear_algebra.jl
+++ b/test/integration/linear_algebra.jl
@@ -192,7 +192,7 @@ end
 
     @test @jit dot(a_ra, b_ra) ≈ dot(a, b)
 
-    a = rand(4)
+    a = rand(Int64, 4)
     b = rand(4)
     a_ra = Reactant.to_rarray(a)
     b_ra = Reactant.to_rarray(b)
@@ -207,12 +207,7 @@ end
     ab = dot(a,b)
     
     @test ab_ra ≈ ab 
-    
-    # I found this strange. If in dot_generat I did not apply Ops.conj,
-    # calling the line below still gives test passed while the one above does not
-    # @test @jit dot(a_ra, b_ra) ≈ dot(a, b)
 end
-
 
 @testset "cross" begin
     a = [1, 2, 3]
@@ -222,7 +217,7 @@ end
 
     @test @jit cross(a_ra, b_ra) ≈ cross(a, b)
 
-    a = rand(3)
+    a = rand(Int64, 3)
     b = rand(3)
     a_ra = Reactant.to_rarray(a)
     b_ra = Reactant.to_rarray(b)
@@ -235,5 +230,39 @@ end
     b_ra = Reactant.to_rarray(b)
 
     @test @jit cross(a_ra, b_ra) ≈ cross(a,b)
-end    
+end  
 
+@testset "adjoint!" begin
+    v = zeros(5)
+    M = rand(1, 5)
+    v_ra = Reactant.to_rarray(v)
+    M_ra = Reactant.to_rarray(M)
+
+    @jit adjoint!(v_ra, M_ra)
+    @test v_ra ≈ adjoint!(v, M)
+
+    v = rand(7)
+    M = zeros(1, 7)
+    v_ra = Reactant.to_rarray(v)
+    M_ra = Reactant.to_rarray(M)
+
+    @jit adjoint!(M_ra, v_ra)
+    @test M_ra ≈ adjoint!(M, v)
+
+    A = [1 2; 3 4; 5 6]
+    B = fill(Float64(0), (2,3))
+    A_ra = Reactant.to_rarray(A)
+    B_ra = Reactant.to_rarray(B)
+    
+    @jit adjoint!(B_ra, A_ra)
+    @test B_ra ≈ adjoint!(B, A)
+
+    A = rand(Complex{Float64}, (2, 3))
+    B = rand(Complex{Float64}, (3, 2))
+    A_ra = Reactant.to_rarray(A)
+    B_ra = Reactant.to_rarray(B)
+    
+    @jit adjoint!(B_ra, A_ra)
+    @test B_ra ≈ adjoint!(B, A)
+
+end


### PR DESCRIPTION
I did the type promotion this time. The stdlibs do this as @avik-pal  mentioned in #808. But there is a discussion that has not yet been resolved, so I haven't fixed it.