### PR TITLE
feat: dispatch on eltype for more wrapped arrays

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -437,7 +437,7 @@ end
 function Base.mapreduce(
     @nospecialize(f),
     @nospecialize(op),
-    @nospecialize(A::AnyTracedRArray{T,N});
+    @nospecialize(A::AbstractArray{<:TracedRNumber{T},N});
     dims=:,
     init=nothing,
 ) where {T,N}
@@ -537,9 +537,9 @@ end
 function Base.mapreducedim!(
     @nospecialize(f),
     @nospecialize(op),
-    @nospecialize(R::AnyTracedRArray),
+    @nospecialize(R::AbstractArray{<:TracedRNumber{T},N}),
     A::Base.AbstractArrayOrBroadcasted,
-)
+) where {T,N}
     @assert length(size(R)) == length(size(A))
     dims = map(enumerate(zip(size(R), size(A)))) do (i, (sR, sA))
         sR == sA && return nothing


### PR DESCRIPTION
This needs to be done in general for all the `AnyTracedRArray` dispatches, but lets try it one at a time