### PR TITLE
[CI] Set timeout of run-tests job to 60 minutes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,6 +113,7 @@ jobs:
         env:
           JULIA_PKG_SERVER_REGISTRY_PREFERENCE: eager
       - name: "Run Tests"
+        timeout-minutes: 60
         run: |
           import Pkg
           Pkg.Registry.update()


### PR DESCRIPTION
macOS runners are occasionally hanging, having a shorter timeout helps by making the job fail earlier than waiting uselessly for 90 minutes, saving some time, especially important since there are only 5 concurrent macOS runners across the entire organisation.