### PR TITLE
[ReactantExtra] Add debug info to Operation dump

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -2387,6 +2387,8 @@ extern "C" void ifrt_hlo_module_cost_analysis_properties(
                          .c_str());
 }
 
+#pragma endregion
+
 extern "C" void dump_operation(Operation *op, const char *filename) {
   std::error_code EC;
   llvm::raw_fd_ostream file(filename, EC, llvm::sys::fs::OF_Text);
@@ -2396,10 +2398,8 @@ extern "C" void dump_operation(Operation *op, const char *filename) {
     return;
   }
 
-  file << *op << "\n";
+  op->print(file, mlir::OpPrintingFlags().enableDebugInfo(true, false));
 }
-
-#pragma endregion
 
 extern "C" bool pjrt_device_is_addressable(PjRtDevice *device) {
   return device->IsAddressable();


### PR DESCRIPTION
Suggested by @ivanradanov during pair debug session. I still don't know why we can't access this function inside GDB, it works great in Julia though:
```julia-repl
julia> using Reactant, Reactant_jll

julia> mod = @code_hlo optimize = :before_kernel sin.(Reactant.to_rarray(Float32[1.0]));

julia> @ccall libReactantExtra.dump_operation(Reactant.MLIR.IR.Operation(mod).operation.ptr::Ptr{Cvoid}, "this_file.txt"::Ptr{Cchar})::Cvoid

shell> cat this_file.txt
#loc = loc(unknown)
module @reactant_Base.Br... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
  func.func @main(%arg0: tensor<1xf32> {reactant.donated} loc(unknown)) -> tensor<1xf32> {
    %0 = stablehlo.sine %arg0 : tensor<1xf32> loc(#loc2)
    return %0 : tensor<1xf32> loc(#loc)
  } loc(#loc)
} loc(#loc)
#loc1 = loc("/home/giordano/.julia/dev/Reactant/src/Ops.jl":283:0)
#loc2 = loc("sine"(#loc1))
```