### PR TITLE
[ReactantExtra] Update XLA and adapt `API.cpp`

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -837,7 +837,7 @@ xla::CompileOptions GenerateCompileOptions(int64_t device_id, bool is_sharded,
   return options;
 }
 
-extern "C" xla::PjRtExecutable *
+extern "C" xla::PjRtLoadedExecutable *
 ClientCompile(PjRtClient *client, MlirModule cmod, int64_t device_id,
               bool is_sharded, const int64_t *mesh_ids, int64_t num_mesh_ids,
               const char *xla_gpu_cuda_data_dir, bool use_shardy_partitioner) {
@@ -855,7 +855,7 @@ ClientCompile(PjRtClient *client, MlirModule cmod, int64_t device_id,
     }
   }
 
-  auto exec_err = client->Compile(cmod_op, options);
+  auto exec_err = client->CompileAndLoad(cmod_op, options);
 
   if (!exec_err.ok()) {
     std::string err_str;

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -837,7 +837,7 @@ xla::CompileOptions GenerateCompileOptions(int64_t device_id, bool is_sharded,
   return options;
 }
 
-extern "C" xla::PjRtLoadedExecutable *
+extern "C" xla::PjRtExecutable *
 ClientCompile(PjRtClient *client, MlirModule cmod, int64_t device_id,
               bool is_sharded, const int64_t *mesh_ids, int64_t num_mesh_ids,
               const char *xla_gpu_cuda_data_dir, bool use_shardy_partitioner) {

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-ENZYMEXLA_COMMIT = "716c84722ee47e75c9d4cb07cc564c8be62cd9d2"
+ENZYMEXLA_COMMIT = "eb0c13dcbe0dcc51eee504bb262956f905a5f3c7"
 ENZYMEXLA_SHA256 = ""
 
 http_archive(
@@ -129,10 +129,9 @@ http_archive(
     patches = ["@enzyme_ad//:patches/jax.patch"],
 )
 
-# load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
-
-XLA_COMMIT = "5e01d79fae2d7884ea9d47a3251f4cec8dcc742e"
-XLA_SHA256 = ""
+load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
+# XLA_COMMIT = "5e01d79fae2d7884ea9d47a3251f4cec8dcc742e"
+# XLA_SHA256 = ""
 
 http_archive(
     name = "xla",

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-ENZYMEXLA_COMMIT = "e0b13d70cab494c927c0bd9b3251f5ed8dcdc8a5"
+ENZYMEXLA_COMMIT = "716c84722ee47e75c9d4cb07cc564c8be62cd9d2"
 ENZYMEXLA_SHA256 = ""
 
 http_archive(
@@ -131,7 +131,7 @@ http_archive(
 
 # load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
 
-XLA_COMMIT = "a909bff68848ff642a8f4aafa59f4e6dc87411c8"
+XLA_COMMIT = "5e01d79fae2d7884ea9d47a3251f4cec8dcc742e"
 XLA_SHA256 = ""
 
 http_archive(

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-ENZYMEXLA_COMMIT = "eb0c13dcbe0dcc51eee504bb262956f905a5f3c7"
+ENZYMEXLA_COMMIT = "2db74a9afd45c7d99d5515a370ffbaac707b114f"
 ENZYMEXLA_SHA256 = ""
 
 http_archive(

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -131,7 +131,7 @@ http_archive(
 
 # load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
 
-XLA_COMMIT = "821715be3f7ded31723b9b4c0d5de8f0d2a30a6b"
+XLA_COMMIT = "a909bff68848ff642a8f4aafa59f4e6dc87411c8"
 XLA_SHA256 = ""
 
 http_archive(

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-ENZYMEXLA_COMMIT = "e28431f92da1a29cd993823a7a4b63fee678e2af"
+ENZYMEXLA_COMMIT = "e0b13d70cab494c927c0bd9b3251f5ed8dcdc8a5"
 ENZYMEXLA_SHA256 = ""
 
 http_archive(
@@ -129,7 +129,10 @@ http_archive(
     patches = ["@enzyme_ad//:patches/jax.patch"],
 )
 
-load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
+# load("@jax//third_party/xla:workspace.bzl", "XLA_COMMIT", "XLA_SHA256")
+
+XLA_COMMIT = "821715be3f7ded31723b9b4c0d5de8f0d2a30a6b"
+XLA_SHA256 = ""
 
 http_archive(
     name = "xla",


### PR DESCRIPTION
This is updating XLA to https://github.com/openxla/xla/commit/821715be3f7ded31723b9b4c0d5de8f0d2a30a6b to solve [upstream issue](https://github.com/openxla/xla/issues/24033) and uses Enzyme-JAX version in https://github.com/EnzymeAD/Enzyme-JAX/pull/511 for testing.