### PR TITLE
Disambiguate offsetarray `getindex` methods

### DIFF
--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -33,10 +33,16 @@ function Base.getindex(
     offset_indices = [arg .- x.offsets[i] for (i, arg) in enumerate(args)]
     return getindex(parent(x), offset_indices...)
 end
+
 function Base.getindex(
-    x::OffsetVector{T,<:AbstractConcreteArray}, args::Union{Int,AbstractUnitRange{Int}}
-) where T
-    offset_indices = args .- x.offsets[1]
+    x::OffsetVector{T,<:AbstractConcreteArray}, index::Int
+) where T 
+    return getindex(parent(x), index - x.offsets[1])
+end
+function Base.getindex(
+    x::OffsetVector{T,<:AbstractConcreteArray}, indices::AbstractUnitRange{Int}
+) where T 
+    offset_indices = indices .- x.offsets[1]
     return getindex(parent(x), offset_indices)
 end
 

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -37,7 +37,9 @@ end
 function Base.getindex(x::OffsetVector{T,<:AbstractConcreteArray}, index::Int) where {T}
     return getindex(parent(x), index - x.offsets[1])
 end
-function Base.getindex( x::OffsetVector{T,<:AbstractConcreteArray}, indices::AbstractUnitRange{Int}) where {T} 
+function function Base.getindex(
+    x::OffsetVector{T,<:AbstractConcreteArray}, indices::AbstractUnitRange{Int}
+) where {T}
     offset_indices = indices .- x.offsets[1]
     return getindex(parent(x), offset_indices)
 end

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -34,14 +34,10 @@ function Base.getindex(
     return getindex(parent(x), offset_indices...)
 end
 
-function Base.getindex(
-    x::OffsetVector{T,<:AbstractConcreteArray}, index::Int
-) where {T} 
+function Base.getindex(x::OffsetVector{T,<:AbstractConcreteArray}, index::Int) where {T}
     return getindex(parent(x), index - x.offsets[1])
 end
-function Base.getindex(
-    x::OffsetVector{T,<:AbstractConcreteArray}, indices::AbstractUnitRange{Int}
-) where {T} 
+function Base.getindex( x::OffsetVector{T,<:AbstractConcreteArray}, indices::AbstractUnitRange{Int}) where {T} 
     offset_indices = indices .- x.offsets[1]
     return getindex(parent(x), offset_indices)
 end

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -36,12 +36,12 @@ end
 
 function Base.getindex(
     x::OffsetVector{T,<:AbstractConcreteArray}, index::Int
-) where T 
+) where {T} 
     return getindex(parent(x), index - x.offsets[1])
 end
 function Base.getindex(
     x::OffsetVector{T,<:AbstractConcreteArray}, indices::AbstractUnitRange{Int}
-) where T 
+) where {T} 
     offset_indices = indices .- x.offsets[1]
     return getindex(parent(x), offset_indices)
 end

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -35,7 +35,7 @@ function Base.getindex(
 end
 function Base.getindex(
     x::OffsetVector{T,<:AbstractConcreteArray}, args::Union{Int,AbstractUnitRange{Int}}
-) where {T,N}
+) where T
     offset_indices = args .- x.offsets[1]
     return getindex(parent(x), offset_indices)
 end

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -34,7 +34,7 @@ function Base.getindex(
     return getindex(parent(x), offset_indices...)
 end
 function Base.getindex(
-    x::OffsetVector{T,N,<:AbstractConcreteArray}, 
+    x::OffsetVector{T,<:AbstractConcreteArray}, 
     args::Union{Int,AbstractUnitRange{Int}}
 ) where {T,N}
     offset_indices = args .- x.offsets[1]

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -27,7 +27,7 @@ function Base.getindex(
     return getindex(parent(x), offset_indices...)
 end
 function Base.getindex(
-    x::OffsetArray{T,N,<:AbstractConcreteArray}, args::Vararg{Int,N}
+    x::OffsetArray{T,N,<:AbstractConcreteArray}, args::Vararg{Union{Int,AbstractUnitRange{Int}},N}
 ) where {T,N}
     offset_indices = [arg .- x.offsets[i] for (i, arg) in enumerate(args)]
     return getindex(parent(x), offset_indices...)

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -37,7 +37,7 @@ end
 function Base.getindex(x::OffsetVector{T,<:AbstractConcreteArray}, index::Int) where {T}
     return getindex(parent(x), index - x.offsets[1])
 end
-function function Base.getindex(
+function Base.getindex(
     x::OffsetVector{T,<:AbstractConcreteArray}, indices::AbstractUnitRange{Int}
 ) where {T}
     offset_indices = indices .- x.offsets[1]

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -1,7 +1,7 @@
 module ReactantOffsetArraysExt
 
 using OffsetArrays
-using OffsetArrays: OffsetArray
+using OffsetArrays: OffsetArray, OffsetVector
 using Reactant: Reactant, MLIR, Ops, TracedRArray, AbstractConcreteArray
 
 Base.@nospecializeinfer function Reactant.traced_type_inner(
@@ -32,6 +32,13 @@ function Base.getindex(
 ) where {T,N}
     offset_indices = [arg .- x.offsets[i] for (i, arg) in enumerate(args)]
     return getindex(parent(x), offset_indices...)
+end
+function Base.getindex(
+    x::OffsetVector{T,N,<:AbstractConcreteArray}, 
+    args::Union{Int,AbstractUnitRange{Int}}
+) where {T,N}
+    offset_indices = args .- x.offsets[1]
+    return getindex(parent(x), offset_indices)
 end
 
 parentindex(r::OffsetArrays.IdOffsetRange, i) = i .- r.offset

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -27,15 +27,14 @@ function Base.getindex(
     return getindex(parent(x), offset_indices...)
 end
 function Base.getindex(
-    x::OffsetArray{T,N,<:AbstractConcreteArray}, 
-    args::Vararg{Union{Int,AbstractUnitRange{Int}},N}
+    x::OffsetArray{T,N,<:AbstractConcreteArray},
+    args::Vararg{Union{Int,AbstractUnitRange{Int}},N},
 ) where {T,N}
     offset_indices = [arg .- x.offsets[i] for (i, arg) in enumerate(args)]
     return getindex(parent(x), offset_indices...)
 end
 function Base.getindex(
-    x::OffsetVector{T,<:AbstractConcreteArray}, 
-    args::Union{Int,AbstractUnitRange{Int}}
+    x::OffsetVector{T,<:AbstractConcreteArray}, args::Union{Int,AbstractUnitRange{Int}}
 ) where {T,N}
     offset_indices = args .- x.offsets[1]
     return getindex(parent(x), offset_indices)

--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -27,7 +27,8 @@ function Base.getindex(
     return getindex(parent(x), offset_indices...)
 end
 function Base.getindex(
-    x::OffsetArray{T,N,<:AbstractConcreteArray}, args::Vararg{Union{Int,AbstractUnitRange{Int}},N}
+    x::OffsetArray{T,N,<:AbstractConcreteArray}, 
+    args::Vararg{Union{Int,AbstractUnitRange{Int}},N}
 ) where {T,N}
     offset_indices = [arg .- x.offsets[i] for (i, arg) in enumerate(args)]
     return getindex(parent(x), offset_indices...)


### PR DESCRIPTION
should disambiguate when indexing an `AbstractConcreteArray` with a unit range. See the errors in https://buildkite.com/clima/oceananigans/builds/21674#0195c13d-e9b1-4000-a551-6e09546a77cb
```
MethodError: getindex(::OffsetVector{Float64, ConcreteIFRTArray{Float64, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}}, ::UnitRange{Int64}) is ambiguous.
  |  
  | Candidates:
  | getindex(A::OffsetVector{T} where T, r::AbstractUnitRange{Int64})
  | @ OffsetArrays /storage5/buildkite-agent/.julia-21674/packages/OffsetArrays/yHW0g/src/OffsetArrays.jl:515
  | getindex(x::OffsetArray{T, N, <:Reactant.AbstractConcreteArray}, args::Vararg{Any, N}) where {T, N}
  | @ ReactantOffsetArraysExt /storage5/buildkite-agent/.julia-21674/packages/Reactant/2J20g/ext/ReactantOffsetArraysExt.jl:22
  | getindex(A::OffsetArray, r::AbstractUnitRange{Int64})
  | @ OffsetArrays /storage5/buildkite-agent/.julia-21674/packages/OffsetArrays/yHW0g/src/OffsetArrays.jl:509
  | getindex(A::OffsetVector{T} where T, r::AbstractRange{Int64})
  | @ OffsetArrays /storage5/buildkite-agent/.julia-21674/packages/OffsetArrays/yHW0g/src/OffsetArrays.jl:523
  |  
  | Possible fix, define
  | getindex(::OffsetVector{T, <:Reactant.AbstractConcreteArray{T, 1}}, ::AbstractUnitRange{Int64}) where T
```