### PR TITLE
feat: add a reactant.donated attr to donated args

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1055,6 +1055,17 @@ function compile_mlir!(
     MLIR.API.mlirOperationDestroy(compiled_f.operation)
     compiled_f.operation = MLIR.API.MlirOperation(C_NULL)
 
+    # Add a `donated` attr to the function arguments. This doesn't affect XLA, but lets us
+    # check which arguments were donated.
+    preserved_args_idx = last.(preserved_args)
+    for (i, arg) in enumerate(linear_args)
+        if i ∉ preserved_args_idx
+            MLIR.API.mlirFuncSetArgAttr(
+                func3, i - 1, "reactant.donated", MLIR.IR.UnitAttribute()
+            )
+        end
+    end
+
     return Reactant.TracedUtils.CompiledMlirFnResult(
         fnwrapped,
         func3,

--- a/test/buffer_donation.jl
+++ b/test/buffer_donation.jl
@@ -17,6 +17,8 @@ end
     b = Reactant.to_rarray(3 * ones(2, 2))
     @jit(donate_fill_x_with_2(a, b))
     @test convert(Array, a) == 2 * ones(2, 2)
+    hlo = @code_hlo(donate_fill_x_with_2(a, b))
+    @test length(findall("reactant.donated", repr(hlo))) == 1
 
     (; preserved_args) = Reactant.Compiler.compile_xla(donate_fill_x_with_2, (a, b))[3]
     preserved_args_idx = last.(preserved_args)
@@ -26,6 +28,8 @@ end
     b = Reactant.to_rarray(3 * ones(2, 2))
     @jit(donate_inplace_mul(a, b))
     @test convert(Array, a) == 6 * ones(2, 2)
+    hlo = @code_hlo(donate_inplace_mul(a, b))
+    @test length(findall("reactant.donated", repr(hlo))) == 1
 
     (; preserved_args) = Reactant.Compiler.compile_xla(donate_inplace_mul, (a, b))[3]
     preserved_args_idx = last.(preserved_args)


### PR DESCRIPTION
```mlir
module @reactant_fn attributes {mhlo.num_partitions = 8 : i64, mhlo.num_replicas = 1 : i64} {
  sdy.mesh @mesh = <["x"=2, "y"=2, "z"=2]>
  func.func @main(%arg0: tensor<2x2x2xf64> {reactant.donated, sdy.sharding = #sdy.sharding<@mesh, [{"z"}, {"y"}, {"x"}]>}) -> (tensor<2x2x2xf64> {sdy.sharding = #sdy.sharding<@mesh, [{"z"}, {"y"}, {"x"}]>}) {
    %cst = stablehlo.constant dense<[[[0.63084595408749855, 0.94852621203725684], [0.37331956478281025, 0.55284767325502948]], [[0.62904737184899251, 0.71429285082865546], [0.51198077904593264, 0.26607778955478978]]]> : tensor<2x2x2xf64>
    return %cst : tensor<2x2x2xf64>
  }
}
```