### PR TITLE
feat: slurm detector + multigpu single process

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,8 +32,11 @@ pages = [
         "Getting Started" => "introduction/index.md",
         "Configuration" => "introduction/configuration.md",
     ],
-    "Tutorials" =>
-        ["Overview" => "tutorials/index.md", "Profiling" => "tutorials/profiling.md"],
+    "Tutorials" => [
+        "Overview" => "tutorials/index.md",
+        "Profiling" => "tutorials/profiling.md",
+        "Distributed" => "tutorials/multihost.md",
+    ],
     "API Reference" => [
         "Reactant API" => "api/api.md",
         "Ops" => "api/ops.md",

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -63,6 +63,7 @@ export default defineConfig({
         items: [
           {text: "Overview", link: "/tutorials/"},
           {text: "Profiling", link: "/tutorials/profiling"},
+          {text: "Distributed", link: "/tutorials/multihost"},
         ],
       },
       {
@@ -122,6 +123,7 @@ export default defineConfig({
         items: [
           { text: "Overview", link: "/tutorials/" },
           { text: "Profiling", link: "/tutorials/profiling" },
+          { text: "Distributed", link: "/tutorials/multihost" },
         ],
       },
       "/api/": {

--- a/docs/src/api/sharding.md
+++ b/docs/src/api/sharding.md
@@ -2,7 +2,7 @@
 CollapsedDocStrings = true
 ```
 
-# Sharding API
+# [Sharding API](@id sharding-api)
 
 `Reactant.Sharding` module provides a high-level API to construct MLIR operations with
 support for sharding.

--- a/docs/src/tutorials/index.md
+++ b/docs/src/tutorials/index.md
@@ -1,5 +1,6 @@
 # Tutorials
 
  - [Profiling](@ref profiling).
+ - [Multi-Host Environments](@ref distributed).
 
 We are currently working on adding more tutorials to Reactant!! Please check back soon!

--- a/docs/src/tutorials/multihost.md
+++ b/docs/src/tutorials/multihost.md
@@ -1,0 +1,82 @@
+# [Multi-Host Environments](@ref distributed)
+
+!!! tip "Use XLA IFRT Runtime"
+
+    While PJRT does support some minimal distributed capabilities on CUDA GPUs, distributed
+    support in Reactant is primarily provided via IFRT. Before loading Reactant, set the
+    "xla_runtime" preference to be "IFRT". This can be done with:
+
+    ```julia
+    using Preferences, UUIDs
+
+    Preferences.set_preference!(
+        UUID("3c362404-f566-11ee-1572-e11a4b42c853"),
+        "xla_runtime" => "IFRT"
+    )
+    ```
+
+At the top of your code, just after loading Reactant and before running any Reactant related
+operations, run `Reactant.Distributed.initialize()`.
+
+!!! tip "Enable debug logging for debugging"
+
+    Reactant emits a lot of useful debugging information when setting up the Distributed
+    Runtime. This can be printing by setting the env var `JULIA_DEBUG` to contain
+    `Reactant`.
+
+After this simply setup your code with [`Reactant.Sharding`](@ref sharding-api) and the code
+will run on multiple devices across multiple nodes.
+
+## Example Slurm Script for Multi-Host Matrix Multiplication
+
+::: code-group
+
+```bash [main.sbatch]
+#!/bin/bash -l
+#
+#SBATCH --job-name=matmul-sharding-reactant
+#SBATCH --time=00:20:00
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=72
+#SBATCH --account=<account>
+#SBATCH --constraint=gpu
+
+export JULIA_DEBUG="Reactant,Reactant_jll"
+
+srun --preserve-env bash ./matmul.sh
+```
+
+```bash [matmul.sh]
+#!/bin/bash -l
+
+# Important else XLA might hang indefinitely
+unset no_proxy http_proxy https_proxy NO_PROXY HTTP_PROXY HTTPS_PROXY
+
+julia --project=. --threads=auto matmul_sharded.jl
+```
+
+```julia [matmul_sharded.jl]
+using Reactant
+
+Reactant.Distributed.initialize(; single_gpu_per_process=false)
+
+@assert length(Reactant.devices()) >= 2
+
+N = min((length(Reactant.devices()) ÷ 2) * 2, 8)
+
+mesh = Sharding.Mesh(reshape(Reactant.devices()[1:N], 2, :), (:x, :y))
+sharding = Sharding.NamedSharding(mesh, (:x, :y))
+
+x = reshape(collect(Float32, 1:64), 8, 8)
+y = reshape(collect(Float32, 1:64), 8, 8)
+
+x_ra = Reactant.to_rarray(x; sharding)
+y_ra = Reactant.to_rarray(y; sharding)
+
+res = @jit x_ra * y_ra
+
+display(res)
+```
+
+:::

--- a/src/Distributed.jl
+++ b/src/Distributed.jl
@@ -58,10 +58,10 @@ function get_local_process_id end
 
 function auto_detect_unset_distributed_params(;
     detector_list=[
+        SlurmEnvDetector(),
         OpenMPIORTEEnvDetector(),
         OpenMPIPMIXEnvDetector(),
         MPIEnvDetector(),
-        SlurmEnvDetector(),
     ],
     coordinator_address::Union{Nothing,String}=nothing,
     num_processes::Union{Nothing,Integer}=nothing,

--- a/src/Distributed.jl
+++ b/src/Distributed.jl
@@ -13,6 +13,11 @@ function initialize(;
     initialization_timeout_in_seconds::Integer=300,
     kwargs...,
 )
+    if isinteractive()
+        @warn "Reactant.Distributed.initialize() should not be called in interactive mode. \
+               Use Reactant.Distributed.initialize() in a script instead."
+    end
+
     @assert !initialized[] "`Distributed.initialize` has already been called"
 
     (coordinator_address, num_processes, process_id, local_gpu_device_ids) = auto_detect_unset_distributed_params(;

--- a/src/xla/Distributed.jl
+++ b/src/xla/Distributed.jl
@@ -129,7 +129,7 @@ function update!(
     coordinator_address::String,
     num_processes::Int,
     process_id::Int,
-    local_gpu_device_ids::Vector{Int},
+    local_gpu_device_ids::Union{Nothing,Vector{Int}},
     coordinator_bind_address::Union{Nothing,String}=nothing,
     cluster_register_timeout_in_minutes::Integer=60,
     rpc_timeout_in_seconds::Integer=120,
@@ -141,7 +141,9 @@ function update!(
     @assert 0 ≤ process_id < num_processes
 
     state.coordinator_address = coordinator_address
-    state.local_gpu_device_ids = local_gpu_device_ids
+    if local_gpu_device_ids !== nothing
+        state.local_gpu_device_ids = local_gpu_device_ids
+    end
     state.process_id = process_id
     state.num_processes = num_processes
 

--- a/src/xla/IFRT/Array.jl
+++ b/src/xla/IFRT/Array.jl
@@ -140,9 +140,7 @@ end
 function XLA.to_host(buffer::Array, data, reactant_sharding)
     reactant_sharding = Reactant.Sharding.unwrap_shardinfo(reactant_sharding)
 
-    if is_single_device_sharding(XLA.sharding(buffer)) ||
-        is_fully_replicated(XLA.sharding(buffer)) ||
-        reactant_sharding isa Reactant.Sharding.NoSharding
+    if reactant_sharding isa Reactant.Sharding.NoSharding
         GC.@preserve buffer data begin
             @ccall MLIR.API.mlir_c.ifrt_array_copy_to_host_buffer(
                 buffer.buffer::Ptr{Cvoid}, data::Ptr{Cvoid}

--- a/test/cluster_detector.jl
+++ b/test/cluster_detector.jl
@@ -1,0 +1,13 @@
+using Reactant, Test
+
+@testset "ORTE_URI parsing" begin
+    addr = Reactant.Distributed._get_coordinator_address_from_orte_uri(
+        "1531576320.0;tcp://10.96.0.1,10.148.0.1,10.108.0.1:34911"
+    )
+    @test startswith(addr, "10.96.0.1:")
+
+    addr = Reactant.Distributed._get_coordinator_address_from_orte_uri(
+        "1314521088.0;tcp6://[fe80::b9b:ac5d:9cf0:b858,2620:10d:c083:150e::3000:2]:43370"
+    )
+    @test startswith(addr, "fe80::b9b:ac5d:9cf0:b858:")
+end

--- a/test/cluster_detector.jl
+++ b/test/cluster_detector.jl
@@ -1,13 +1,111 @@
 using Reactant, Test
 
 @testset "ORTE_URI parsing" begin
-    addr = Reactant.Distributed._get_coordinator_address_from_orte_uri(
-        "1531576320.0;tcp://10.96.0.1,10.148.0.1,10.108.0.1:34911"
-    )
+    addr = withenv(
+        "OMPI_MCA_orte_hnp_uri" => "1531576320.0;tcp://10.96.0.1,10.148.0.1,10.108.0.1:34911",
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.OpenMPIORTEEnvDetector(), -1
+        )
+    end
     @test startswith(addr, "10.96.0.1:")
 
-    addr = Reactant.Distributed._get_coordinator_address_from_orte_uri(
-        "1314521088.0;tcp6://[fe80::b9b:ac5d:9cf0:b858,2620:10d:c083:150e::3000:2]:43370"
-    )
+    addr = withenv(
+        "OMPI_MCA_orte_hnp_uri" => "1314521088.0;tcp6://[fe80::b9b:ac5d:9cf0:b858,2620:10d:c083:150e::3000:2]:43370",
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.OpenMPIORTEEnvDetector(), -1
+        )
+    end
     @test startswith(addr, "fe80::b9b:ac5d:9cf0:b858:")
+end
+
+@testset "PMIX_SERVER_URI parsing" begin
+    @test_throws ErrorException withenv(
+        "PMIX_SERVER_URI21" => "961478656.0;tcp4://127.0.0.1:35625",
+        "PMIX_NAMESPACE" => "961478657",
+        "PMIX_VERSION" => "4.1.5",
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.OpenMPIPMIXEnvDetector(), -1
+        )
+    end
+
+    addr = withenv(
+        "PMIX_SERVER_URI21" => "961478656.0;tcp4://127.0.0.1:35625",
+        "PMIX_NAMESPACE" => "961478657",
+        "PMIX_VERSION" => "3.1.5",
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.OpenMPIPMIXEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "127.0.0.1:")
+
+    addr = withenv(
+        "PMIX_SERVER_URI21" => "pmix-server.40985;tcp4://127.0.0.1:48103",
+        "PMIX_NAMESPACE" => "slurm.pmix.1591154.6",
+        "PMIX_VERSION" => "3.1.5rc4",
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.OpenMPIPMIXEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "127.0.0.1:")
+
+    addr = withenv(
+        "PMIX_SERVER_URI3" => "pmix-server.41512;tcp4://127.0.0.1:60120",
+        "PMIX_NAMESPACE" => "slurm.pmix.1591154.7",
+        "PMIX_VERSION" => "2.2.2",
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.OpenMPIPMIXEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "127.0.0.1:")
+
+    addr = withenv(
+        "PMIX_SERVER_URI2" => "prterun-hydra-3874047@0.0;tcp4://118.143.212.23:49157",
+        "PMIX_NAMESPACE" => "prterun-hydra-3874047@1",
+        "PMIX_VERSION" => "5.0.5rc10",
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.OpenMPIPMIXEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "118.143.212.23:")
+end
+
+@testset "Slurm parsing" begin
+    addr = withenv("SLURM_STEP_NODELIST" => "node001", "SLURM_JOB_ID" => "12345") do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.SlurmEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "node001:")
+
+    addr = withenv("SLURM_STEP_NODELIST" => "node001,host2", "SLURM_JOB_ID" => "12345") do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.SlurmEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "node001:")
+
+    addr = withenv(
+        "SLURM_STEP_NODELIST" => "node[001-015],host2", "SLURM_JOB_ID" => "12345"
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.SlurmEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "node001:")
+
+    addr = withenv(
+        "SLURM_STEP_NODELIST" => "node[001,007-015],host2", "SLURM_JOB_ID" => "12345"
+    ) do
+        Reactant.Distributed.get_coordinator_address(
+            Reactant.Distributed.SlurmEnvDetector(), -1
+        )
+    end
+    @test startswith(addr, "node001:")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,7 @@ const REACTANT_TEST_GROUP = lowercase(get(ENV, "REACTANT_TEST_GROUP", "all"))
             @safetestset "Custom Number Types" include("custom_number_types.jl")
         end
         @safetestset "Sharding" include("sharding.jl")
+        @safetestset "Cluster Detection" include("cluster_detector.jl")
     end
 
     if REACTANT_TEST_GROUP == "all" || REACTANT_TEST_GROUP == "integration"

--- a/test/sharding.jl
+++ b/test/sharding.jl
@@ -25,11 +25,10 @@ end
         cdata_sharded2 = Reactant.to_rarray(data; sharding=data_sharding2)
         cdata_sharded3 = Reactant.to_rarray(data; sharding=data_sharding3)
 
-        @test data ≈
-            Array(cdata) ≈
-            Array(cdata_sharded) ≈
-            Array(cdata_sharded2) ≈
-            Array(cdata_sharded3)
+        @test data ≈ Array(cdata)
+        @test data ≈ Array(cdata_sharded)
+        @test data ≈ Array(cdata_sharded2)
+        @test data ≈ Array(cdata_sharded3)
 
         @test cdata_sharded.sharding isa Sharding.ShardInfo{<:Sharding.HloSharding}
         @test cdata_sharded2.sharding isa Sharding.ShardInfo{<:Sharding.HloSharding}


### PR DESCRIPTION
Last bit needed to run on ALPs. By default we run a single GPU per process, but if `single_gpu_per_process` is set to false, we will use all GPUs accessible locally in that process