### PR TITLE
fix: apply init values after reduction

### DIFF
--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -393,14 +393,6 @@ buffer_on_cpu(::Any) = true
 buffer_on_cpu(x::ConcretePJRTArray) = all(XLA.buffer_on_cpu, x.data)
 buffer_on_cpu(x::ConcreteIFRTArray) = XLA.buffer_on_cpu(x.data)
 
-function Ops.constant(x::AbstractConcreteArray; kwargs...)
-    return Ops.constant(Base.convert(Array, x); kwargs...)
-end
-
-function Ops.constant(x::AbstractConcreteNumber{T}; kwargs...) where {T}
-    return Ops.constant(Base.convert(T, x); kwargs...)
-end
-
 function Base.zero(x::ConcretePJRTArray{T,N}) where {T,N}
     return ConcretePJRTArray(
         zeros(T, size(x)...); client=XLA.client(x), device=XLA.device(x), x.sharding
@@ -462,5 +454,11 @@ function Base.mapreducedim!(
 )
     fn = compile(mymapreducedim!, (f, op, R, A))
     fn(f, op, R, A)
+    return R
+end
+
+function Base.map!(f, R::Union{AnyConcreteIFRTArray,AnyConcretePJRTArray}, A::AbstractArray)
+    fn = compile(Base.map!, (f, R, A))
+    fn(f, R, A)
     return R
 end

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2377,7 +2377,7 @@ end
         x::TracedRArray{T},
         init_values::TracedRNumber{T},
         dimensions::Vector{Int},
-        fn::Function,
+        fn::Function;
         location=mlir_stacktrace("rand", @__FILE__, @__LINE__),
     )
 
@@ -2409,7 +2409,7 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
     - **CPU version & Julia's `reduce`**:
       - Reduce along dimension 1 → `[(15) (21); (18) (24)]`
       - Reduce along dimension 3 → `[(33 + 2)  (45 + 2)]` → `[35 47]`
-    
+
     - **GPU version**:
       - Reduce along dimension 1 → `[(15 + 2) (21 + 2); (18 + 2) (24 + 2)]`
       - Reduce along dimension 3 → `[37 49]`
@@ -2418,7 +2418,7 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
     x::TracedRArray{T},
     init_values::TracedRNumber{T},
     dimensions::Vector{Int},
-    fn::Function,
+    fn::Function;
     location=mlir_stacktrace("reduce", @__FILE__, @__LINE__),
 ) where {T}
     reduced_shape = Tuple(deleteat!(collect(size(x)), dimensions))

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2416,7 +2416,7 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
 """
 @noinline function reduce(
     x::TracedRArray{T},
-    init_values::Union{TracedRNumber{T}, Nothing},
+    init_values::Union{TracedRNumber{T},Nothing},
     dimensions::Vector{Int},
     fn::Function;
     location=mlir_stacktrace("reduce", @__FILE__, @__LINE__),

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2421,25 +2421,31 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
     fn::Function;
     location=mlir_stacktrace("reduce", @__FILE__, @__LINE__),
 ) where {T}
+    elT = T
     if init_values === nothing
-        if fn === min
-            init = typemax(T)
-        elseif fn === max
-            init = typemin(T)
+        if fn === min || fn === Base.FastMath.min_fast
+            init = typemax(elT)
+        elseif fn === max || fn === Base.FastMath.max_fast
+            init = typemin(elT)
         else
-            init = Base.reduce_empty(Base.BottomRF(fn), T)
+            init = Base.reduce_empty(Base.BottomRF(fn), elT)
         end
 
-        init_values = Reactant.TracedUtils.promote_to(TracedRNumber{T}, init)
+        initT = unwrapped_eltype(typeof(init))
+        if initT != elT # Bool, etc. reductions
+            elT = promote_type(initT, elT)
+            x = elT.(x)
+        end
+        init_values = Reactant.TracedUtils.promote_to(TracedRNumber{elT}, init)
     end
 
     reduced_shape = Tuple(deleteat!(collect(size(x)), dimensions))
 
-    result_type = mlir_type(TracedRArray{T,length(reduced_shape)}, reduced_shape)
+    result_type = mlir_type(TracedRArray{elT,length(reduced_shape)}, reduced_shape)
 
     sample_inputs = [
-        Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0),
-        Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0),
+        Reactant.TracedUtils.promote_to(TracedRNumber{elT}, 0),
+        Reactant.TracedUtils.promote_to(TracedRNumber{elT}, 0),
     ]
 
     func =
@@ -2454,7 +2460,7 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
         ).f
     @assert MLIR.IR.nregions(func) == 1
     ftype = MLIR.IR.Type(MLIR.IR.attr(func, "function_type"))
-    @assert MLIR.IR.result(ftype) == MLIR.IR.TensorType((), MLIR.IR.Type(T)) "$fn return type is not tensor<i1>"
+    @assert MLIR.IR.result(ftype) == MLIR.IR.TensorType((), MLIR.IR.Type(elT)) "$fn return type is not tensor<i1>"
     fn = MLIR.IR.Region()
     MLIR.API.mlirRegionTakeBody(fn, MLIR.IR.region(func, 1))
     MLIR.IR.rmfromparent!(func)
@@ -2472,7 +2478,7 @@ Applies a reduction function `fn` along the specified `dimensions` of input `x`,
         ),
     )
 
-    return TracedRArray{T,length(reduced_shape)}((), res, reduced_shape)
+    return TracedRArray{elT,length(reduced_shape)}((), res, reduced_shape)
 end
 
 end # module Ops

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -120,11 +120,25 @@ end
 end
 
 @noinline function constant(
+    x::AbstractArray{T,N}; location=mlir_stacktrace("constant", @__FILE__, @__LINE__)
+) where {T,N}
+    return constant(collect(x); location)
+end
+
+@noinline function constant(x::Reactant.AbstractConcreteArray; kwargs...)
+    return constant(Base.convert(Array, x); kwargs...)
+end
+
+@noinline function constant(
     x::T; location=mlir_stacktrace("constant", @__FILE__, @__LINE__)
 ) where {T<:Number}
     x isa TracedRNumber && return x
     res = fill(x; location)
     return TracedRNumber{T}((), res.mlir_data)
+end
+
+@noinline function constant(x::Reactant.AbstractConcreteNumber{T}; kwargs...) where {T}
+    return constant(Base.convert(T, x); kwargs...)
 end
 
 function fill(

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -1015,4 +1015,11 @@ function Base.findmax(f, x::AnyTracedRArray; dims::Union{Integer,Nothing}=nothin
     return (values, linear_indices)
 end
 
+Base.map(f, x::AnyTracedRArray) = f.(x)
+
+function Base.map!(f, y::AnyTracedRArray, x::AbstractArray)
+    y .= f.(x)
+    return y
+end
+
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -946,5 +946,7 @@ end
     init = 3.0
     init_ra = Reactant.to_rarray(init; track_numbers=Number)
 
-    @test @jit(sum(x_ra; init=init_ra, dims=2)) ≈ sum(x; init=init, dims=2)
+    fn(x, init; kwargs...) = sum(x; init, kwargs...)
+
+    @test @jit(fn(x_ra, init_ra; dims=2)) ≈ fn(x, init; dims=2)
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -938,3 +938,13 @@ end
         rv
     )
 end
+
+@testset "mapreduce with init" begin
+    x = reshape(collect(Float32, 1:12), 3, 4)
+    x_ra = Reactant.to_rarray(x)
+
+    init = 3.0
+    init_ra = Reactant.to_rarray(init; track_numbers=Number)
+
+    @test @jit(sum(x_ra; init=init_ra, dims=2)) ≈ sum(x; init=init, dims=2)
+end


### PR DESCRIPTION
stablehlo.reduce has somewhat different semantics compared to julia's reduce. Applying the init values later ensures that the results are consistent