### PR TITLE
Shorten mapreduce by using Ops.reduce

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1483,7 +1483,7 @@ julia> Reactant.@jit(
                     MLIR.IR.Attribute("private"),
                 )
 
-                # Change function nane
+                # Change function name
                 MLIR.IR.attr!(op, symbol_attr_name, MLIR.IR.Attribute(new_name))
             end
         end

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2368,7 +2368,7 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
 
     sample_inputs = [
         Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0),
-        Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0)
+        Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0),
     ]
 
     func =

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2366,14 +2366,18 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
 
     result_type = mlir_type(TracedRArray{T,length(reduced_shape)}, reduced_shape)
 
-    sample_inputs = [Reactant.ConcretePJRTNumber(T(0)), Reactant.ConcretePJRTNumber(T(0))]
+    sample_inputs = [
+        Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0),
+        Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0)
+    ]
 
     func =
         Reactant.TracedUtils.make_mlir_fn(
             fn,
             (sample_inputs),
             (),
-            "reduce_fn";
+            "reduce_fn",
+            false;
             args_in_result=:none,
             return_dialect=:stablehlo,
         ).f

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2318,12 +2318,12 @@ end
     init_values::TracedRNumber{T},
     dimensions::Vector{Int},
     fn::Function,
-    location=mlir_stacktrace("reduce", @__FILE__, @__LINE__)
+    location=mlir_stacktrace("reduce", @__FILE__, @__LINE__),
 ) where {T}
     reduced_shape = Tuple(deleteat!(collect(size(x)), dimensions))
 
-    result_type = mlir_type(TracedRArray{T, length(reduced_shape)}, reduced_shape)
-    
+    result_type = mlir_type(TracedRArray{T,length(reduced_shape)}, reduced_shape)
+
     sample_inputs = [Reactant.ConcretePJRTNumber(T(0)), Reactant.ConcretePJRTNumber(T(0))]
 
     func =
@@ -2348,15 +2348,21 @@ end
     fn = MLIR.IR.Region()
     MLIR.API.mlirRegionTakeBody(fn, MLIR.IR.region(func, 1))
     MLIR.IR.rmfromparent!(func)
-    
-    dimensions = MLIR.IR.Attribute(dimensions .- 1) 
 
-    res = MLIR.IR.result(stablehlo.reduce(
-        [x.mlir_data], [init_values.mlir_data];
-        result_0=[result_type], dimensions=dimensions, body=fn, location=location
-    ))
+    dimensions = MLIR.IR.Attribute(dimensions .- 1)
 
-    return TracedRArray{T, length(reduced_shape)}((), res, reduced_shape)
+    res = MLIR.IR.result(
+        stablehlo.reduce(
+            [x.mlir_data],
+            [init_values.mlir_data];
+            result_0=[result_type],
+            dimensions=dimensions,
+            body=fn,
+            location=location,
+        ),
+    )
+
+    return TracedRArray{T,length(reduced_shape)}((), res, reduced_shape)
 end
 
 end # module Ops

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -1079,17 +1079,19 @@ end
         return dropdims(r,dims=tuple(findall(size(r).==1)...))
     end
 
-    A = rand(3, 4, 5)
+    # Floating point operation is not associative
+    A = rand(Int64, 3, 4, 5)
     A_ra = Reactant.to_rarray(A)
-    init = 2.1 
+    init = 1 
     init_ra = @jit Reactant.Ops.constant(init)
-    
     dims = [2]    
     r_hlo = @jit Reactant.Ops.reduce(A_ra, init_ra, dims, *)
     r = reduce(*, A; dims=dims, init=init)
     @test r_hlo ≈ squeeze_dims(r)
 
     dims = [1,3]
+    init = 0 
+    init_ra = @jit Reactant.Ops.constant(init)
     r_hlo = @jit Reactant.Ops.reduce(A_ra, init_ra, dims, +)
     r = reduce(+, A; dims=dims, init=init)
     @test r_hlo ≈ squeeze_dims(r)
@@ -1100,6 +1102,4 @@ end
     @test r_hlo ≈ squeeze_dims(r)
 
 end
-
-
 

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -1076,30 +1076,28 @@ end
     # stablehlo reduce collapse the dimension so that (1,3) beomces (3, )
     # while Julia reduce retains (1, 3). The test will fail despite elements being equal
     function squeeze_dims(r)
-        return dropdims(r,dims=tuple(findall(size(r).==1)...))
+        return dropdims(r; dims=tuple(findall(size(r) .== 1)...))
     end
 
     # Floating point operation is not associative
     A = rand(Int64, 3, 4, 5)
     A_ra = Reactant.to_rarray(A)
-    init = 1 
+    init = 1
     init_ra = @jit Reactant.Ops.constant(init)
-    dims = [2]    
+    dims = [2]
     r_hlo = @jit Reactant.Ops.reduce(A_ra, init_ra, dims, *)
     r = reduce(*, A; dims=dims, init=init)
     @test r_hlo ≈ squeeze_dims(r)
 
-    dims = [1,3]
-    init = 0 
+    dims = [1, 3]
+    init = 0
     init_ra = @jit Reactant.Ops.constant(init)
     r_hlo = @jit Reactant.Ops.reduce(A_ra, init_ra, dims, +)
     r = reduce(+, A; dims=dims, init=init)
     @test r_hlo ≈ squeeze_dims(r)
 
-    dims = [1,2,3]
+    dims = [1, 2, 3]
     r_hlo = @jit Reactant.Ops.reduce(A_ra, init_ra, dims, +)
     r = reduce(+, A; dims=dims, init=init)
     @test r_hlo ≈ squeeze_dims(r)
-
 end
-

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -1113,18 +1113,18 @@ end
     C_ra = Reactant.to_rarray(C)
     D_ra = Reactant.to_rarray(D)
 
-    mr_ra = mapreduce(x -> 3*x+1.2, *, A_ra; dims=2)
-    @test mr_ra ≈ squeeze_dims(mapreduce(x -> 3*x+1.2, *, A; dims=2))
+    mr_ra = mapreduce(x -> 3 * x + 1.2, *, A_ra; dims=2)
+    @test mr_ra ≈ squeeze_dims(mapreduce(x -> 3 * x + 1.2, *, A; dims=2))
 
     mr_ra = mapreduce(x -> x^3, +, A_ra; dims=1:2)
     @test mr_ra ≈ squeeze_dims(mapreduce(x -> x^3, +, A; dims=1:2))
 
-    mr_ra = mapreduce(x -> 3*x+1.2, +, A_ra; dims=:)
-    @test mr_ra ≈ mapreduce(x -> 3*x+1.2, +, A; dims=:)
+    mr_ra = mapreduce(x -> 3 * x + 1.2, +, A_ra; dims=:)
+    @test mr_ra ≈ mapreduce(x -> 3 * x + 1.2, +, A; dims=:)
 
-    mr_ra = mapreduce(x -> 3*x+1.2, max, A_ra; dims=:)
-    @test mr_ra ≈ mapreduce(x -> 3*x+1.2, max, A; dims=:)
+    mr_ra = mapreduce(x -> 3 * x + 1.2, max, A_ra; dims=:)
+    @test mr_ra ≈ mapreduce(x -> 3 * x + 1.2, max, A; dims=:)
 
-    mr_ra = mapreduce(x -> 3*x+1.2, min, A_ra; dims=2:3)
-    @test mr_ra ≈ mapreduce(x -> 3*x+1.2, min, A; dims=2:3)
+    mr_ra = mapreduce(x -> 3 * x + 1.2, min, A_ra; dims=2:3)
+    @test mr_ra ≈ mapreduce(x -> 3 * x + 1.2, min, A; dims=2:3)
 end


### PR DESCRIPTION
From PR #840, the mapreduce() can be changed to call the Ops.reduce(). 
I found that I have to change the function signature by taking the `@nonspecialize(f)` out and substitute with (somewhat ugly?) `f::F` to force the Julia's compiler to recompile this function every time the new anonymous function for map is introduced to the function call i.e., what is in the test cases. Otherwise, there will be the world age issue. 

I'm not so sure where to put the test in, so put it in `ops.jl`