### PR TITLE
Emit debug info on big `Ops.constant` values

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -89,8 +89,12 @@ end
 @noinline function constant(
     x::DenseArray{T,N}; location=mlir_stacktrace("constant", @__FILE__, @__LINE__)
 ) where {T,N}
-    sizeof(x) > LARGE_CONSTANT_THRESHOLD[] &&
-        error("Generating a constant larger than $(LARGE_CONSTANT_THRESHOLD[]) bytes.")
+    if sizeof(x) > LARGE_CONSTANT_THRESHOLD[]
+        location = with_debug() do
+            mlir_stacktrace("constant", @__FILE__, @__LINE__)
+        end
+    end
+
     value = MLIR.IR.DenseElementsAttribute(x)
     constants = constant_context()[2]
     if haskey(constants, value)


### PR DESCRIPTION
@giordano with this PR, you just need to configure the `LARGE_CONSTANT_THRESHOLD` and it will emit the full backtrace as the MLIR location in the debug info of the `stablehlo.constant` op.