### PR TITLE
ReactantExtra changes to fix MPI PR

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -33,6 +33,7 @@
 #include "mlir/InitAllPasses.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
+#include "mlir/Parser/Parser.h"
 #include "src/enzyme_ad/jax/Dialect/Dialect.h"
 #include "src/enzyme_ad/jax/Implementations/XLADerivatives.h"
 #include "src/enzyme_ad/jax/Passes/Passes.h"
@@ -224,6 +225,15 @@ extern "C" MlirAttribute mlirComplexAttrDoubleGetChecked(MlirLocation loc,
                                                          double imag) {
   return wrap(complex::NumberAttr::getChecked(
       unwrap(loc), cast<ComplexType>(unwrap(type)), real, imag));
+}
+
+extern "C" MlirOperation mlirOperationParse(MlirContext ctx,
+                                            MlirStringRef code) {
+  ParserConfig config(unwrap(ctx));
+  OwningOpRef<Operation*> owning_op = parseSourceString(unwrap(code), config);
+  if (!owning_op)
+    return MlirOperation{nullptr};
+  return MlirOperation{owning_op.release()};
 }
 
 // TODO mlirComplexAttrGetnValue

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -1040,6 +1040,7 @@ extern "C" void RegisterDialects(MlirContext cctx) {
   context.loadDialect<mlir::stablehlo::StablehloDialect>();
   context.loadDialect<mlir::chlo::ChloDialect>();
   context.loadDialect<mlir::sdy::SdyDialect>();
+  context.loadDialect<mlir::LLVM::LLVMDialect>();
 }
 
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-ENZYMEXLA_COMMIT = "434f13a212fdc1967169b81d77d78705843377bd"
+ENZYMEXLA_COMMIT = "b8a889d86bb55b93ce4f989c9d7bb5417f52da4d"
 ENZYMEXLA_SHA256 = ""
 
 http_archive(


### PR DESCRIPTION
This PR fixes the registration of the LLVM dialect, and adds a lil extra utility for parsing single MLIR ops. The only limitation is that since we don't know the SSA names in advance, it fails when we need pass a argument, but it's still useful for writing some simple `func.func`s that need to be injected in the module.