### PR TITLE
Revert "fix: noop check"

### DIFF
--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -629,7 +629,6 @@ function elem_apply(f, args::Vararg{Any,Nargs}) where {Nargs}
 end
 
 function broadcast_to_size(arg::AbstractArray{<:TracedRNumber}, rsize)
-    collect(size(arg)) == collect(rsize) && return arg
     if Reactant.ancestor(arg) isa TracedRArray
         return broadcast_to_size(materialize_traced_array(arg), rsize)
     end


### PR DESCRIPTION
Reverts EnzymeAD/Reactant.jl#953

This causes
```
  TypeError: in new, expected Reactant.TracedRArray{Float32, 2}, got a value of type Reactant.TracedRNumber{Float32}
  Stacktrace:
    [1] make_tracer(seen::Reactant.OrderedIdDict{Any, Any}, prev::Any, path::Any, mode::Reactant.TraceMode; track_numbers::Type, sharding::Any, runtime::Any, kwargs::@Kwargs{toscalar::Bool})
      @ Reactant ~/work/Reactant.jl/Reactant.jl/src/Tracing.jl:1117
    [2] make_tracer(seen::Reactant.OrderedIdDict{Any, Any}, prev::Any, path::Any, mode::Reactant.TraceMode; track_numbers::Type, sharding::Any, runtime::Any, kwargs::@Kwargs{toscalar::Bool})
      @ Reactant ~/work/Reactant.jl/Reactant.jl/src/Tracing.jl:1091
    [3] make_tracer
      @ ~/work/Reactant.jl/Reactant.jl/src/Tracing.jl:1010 [inlined]
    [4] make_mlir_fn(f::typeof(+), args::Tuple{LinearAlgebra.Adjoint{Reactant.TracedRNumber{Float32}, SubArray{Reactant.TracedRNumber{Float32}, 2, Reactant.TracedRArray{Float32, 2}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}, Reactant.TracedRArray{Float32, 2}}, kwargs::Tuple{}, name::String, concretein::Bool; toscalar::Bool, return_dialect::Symbol, args_in_result::Symbol, construct_function_without_args::Bool, do_transpose::Bool, input_shardings::Nothing, runtime::Nothing)
      @ Reactant.TracedUtils ~/work/Reactant.jl/Reactant.jl/src/TracedUtils.jl:192
    [5] elem_apply(::Function, ::LinearAlgebra.Adjoint{Reactant.TracedRNumber{Float32}, SubArray{Reactant.TracedRNumber{Float32}, 2, Reactant.TracedRArray{Float32, 2}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}, ::Reactant.TracedRArray{Float32, 2})
      @ Reactant.TracedUtils ~/work/Reactant.jl/Reactant.jl/src/TracedUtils.jl:551
    [6] _copyto!
      @ ~/work/Reactant.jl/Reactant.jl/src/TracedRArray.jl:675 [inlined]
    [7] _copyto!(none::Reactant.TracedRArray{Float32, 2}, none::Base.Broadcast.Broadcasted{Nothing, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}, typeof(+), Tuple{LinearAlgebra.Adjoint{Reactant.TracedRNumber{Float32}, SubArray{Reactant.TracedRNumber{Float32}, 2, Reactant.TracedRArray{Float32, 2}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}, SubArray{Reactant.TracedRNumber{Float32}, 2, Reactant.TracedRArray{Float32, 2}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}})
      @ Reactant ./<missing>:0
    [8] _copyto!
      @ ~/work/Reactant.jl/Reactant.jl/src/TracedRArray.jl:668 [inlined]
    [9] call_with_reactant(::typeof(Reactant.TracedRArrayOverrides._copyto!), ::Reactant.TracedRArray{Float32, 2}, ::Base.Broadcast.Broadcasted{Nothing, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}, typeof(+), Tuple{LinearAlgebra.Adjoint{Reactant.TracedRNumber{Float32}, SubArray{Reactant.TracedRNumber{Float32}, 2, Reactant.TracedRArray{Float32, 2}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}, SubArray{Reactant.TracedRNumber{Float32}, 2, Reactant.TracedRArray{Float32, 2}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}}})
      @ Reactant ~/work/Reactant.jl/Reactant.jl/src/utils.jl:0
   [10] copyto!
      @ ~/work/Reactant.jl/Reactant.jl/src/TracedRArray.jl:656 [inlined]
   [11] copyto!
      @ ./broadcast.jl:956 [inlined]
   [12] copy
      @ ~/work/Reactant.jl/Reactant.jl/src/TracedRArray.jl:647 [inlined]
   [13] materialize
      @ ./broadcast.jl:903 [inlined]
   [14] view_adjoint
      @ ~/work/Reactant.jl/Reactant.jl/test/wrapped_arrays.jl:270 [inlined]
   [15] view_adjoint(none::Reactant.TracedRArray{Float32, 2})
      @ Reactant ./<missing>:0
   [16] view_adjoint
      @ ~/work/Reactant.jl/Reactant.jl/test/wrapped_arrays.jl:269 [inlined]
   [17] call_with_reactant(::typeof(Main.var"##Wrapped Arrays#236".view_adjoint), ::Reactant.TracedRArray{Float32, 2})
      @ Reactant ~/work/Reactant.jl/Reactant.jl/src/utils.jl:0
   [18] make_mlir_fn(f::typeof(Main.var"##Wrapped Arrays#236".view_adjoint), args::Tuple{ConcretePJRTArray{Float32, 2, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}}, kwargs::@NamedTuple{}, name::String, concretein::Bool; toscalar::Bool, return_dialect::Symbol, args_in_result::Symbol, construct_function_without_args::Bool, do_transpose::Bool, input_shardings::Nothing, runtime::Val{:PJRT})
      @ Reactant.TracedUtils ~/work/Reactant.jl/Reactant.jl/src/TracedUtils.jl:267
   [19] make_mlir_fn
      @ ~/work/Reactant.jl/Reactant.jl/src/TracedUtils.jl:154 [inlined]
   [20] compile_mlir!(mod::Reactant.MLIR.IR.Module, f::typeof(Main.var"##Wrapped Arrays#236".view_adjoint), args::Tuple{ConcretePJRTArray{Float32, 2, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}}, callcache::Dict{Vector, @NamedTuple{f_name::String, mlir_result_types::Vector{Reactant.MLIR.IR.Type}, traced_result, mutated_args::Vector{Int64}}}, sdycache::IdDict{Reactant.Sharding.Mesh, @NamedTuple{sym_name::Reactant.MLIR.IR.Attribute, mesh_attr::Reactant.MLIR.IR.Attribute, mesh_op::Reactant.MLIR.IR.Operation}}; optimize::Bool, shardy_passes::Symbol, no_nan::Bool, backend::String, fn_kwargs::@NamedTuple{}, raise::Bool, input_shardings::Nothing, runtime::Val{:PJRT})
      @ Reactant.Compiler ~/work/Reactant.jl/Reactant.jl/src/Compiler.jl:754
   [21] compile_mlir!
      @ ~/work/Reactant.jl/Reactant.jl/src/Compiler.jl:705 [inlined]
   [22] compile_xla(f::Function, args::Tuple{ConcretePJRTArray{Float32, 2, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}}; client::Nothing, kwargs::@Kwargs{fn_kwargs::@NamedTuple{}, no_nan::Bool, raise::Bool, shardy_passes::Symbol, optimize::Bool})
      @ Reactant.Compiler ~/work/Reactant.jl/Reactant.jl/src/Compiler.jl:1794
```
in the `core` tests.  This was already failing in the original PR.