### PR TITLE
chore: display loud warning that distributed is being used with PJRT

### DIFF
--- a/src/Distributed.jl
+++ b/src/Distributed.jl
@@ -35,6 +35,12 @@ function initialize(;
     initialization_timeout_in_seconds::Integer=300,
     kwargs...,
 )
+    if Reactant.XLA.runtime() isa Val{:PJRT}
+        @warn "Attempting to using Reactant Distributed functionality with PJRT runtime. \
+               This will never be properly supported. Switch to using IFRT runtime by \
+               adding a `xla_runtime` preference with value \"IFRT\""
+    end
+
     if isinteractive()
         @warn "Reactant.Distributed.initialize() should not be called in interactive mode. \
                Use Reactant.Distributed.initialize() in a script instead."


### PR DESCRIPTION
@simone-silvestri was accidentally using PJRT with Distributed. This will be a common error since PJRT is our default runtime. If we detect this combination, we display a loud warning 