### PR TITLE
[CI] Disable `macOS-13` entirely, not just `core` and `integration`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,9 @@ jobs:
           # `ubuntu-22.04-arm` is considered more stable than `ubuntu-24.04-arm`:
           # <https://github.com/orgs/community/discussions/148648#discussioncomment-12099554>.
           - ubuntu-22.04-arm
-          - macOS-13
+          # Disable `macOS-13` until
+          # <https://github.com/EnzymeAD/Reactant.jl/issues/867> is resolved.
+          # - macOS-13
           - macOS-latest
         test_group:
           - core
@@ -56,13 +58,6 @@ jobs:
           - "IFRT"
         assertions:
           - false
-        exclude:
-          # Until <https://github.com/EnzymeAD/Reactant.jl/issues/867>
-          # is resolved.
-          - os: macOS-13
-            test_group: core
-          - os: macOS-13
-            test_group: integration
         include:
           - os: ubuntu-24.04
             version: '1.10'


### PR DESCRIPTION
I was under the impression the neural networks jobs were safe from #867, but it looks like I was wrong, so with this PR we just disable all macOS-13 jobs entirely.