### PR TITLE
Fix #1066

### DIFF
--- a/src/xla/IFRT/Array.jl
+++ b/src/xla/IFRT/Array.jl
@@ -61,7 +61,7 @@ function Array(
             idx = seen_slice[slice]
             push!(addressable_shard_indices[idx], cur_shard)
         else
-            host_buffer = array[slice...]
+            host_buffer = view(array, slice...)
             push!(host_buffers, host_buffer)
             push!(addressable_shard_indices, Int64[cur_shard])
             seen_slice[slice] = length(host_buffers)


### PR DESCRIPTION
this should fix #1066

@glwagner would you mind trying this?

cc @avik-pal not sure if we should use `collect` or we can use `view` to avoid allocations.

note that `collect(1)` returns a 0-dim `Array` fix the edge case of #1066 and `view` returns a `SubArray` always.