### PR TITLE
[ReactantExtra] Fix `mlirOperationParse` and add `mlirOperationInject`

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -227,31 +227,26 @@ extern "C" MlirAttribute mlirComplexAttrDoubleGetChecked(MlirLocation loc,
       unwrap(loc), cast<ComplexType>(unwrap(type)), real, imag));
 }
 
-extern "C" bool mlirOperationInject(MlirContext ctx,
-  MlirBlock block,
-  MlirStringRef code,
-  MlirLocation location,
-  bool verify_after_parse
-) {
+extern "C" bool mlirOperationInject(MlirContext ctx, MlirBlock block,
+                                    MlirStringRef code, MlirLocation location,
+                                    bool verify_after_parse) {
   ParserConfig config(unwrap(ctx), verify_after_parse);
   if (failed(parseSourceString(unwrap(code), unwrap(block), config)))
     return false;
   return true;
 }
 
-extern "C" MlirOperation mlirOperationParse(MlirContext ctx,
-  MlirBlock block,
-  MlirStringRef code,
-  MlirLocation location,
-  bool verify_after_parse
-) {
+extern "C" MlirOperation mlirOperationParse(MlirContext ctx, MlirBlock block,
+                                            MlirStringRef code,
+                                            MlirLocation location,
+                                            bool verify_after_parse) {
   ParserConfig config(unwrap(ctx), verify_after_parse);
   if (failed(parseSourceString(unwrap(code), unwrap(block), config)))
     return MlirOperation{nullptr};
   return MlirOperation{
-    mlir::detail::constructContainerOpForParserIfNecessary<Operation*>(
-      unwrap(block), config.getContext(), unwrap(location)).release()
-    };
+      mlir::detail::constructContainerOpForParserIfNecessary<Operation *>(
+          unwrap(block), config.getContext(), unwrap(location))
+          .release()};
 }
 
 // TODO mlirComplexAttrGetnValue

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -227,13 +227,31 @@ extern "C" MlirAttribute mlirComplexAttrDoubleGetChecked(MlirLocation loc,
       unwrap(loc), cast<ComplexType>(unwrap(type)), real, imag));
 }
 
+extern "C" bool mlirOperationInject(MlirContext ctx,
+  MlirBlock block,
+  MlirStringRef code,
+  MlirLocation location,
+  bool verify_after_parse
+) {
+  ParserConfig config(unwrap(ctx), verify_after_parse);
+  if (failed(parseSourceString(unwrap(code), unwrap(block), config)))
+    return false;
+  return true;
+}
+
 extern "C" MlirOperation mlirOperationParse(MlirContext ctx,
-                                            MlirStringRef code) {
-  ParserConfig config(unwrap(ctx));
-  OwningOpRef<Operation *> owning_op = parseSourceString(unwrap(code), config);
-  if (!owning_op)
+  MlirBlock block,
+  MlirStringRef code,
+  MlirLocation location,
+  bool verify_after_parse
+) {
+  ParserConfig config(unwrap(ctx), verify_after_parse);
+  if (failed(parseSourceString(unwrap(code), unwrap(block), config)))
     return MlirOperation{nullptr};
-  return MlirOperation{owning_op.release()};
+  return MlirOperation{
+    mlir::detail::constructContainerOpForParserIfNecessary<Operation*>(
+      unwrap(block), config.getContext(), unwrap(location)).release()
+    };
 }
 
 // TODO mlirComplexAttrGetnValue


### PR DESCRIPTION
This fixes a problem in the previous implementation that was preventing us from injecting the MLIR code string inplace on an already existing MLIR block (verifier was the issue).