### PR TITLE
fix: codegen for resharded input arrays

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1808,6 +1808,8 @@ function codegen_unflatten!(
                 res = :(args[$(path[2])])
                 path = path[3:end]
             end
+
+            # TODO: We might not be able to directly set the field here.
             for p in path
                 res = :(traced_getfield($res, $(Meta.quot(p))))
             end
@@ -2132,7 +2134,7 @@ function compile(f, args; sync=false, kwargs...)
         return result
     end
 
-    if DEBUG_PRINT_CODEGEN[]
+    if DEBUG_PRINT_CODEGEN[] && Reactant.Distributed.local_rank() == 0
         display(body)
     end
 

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1720,10 +1720,10 @@ function codegen_unflatten!(
                         unflatcode = quote
                             # XXX: we might need to handle sharding here
                             traced_setfield_buffer!(
-                                $runtime,
-                                $cache_dict,
-                                traced_getfield($unflatcode, $(Meta.quot(path[end]))),
-                                $concrete_res_name,
+                                $(runtime),
+                                $(cache_dict),
+                                traced_getfield($(unflatcode), $(Meta.quot(path[end]))),
+                                $(concrete_res_name),
                             )
                         end
                     else
@@ -1731,7 +1731,7 @@ function codegen_unflatten!(
                         local_unflatcode_sym = gensym(:local_val)
                         unflatcode = quote
                             $(local_unflatcode_sym) = traced_getfield(
-                                $unflatcode, $(Meta.quot(path[end]))
+                                $(unflatcode), $(Meta.quot(path[end]))
                             )
                             $unreshard_sym = generate_unresharded_ifrt_array(
                                 $(concrete_res_name),
@@ -1741,10 +1741,10 @@ function codegen_unflatten!(
                                 size($(local_unflatcode_sym)),
                             )
                             traced_setfield_buffer!(
-                                $runtime,
-                                $cache_dict,
-                                $local_unflatcode_sym,
-                                $concrete_res_name,
+                                $(runtime),
+                                $(cache_dict),
+                                $(local_unflatcode_sym),
+                                $(unreshard_sym).data,
                             )
                         end
                     end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -325,7 +325,7 @@ function generate_unresharded_ifrt_array(
     @assert size_arr == res_arr_size "Expected size of array to be $(size_arr), but got \
                                       $(res_arr_size)"
 
-    ifrt_sharding = Reactant.XLA.sharding(res_arr.buffer)
+    ifrt_sharding = Reactant.XLA.sharding(res_arr)
     if !Reactant.XLA.IFRT.is_single_device_sharding(ifrt_sharding)
         error("Unexpected sharding of result array: $(string(ifrt_sharding))")
     end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -101,7 +101,7 @@ function traced_setfield_buffer!(runtime::Val, cache_dict, concrete_res, obj, fi
 end
 
 function traced_setfield_buffer!(::Val, cache_dict, val, concrete_res, obj, field)
-    return traced_setfield!(obj, field, concrete_res)
+    return traced_setfield!(val, :data, concrete_res)
 end
 
 function traced_setfield_buffer!(

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1707,24 +1707,21 @@ function codegen_unflatten!(
                     unflatcode = :(traced_getfield($unflatcode, $(Meta.quot(p))))
                 end
 
-                if need_to_unreshard !== nothing &&
-                    !haskey(unresharded_arrays_cache, concrete_res_name)
-                    unreshard_sym = gensym(:unresharded_buffer)
-                    push!(
-                        unresharded_code,
-                        :(
-                            $unreshard_sym = generate_unresharded_ifrt_array(
-                                $(concrete_res_name), $(need_to_unreshard)
-                            )
-                        ),
-                    )
-                    unresharded_arrays_cache[concrete_res_name] = unreshard_sym
-                end
-
-                concrete_res_name_final = if need_to_unreshard === nothing
-                    concrete_res_name
-                else
-                    unresharded_arrays_cache[concrete_res_name]
+                concrete_res_name_final = concrete_res_name
+                if need_to_unreshard !== nothing
+                    if !haskey(unresharded_arrays_cache, concrete_res_name)
+                        unreshard_sym = gensym(:unresharded_buffer)
+                        push!(
+                            unresharded_code,
+                            :(
+                                $unreshard_sym = generate_unresharded_ifrt_array(
+                                    $(concrete_res_name), $(need_to_unreshard)
+                                )
+                            ),
+                        )
+                        unresharded_arrays_cache[concrete_res_name] = unreshard_sym
+                    end
+                    concrete_res_name_final = unresharded_arrays_cache[concrete_res_name]
                 end
 
                 if length(path) > 0

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1761,8 +1761,6 @@ function codegen_unflatten!(
     postkeys = collect(keys(result_stores))
     used = [t for t in prevkeys if !in(t, postkeys)]
 
-    @show preserved_args
-
     # if some argument is mutated, change them to point to the correct concrete results
     for (result, arg_idx) in preserved_args
         paths = (
@@ -1771,8 +1769,6 @@ function codegen_unflatten!(
                 length(p) > 0 && (p[1] == :result || p[1] == :resargs || p[1] == :args)
             )...,
         )
-
-        @show paths
 
         for path in paths
             arg = linear_args[arg_idx + 1]
@@ -1797,11 +1793,14 @@ function codegen_unflatten!(
                 path = path[3:end]
             end
 
-            error(1)
-
-            # TODO: We might not be able to directly set the field here.
             for p in path
                 res = :(traced_getfield($res, $(Meta.quot(p))))
+            end
+
+            need_to_unreshard = get(resharded_inputs, (:args, argpath[2:end]...), nothing)
+            if need_to_unreshard !== nothing
+                # TODO(@avik-pal): I need an MWE to debug this codepath
+                error("TODO: Not yet Implemented. Open an issue on Reactant.jl.")
             end
 
             argres = :(args[$(argpath[2])])

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1575,8 +1575,8 @@ function codegen_flatten!(
                     )
 
                     # XXX: Currently we copy to host and then make the transfer to the
-                    #      sharded devices. This is not ideal, we might be able to do a
-                    #      device-to-device transfer, maybe using reshard?
+                    #      sharded devices. This is not ideal, we should be able to do a
+                    #      direct transfer using remapplan
                     hlo_sharding = convert(XLA.HloSharding, condensed_op_sharding)
                     ifrt_sharding = XLA.IFRT.Sharding(
                         vec(Reactant.XLA.get_device.((client,), mesh.device_ids)),
@@ -2042,7 +2042,7 @@ function compile(f, args; sync=false, kwargs...)
         result_stores,
         mlir_fn_res.is_sharded,
         mlir_fn_res.sharding_mesh,
-        XLA.get_parameter_shardings(exec),
+        XLA.get_parameter_shardings(exec), # TODO: use the same workflow as output shardings to parse the tensor sharding attributes directly if possible
         client,
     )
 

--- a/src/Sharding.jl
+++ b/src/Sharding.jl
@@ -582,14 +582,7 @@ struct HloSharding{D1,D2,PS} <: AbstractSharding
 end
 
 function Base.convert(::Type{HloSharding}, sharding::NamedSharding)
-    if MLIR.IR._has_context()
-        ctx = MLIR.IR.context()
-    else
-        ctx = MLIR.IR.Context(Reactant.registry[], false)
-        @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
-    end
-
-    MLIR.IR.context!(ctx) do
+    MLIR.IR.with_context(; allow_use_existing=true) do ctx
         mesh_op = Reactant.Ops.mesh(
             sharding.mesh; mod=MLIR.IR.Module(MLIR.IR.Location(; context=ctx))
         )

--- a/src/mlir/IR/Context.jl
+++ b/src/mlir/IR/Context.jl
@@ -79,6 +79,33 @@ function context!(f, ctx::Context)
     end
 end
 
+function with_context(f; allow_use_existing=false)
+    delete_context = false
+    if allow_use_existing && _has_context()
+        ctx = context()
+    else
+        delete_context = true
+        ctx = Context(Reactant.registry[], false)
+        Reactant.Compiler.context_gc_vector[ctx] = Vector{
+            Union{Reactant.TracedRArray,Reactant.TracedRNumber}
+        }(
+            undef, 0
+        )
+        @ccall API.mlir_c.RegisterDialects(ctx::API.MlirContext)::Cvoid
+    end
+
+    activate!(ctx)
+    result = try
+        f(ctx)
+    finally
+        deactivate!(ctx)
+    end
+
+    delete_context && delete!(Reactant.Compiler.context_gc_vector, ctx)
+
+    return result
+end
+
 function enable_multithreading!(enable::Bool=true; context::Context=context())
     API.mlirContextEnableMultithreading(context, enable)
     return context

--- a/src/mlir/IR/Context.jl
+++ b/src/mlir/IR/Context.jl
@@ -101,7 +101,7 @@ function with_context(f; allow_use_existing=false)
         deactivate!(ctx)
     end
 
-    delete_context && delete!(Reactant.Compiler.context_gc_vector, ctx)
+    delete_context && Base.delete!(Reactant.Compiler.context_gc_vector, ctx)
 
     return result
 end

--- a/src/xla/IFRT/Array.jl
+++ b/src/xla/IFRT/Array.jl
@@ -310,7 +310,7 @@ function replicate_array_to_all_devices(array::Array, sharding, mesh, size_arr)
             use_shardy_partitioner=false, # unused
         )
 
-        only(XLA.execute(exec, (array.buffer,), (UInt8(0),), Val(1))).buffer
+        only(XLA.execute(exec, (array.buffer,), (UInt8(0),), Val(1)))
     finally
         Reactant.Compiler.deactivate_sdycache!(sdycache)
         MLIR.IR.deactivate!(ctx)

--- a/src/xla/IFRT/Array.jl
+++ b/src/xla/IFRT/Array.jl
@@ -235,7 +235,6 @@ function replicate_array_to_all_devices(array::Array, sharding, mesh, size_arr)
         AsyncArray(array, nothing), size_arr, shard_info
     )
 
-    # TODO: Directly write the MLIR for this part??
     fn_compiled = Reactant.compile(
         identity,
         (data,);

--- a/src/xla/IFRT/AsyncArray.jl
+++ b/src/xla/IFRT/AsyncArray.jl
@@ -18,3 +18,10 @@ function replicate_array_to_all_devices(array::AsyncArray, args...)
     wait(array)
     return replicate_array_to_all_devices(array.buffer, args...)
 end
+
+function XLA.to_host(array::AsyncArray, data, reactant_sharding)
+    wait(array)
+    return XLA.to_host(array.buffer, data, reactant_sharding)
+end
+
+XLA.sharding(x::AsyncArray) = XLA.sharding(x.buffer)

--- a/test/bcast.jl
+++ b/test/bcast.jl
@@ -19,10 +19,7 @@ end
 end
 
 function test()
-    ctx = MLIR.IR.Context(Reactant.registry[], false)
-    @ccall MLIR.API.mlir_c.RegisterDialects(ctx::MLIR.API.MlirContext)::Cvoid
-
-    MLIR.IR.context!(ctx) do
+    MLIR.IR.with_context() do ctx
         mod = MLIR.IR.Module(MLIR.IR.Location())
         modbody = MLIR.IR.body(mod)
 


### PR DESCRIPTION
- [x] fixes #1027
  - [x] do it for all codepaths
- [x] make unresharding more efficient -- we need to ensure that we only unreshard once
- [x] add test
- [x] faster replication --- no tracing (we directly construct the MLIR needed) + more checks to avoid having to replicate in the first place