### PR TITLE
Fix logic for dumping MLIR modules

### DIFF
--- a/src/mlir/IR/Pass.jl
+++ b/src/mlir/IR/Pass.jl
@@ -107,7 +107,9 @@ function try_compile_dump_mlir(f, mod::Module, pm=nothing)
         failed = true
         rethrow()
     finally
-        dump_mlir(mod, pm; failed)
+        if failed || DUMP_MLIR_ALWAYS[]
+            dump_mlir(mod, pm; failed)
+        end
     end
 end
 

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1087,14 +1087,22 @@ end
     always_old = Reactant.MLIR.IR.DUMP_MLIR_ALWAYS[]
     dir_old = Reactant.MLIR.IR.DUMP_MLIR_DIR[]
 
-    Reactant.MLIR.IR.DUMP_MLIR_ALWAYS[] = true
-
     mktempdir() do dir
+        Reactant.MLIR.IR.DUMP_MLIR_ALWAYS[] = true
         Reactant.MLIR.IR.DUMP_MLIR_DIR[] = dir
         @compile sin.(Reactant.to_rarray(Float32[1.0]))
         for mod in readdir(dir; join=true)
             @test contains(read(mod, String), "hlo.sine")
         end
+    end
+
+    mktempdir() do dir
+        Reactant.MLIR.IR.DUMP_MLIR_ALWAYS[] = false
+        Reactant.MLIR.IR.DUMP_MLIR_DIR[] = dir
+        @compile exp.(Reactant.to_rarray(Float32[1.0]))
+        # Make sure we don't save anything to file when compilation is
+        # successful and `DUMP_MLIR_ALWAYS=false`.
+        @test isempty(readdir(dir; join=true))
     end
 
     Reactant.MLIR.IR.DUMP_MLIR_ALWAYS[] = always_old


### PR DESCRIPTION
In certain cases we were _always_ dumping the modules even with a successful compilation and `DUMP_MLIR_ALWAYS=false`.  Add also a relevant test to catch this mistake.

Ref: https://github.com/EnzymeAD/Reactant.jl/pull/1061#issuecomment-2761297988.