### PR TITLE
nicer error for type mutation in traced loop body

### DIFF
--- a/lib/ReactantCore/src/ReactantCore.jl
+++ b/lib/ReactantCore/src/ReactantCore.jl
@@ -231,7 +231,7 @@ function trace_for(mod, expr; track_numbers)
                 end
 
             $(ReactantCore).traced_while(
-                cond_fn, body_fn, args; track_numbers=$(track_numbers)
+                cond_fn, body_fn, args; track_numbers=$(track_numbers), verify_arg_names=$(QuoteNode(args_init))
             )
         end
     end

--- a/src/ControlFlow.jl
+++ b/src/ControlFlow.jl
@@ -9,7 +9,8 @@ function ReactantCore.traced_call(f::Function, args...)
 end
 
 function ReactantCore.traced_while(
-    cond_fn::CFn, body_fn::BFn, args; track_numbers=Number
+    cond_fn::CFn, body_fn::BFn, args; track_numbers=Number, verify_arg_names=nothing
 ) where {CFn,BFn}
-    return Ops.while_loop(cond_fn, body_fn, args...; track_numbers)
+    @warn verify_arg_names
+    return Ops.while_loop(cond_fn, body_fn, args...; track_numbers, verify_arg_names)
 end

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1746,7 +1746,7 @@ use [`MLIR.Dialects.stablehlo.dynamic_slice`](@ref) instead.
 end
 
 @noinline function while_loop(
-    cond_fn::CFn, body_fn::BFn, args...; track_numbers
+    cond_fn::CFn, body_fn::BFn, args...; track_numbers, verify_arg_names=nothing
 ) where {CFn,BFn}
     # TODO: detect and prevent mutation within the condition
 
@@ -1780,6 +1780,7 @@ end
             do_transpose=false,
         ).f
 
+    @warn verify_arg_names
     body_fn_compiled =
         Reactant.TracedUtils.make_mlir_fn(
             body_fn,
@@ -1790,6 +1791,7 @@ end
             return_dialect=:stablehlo,
             args_in_result=:none,
             do_transpose=false,
+            verify_arg_names
         ).f
 
     cond_reg = Reactant.TracedUtils.__take_region(cond_fn_compiled)


### PR DESCRIPTION
I should still bump versions but I'm afk for a bit.
```jl
using Reactant

function mysum(x)
    s = 0.
    a = 10
    @trace track_numbers=false for _ in 1:3
        a += x
        s += x
    end
    s
end
@code_hlo mysum(ConcreteRNumber(4.))

```

```
ERROR: Types do not match between function arguments and results.
The following arguments should be traced:
a, s
```