### PR TITLE
Also dump MLIR module of failed compilation inside IFRT and PJRT

### DIFF
--- a/src/xla/PJRT/LoadedExecutable.jl
+++ b/src/xla/PJRT/LoadedExecutable.jl
@@ -79,16 +79,18 @@ function XLA.compile(
 )
     device_id = is_sharded ? Int64(-1) : Int64(XLA.device_ordinal(device))
     GC.@preserve client mod begin
-        exec = @ccall MLIR.API.mlir_c.ClientCompile(
-            client.client::Ptr{Cvoid},
-            mod.module_::MLIR.API.MlirModule,
-            device_id::Clong,
-            is_sharded::Bool,
-            global_device_ids::Ptr{Clong},
-            length(global_device_ids)::Clong,
-            XLA.CUDA_DATA_DIR[]::Cstring,
-            use_shardy_partitioner::Bool,
-        )::Ptr{Cvoid}
+        exec = MLIR.IR.try_compile_dump_mlir(mod) do
+            @ccall MLIR.API.mlir_c.ClientCompile(
+                client.client::Ptr{Cvoid},
+                mod.module_::MLIR.API.MlirModule,
+                device_id::Clong,
+                is_sharded::Bool,
+                global_device_ids::Ptr{Clong},
+                length(global_device_ids)::Clong,
+                XLA.CUDA_DATA_DIR[]::Cstring,
+                use_shardy_partitioner::Bool,
+            )::Ptr{Cvoid}
+        end
     end
     return LoadedExecutable(
         exec, num_outputs, num_parameters, is_sharded, num_replicas, num_partitions


### PR DESCRIPTION
Extending the cases where the MLIR module is written to file in case of failed compilation.  Perhaps not always as useful as we'd like, but better than nothing I guess.