### PR TITLE
[CI] Disable failing macOS-13 jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,6 +56,13 @@ jobs:
           - "IFRT"
         assertions:
           - false
+        exclude:
+          # Until <https://github.com/EnzymeAD/Reactant.jl/issues/867>
+          # is resolved.
+          - os: macOS-13
+            test_group: core
+          - os: macOS-13
+            test_group: integration
         include:
           - os: ubuntu-24.04
             version: '1.10'


### PR DESCRIPTION
Ref: https://github.com/EnzymeAD/Reactant.jl/issues/867.

I'm not particularly happy about this, but short of having someone to fix the issue above in this way we can have green CI back.