### PR TITLE
fix: shardy passes

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -7,6 +7,7 @@ import ..Reactant:
     Reactant,
     MLIR,
     XLA,
+    Sharding,
     ConcretePJRTArray,
     ConcretePJRTNumber,
     ConcreteIFRTArray,
@@ -91,8 +92,8 @@ end
 
     # This case is triggered if the user had provided an unsharded input (NoSharding), but
     # we had to replicate it before feeding it to XLA
-    @assert !Reactant.Sharding.is_sharded(obj) "Expected unsharded input. Open an issue on \
-                                                Reactant.jl with a MWE."
+    @assert !Sharding.is_sharded(obj) "Expected unsharded input. Open an issue on \
+                                       Reactant.jl with a MWE."
     devices = Reactant.XLA.device.(val)
     device = Reactant.XLA.device(only(obj.data))
     idx = findfirst(isequal(device), devices)
@@ -1074,40 +1075,13 @@ function compile_mlir!(
             # Extract the result shardings from the compiled function
             result_attrs = MLIR.IR.attr(compiled_f, "res_attrs")
             if result_attrs !== nothing
-                result_shardings = Vector{
-                    Union{Reactant.Sharding.NamedSharding,Reactant.Sharding.NoSharding}
-                }(
+                result_shardings = Vector{Union{Sharding.NamedSharding,Sharding.NoSharding}}(
                     undef, length(result_attrs)
                 )
                 for i in 1:length(result_attrs)
-                    result_attr = result_attrs[i - 1]
-                    @assert MLIR.IR.isdict(result_attr)
-                    mlir_attr = MLIR.API.mlirDictionaryAttrGetElementByName(
-                        result_attr, "sdy.sharding"
+                    result_shardings[i] = Sharding.sdy_sharding_to_reactant_sharding(
+                        result_attrs[i - 1], mlir_fn_res.global_device_ids, mod
                     )
-                    if mlir_attr.ptr == C_NULL
-                        result_shardings[i] = Reactant.Sharding.NoSharding()
-                    else
-                        mesh_op = MLIR.IR.Operation(
-                            MLIR.API.mlirSymbolTableLookup(
-                                MLIR.IR.SymbolTable(MLIR.IR.Operation(mod)),
-                                MLIR.IR.leafref(
-                                    MLIR.IR.Attribute(
-                                        MLIR.API.sdyTensorShardingAttrGetMeshOrRef(
-                                            mlir_attr
-                                        ),
-                                    ),
-                                ),
-                            ),
-                            false,
-                        )
-                        result_shardings[i] = Reactant.Sharding.named_sharding_from_tensor_sharding_attr(
-                            Reactant.Sharding.mesh_from_sdy_mesh_attr(
-                                MLIR.IR.attr(mesh_op, "mesh"), mlir_fn_res.global_device_ids
-                            ),
-                            MLIR.IR.Attribute(mlir_attr),
-                        )
-                    end
                 end
             end
 
@@ -1437,7 +1411,7 @@ function assert_mismatched_sharding(
     sharding_from_input, hlo_sharding_from_executable::Reactant.XLA.HloSharding
 )
     return assert_mismatched_sharding(
-        convert(Reactant.Sharding.HloSharding, sharding_from_input).hlo_sharding,
+        convert(Sharding.HloSharding, sharding_from_input).hlo_sharding,
         hlo_sharding_from_executable,
     )
 end
@@ -1521,7 +1495,7 @@ function codegen_flatten!(
                 hlo_sharding_from_executable = convert(
                     XLA.HloSharding, condensed_op_sharding
                 )
-                if Reactant.Sharding.is_sharded(carg)
+                if Sharding.is_sharded(carg)
                     # Check if the sharding provided is same as the one we have
                     assert_mismatched_sharding(
                         carg.sharding.sharding.hlo_sharding, hlo_sharding_from_executable
@@ -1614,7 +1588,7 @@ function codegen_flatten!(
                     XLA.HloSharding, condensed_op_sharding
                 )
 
-                if Reactant.Sharding.is_sharded(carg)
+                if Sharding.is_sharded(carg)
                     # Check if the sharding provided is same as the one we have
                     assert_mismatched_sharding(
                         carg.sharding.sharding.hlo_sharding, hlo_sharding_from_executable
@@ -2067,15 +2041,14 @@ function compile(f, args; sync=false, assert_nonallocating=false, kwargs...)
     end
 
     result_stores = Dict{Tuple,Symbol}()
-    path_to_shard_info =
-        mlir_fn_res.is_sharded ? Dict{Tuple,Reactant.Sharding.ShardInfo}() : nothing
+    path_to_shard_info = mlir_fn_res.is_sharded ? Dict{Tuple,Sharding.ShardInfo}() : nothing
 
     global_mesh = if mlir_fn_res.unique_meshes === nothing
         nothing
     elseif length(mlir_fn_res.unique_meshes) == 1
         only(mlir_fn_res.unique_meshes)
     else
-        Reactant.Sharding.Mesh(
+        Sharding.Mesh(
             mlir_fn_res.global_device_ids,
             0:(length(mlir_fn_res.global_device_ids) - 1),
             (:flat_mesh,),
@@ -2104,7 +2077,7 @@ function compile(f, args; sync=false, assert_nonallocating=false, kwargs...)
     linear_result_shard_info = if mlir_fn_res.is_sharded
         output_hlo_shardings = XLA.get_output_shardings(exec)
         output_reactant_shardings = mlir_fn_res.result_shardings
-        local linear_result_shard_info = Vector{Reactant.Sharding.ShardInfo}(
+        local linear_result_shard_info = Vector{Sharding.ShardInfo}(
             undef, length(linear_results)
         )
         for i in 1:length(linear_results)
@@ -2118,17 +2091,16 @@ function compile(f, args; sync=false, assert_nonallocating=false, kwargs...)
             if output_reactant_shardings !== missing
                 reactant_sharding = output_reactant_shardings[i]
                 use_hlo_sharding =
-                    reactant_sharding isa Reactant.Sharding.NoSharding ||
-                    convert(
-                        Reactant.Sharding.HloSharding, reactant_sharding
-                    ).hlo_sharding != hlo_sharding
+                    reactant_sharding isa Sharding.NoSharding ||
+                    convert(Sharding.HloSharding, reactant_sharding).hlo_sharding !=
+                    hlo_sharding
             else
                 use_hlo_sharding = true
             end
 
             if use_hlo_sharding
-                linear_result_shard_info[i] = Reactant.Sharding.ShardInfo(
-                    Reactant.Sharding.HloSharding(
+                linear_result_shard_info[i] = Sharding.ShardInfo(
+                    Sharding.HloSharding(
                         hlo_sharding,
                         global_mesh,
                         ntuple(Returns(true), length(res_size)),
@@ -2137,7 +2109,7 @@ function compile(f, args; sync=false, assert_nonallocating=false, kwargs...)
                     array_slices,
                 )
             else
-                linear_result_shard_info[i] = Reactant.Sharding.ShardInfo(
+                linear_result_shard_info[i] = Sharding.ShardInfo(
                     output_reactant_shardings[i], array_slices
                 )
             end
@@ -2314,7 +2286,7 @@ function default_sdycache()
             sym_name::MLIR.IR.Attribute,
             mesh_attr::MLIR.IR.Attribute,
             mesh_op::MLIR.IR.Operation,
-            mesh::Reactant.Sharding.Mesh,
+            mesh::Sharding.Mesh,
         }
     }()
 end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -791,7 +791,7 @@ function compile_mlir!(
     sdycache=default_sdycache();
     optimize::Union{Bool,Symbol}=true,
     # default refers to letting XLA handle the shardy inport/propagation/export
-    shardy_passes::Symbol=:to_mhlo_shardings, # [:none, :xla_default, :to_mhlo_shardings]
+    shardy_passes::Symbol=:to_mhlo_shardings, # [:none, :to_mhlo_shardings]
     no_nan::Bool=false,
     assert_nonallocating::Bool=false,
     backend="gpu",
@@ -1067,7 +1067,7 @@ function compile_mlir!(
     if is_sharded
         if shardy_passes == :none
             use_shardy_partitioner = true
-        elseif shardy_passes ∈ (:xla_default, :to_mhlo_shardings)
+        elseif shardy_passes == :to_mhlo_shardings
             run_pass_pipeline!(
                 mod, join(["sdy-propagation-pipeline", "sdy-close-shardings"], ",")
             )
@@ -1085,11 +1085,7 @@ function compile_mlir!(
                 end
             end
 
-            if shardy_passes == :xla_default
-                use_shardy_partitioner = true
-            else
-                run_pass_pipeline!(mod, "xla-sdy-stablehlo-export-pipeline")
-            end
+            run_pass_pipeline!(mod, "xla-sdy-stablehlo-export-pipeline")
         else
             error("Invalid shardy_passes option: $(Meta.quot(shardy_passes))")
         end

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1088,9 +1088,7 @@ function compile_mlir!(
             if shardy_passes == :xla_default
                 use_shardy_partitioner = true
             else
-                run_pass_pipeline!(
-                    mod, join(["xla-sdy-stablehlo-export-pipeline", "cse"], ',')
-                )
+                run_pass_pipeline!(mod, "xla-sdy-stablehlo-export-pipeline")
             end
         else
             error("Invalid shardy_passes option: $(Meta.quot(shardy_passes))")

--- a/src/Sharding.jl
+++ b/src/Sharding.jl
@@ -920,7 +920,7 @@ unwrap_shardinfo(x::AbstractSharding) = x
 unwrap_shardinfo(x::ShardInfo) = unwrap_shardinfo(x.sharding)
 
 # sdy attributes to high-level sharding information
-function sdy_sharding_to_reactant_sharding(attr, global_device_ids)
+function sdy_sharding_to_reactant_sharding(attr, global_device_ids, mod)
     !MLIR.IR.isdict(attr) && return NoSharding()
 
     mlir_attr = MLIR.API.mlirDictionaryAttrGetElementByName(attr, "sdy.sharding")

--- a/src/Sharding.jl
+++ b/src/Sharding.jl
@@ -87,7 +87,7 @@ struct Mesh{D,ID<:AbstractVector{Int}}
     end
 end
 
-function mesh_from_sdy_mesh_attr(mesh_attr::MLIR.IR.Attribute, global_device_ids)
+function sdy_mesh_to_reactant_mesh(mesh_attr::MLIR.IR.Attribute, global_device_ids)
     @assert MLIR.API.sdyAttributeIsAMeshAttr(mesh_attr.attribute)
 
     ndevice_ids = MLIR.API.sdyMeshAttrGetDeviceIdsSize(mesh_attr)
@@ -305,7 +305,7 @@ struct NamedSharding{D,M<:Mesh} <: AbstractSharding
     end
 end
 
-function named_sharding_from_tensor_sharding_attr(mesh::Mesh, tensor_sharding_attr)
+function sdy_tensor_sharding_to_named_sharding(mesh::Mesh, tensor_sharding_attr)
     @assert MLIR.API.sdyAttributeIsATensorShardingAttr(tensor_sharding_attr)
 
     ndims = MLIR.API.sdyTensorShardingAttrGetDimShardingsSize(tensor_sharding_attr)
@@ -534,7 +534,7 @@ function sharding_to_array_slices(
                 MLIR.IR.attr(func, "res_attrs")[0], "sdy.sharding"
             )
             @assert mlir_attr.ptr != C_NULL
-            sharding = named_sharding_from_tensor_sharding_attr(
+            sharding = sdy_tensor_sharding_to_named_sharding(
                 sharding.mesh, MLIR.IR.Attribute(mlir_attr)
             )
 
@@ -918,5 +918,27 @@ Unwraps a sharding info object, returning the sharding object itself.
 """
 unwrap_shardinfo(x::AbstractSharding) = x
 unwrap_shardinfo(x::ShardInfo) = unwrap_shardinfo(x.sharding)
+
+# sdy attributes to high-level sharding information
+function sdy_sharding_to_reactant_sharding(attr, global_device_ids)
+    !MLIR.IR.isdict(attr) && return NoSharding()
+
+    mlir_attr = MLIR.API.mlirDictionaryAttrGetElementByName(attr, "sdy.sharding")
+    mlir_attr.ptr == C_NULL && return NoSharding()
+
+    mesh_op = MLIR.IR.Operation(
+        MLIR.API.mlirSymbolTableLookup(
+            MLIR.IR.SymbolTable(MLIR.IR.Operation(mod)),
+            MLIR.IR.leafref(
+                MLIR.IR.Attribute(MLIR.API.sdyTensorShardingAttrGetMeshOrRef(mlir_attr))
+            ),
+        ),
+        false,
+    )
+    return sdy_tensor_sharding_to_named_sharding(
+        sdy_mesh_to_reactant_mesh(MLIR.IR.attr(mesh_op, "mesh"), global_device_ids),
+        MLIR.IR.Attribute(mlir_attr),
+    )
+end
 
 end

--- a/test/sharding.jl
+++ b/test/sharding.jl
@@ -132,8 +132,8 @@ end
         x_ra = Reactant.to_rarray(
             x; sharding=Sharding.NamedSharding(mesh, (("data", "model"), nothing))
         )
-        @test Array(@jit shardy_passes = :default fn_test2(x_ra)) ≈ fn_test2(x)
-        @test Reactant.to_number(@jit shardy_passes = :default sum(x_ra)) ≈ sum(x)
+        @test Array(@jit shardy_passes = :xla_default fn_test2(x_ra)) ≈ fn_test2(x)
+        @test Reactant.to_number(@jit shardy_passes = :xla_default sum(x_ra)) ≈ sum(x)
 
         @test Array(@jit shardy_passes = :to_mhlo_shardings fn_test3(x_ra)) ≈ fn_test3(x)
         @test Reactant.to_number(@jit shardy_passes = :to_mhlo_shardings sum(x_ra)) ≈ sum(x)
@@ -153,8 +153,8 @@ end
             ),
         )
 
-        @test Array(@jit shardy_passes = :default fn_test2(x_ra)) ≈ fn_test2(x)
-        @test Reactant.to_number(@jit shardy_passes = :default sum(x_ra)) ≈ sum(x)
+        @test Array(@jit shardy_passes = :xla_default fn_test2(x_ra)) ≈ fn_test2(x)
+        @test Reactant.to_number(@jit shardy_passes = :xla_default sum(x_ra)) ≈ sum(x)
 
         @test Array(@jit shardy_passes = :to_mhlo_shardings fn_test3(x_ra)) ≈ fn_test3(x)
         @test Reactant.to_number(@jit shardy_passes = :to_mhlo_shardings sum(x_ra)) ≈ sum(x)
@@ -262,7 +262,7 @@ end
             x; sharding=Sharding.NamedSharding(mesh, ("data", "model"))
         )
 
-        @test Array(@jit shardy_passes = :default sum(x_ra; dims=2)) ≈ sum(x; dims=2)
+        @test Array(@jit shardy_passes = :xla_default sum(x_ra; dims=2)) ≈ sum(x; dims=2)
         @test Array(@jit shardy_passes = :to_mhlo_shardings sum(x_ra; dims=2)) ≈
             sum(x; dims=2)
 
@@ -271,7 +271,7 @@ end
             x; sharding=Sharding.NamedSharding(mesh, ("data", "model"))
         )
 
-        @test Array(@jit shardy_passes = :default fn_test2(x_ra)) ≈ fn_test2(x)
+        @test Array(@jit shardy_passes = :xla_default fn_test2(x_ra)) ≈ fn_test2(x)
         @test Array(@jit shardy_passes = :to_mhlo_shardings fn_test2(x_ra)) ≈ fn_test2(x)
 
         @testset "Handle Sub-Axis Info" begin
@@ -332,7 +332,7 @@ end
         x_ra_arr = Array(x_ra)
         z_ra_arr = fn(x_ra_arr, y_ra_arr)
 
-        z_ra = @jit shardy_passes = :default fn(x_ra, y_ra)
+        z_ra = @jit shardy_passes = :xla_default fn(x_ra, y_ra)
         y_ra_final = Array(y_ra)
 
         @test z_ra_arr ≈ Array(z_ra)

--- a/test/sharding.jl
+++ b/test/sharding.jl
@@ -132,8 +132,8 @@ end
         x_ra = Reactant.to_rarray(
             x; sharding=Sharding.NamedSharding(mesh, (("data", "model"), nothing))
         )
-        @test Array(@jit shardy_passes = :xla_default fn_test2(x_ra)) ≈ fn_test2(x)
-        @test Reactant.to_number(@jit shardy_passes = :xla_default sum(x_ra)) ≈ sum(x)
+        @test Array(@jit shardy_passes = :none fn_test2(x_ra)) ≈ fn_test2(x)
+        @test Reactant.to_number(@jit shardy_passes = :none sum(x_ra)) ≈ sum(x)
 
         @test Array(@jit shardy_passes = :to_mhlo_shardings fn_test3(x_ra)) ≈ fn_test3(x)
         @test Reactant.to_number(@jit shardy_passes = :to_mhlo_shardings sum(x_ra)) ≈ sum(x)
@@ -153,8 +153,8 @@ end
             ),
         )
 
-        @test Array(@jit shardy_passes = :xla_default fn_test2(x_ra)) ≈ fn_test2(x)
-        @test Reactant.to_number(@jit shardy_passes = :xla_default sum(x_ra)) ≈ sum(x)
+        @test Array(@jit shardy_passes = :none fn_test2(x_ra)) ≈ fn_test2(x)
+        @test Reactant.to_number(@jit shardy_passes = :none sum(x_ra)) ≈ sum(x)
 
         @test Array(@jit shardy_passes = :to_mhlo_shardings fn_test3(x_ra)) ≈ fn_test3(x)
         @test Reactant.to_number(@jit shardy_passes = :to_mhlo_shardings sum(x_ra)) ≈ sum(x)
@@ -209,7 +209,7 @@ end
         @test contains(repr(hlo), "sharding_constraint")
         hlo = @code_hlo shardy_passes = :to_mhlo_shardings fn_with_constraint(x_ra)
         @test !contains(repr(hlo), "sharding_constraint")
-        @test length(collect(eachmatch(r"mhlo.sharding", repr(hlo)))) == 5
+        @test length(collect(eachmatch(r"mhlo.sharding", repr(hlo)))) == 6
 
         z = Reactant.to_rarray(x; sharding=constraint)
         res = @jit fn_with_constraint(x_ra)
@@ -235,7 +235,7 @@ end
             x_ra_no_sharding
         )
         @test !contains(repr(hlo), "sharding_constraint")
-        @test length(collect(eachmatch(r"mhlo.sharding", repr(hlo)))) == 5
+        @test length(collect(eachmatch(r"mhlo.sharding", repr(hlo)))) == 6
 
         res = @jit fn_with_constraint(x_ra_no_sharding)
         @test x .+ x ≈ Array(res)
@@ -262,7 +262,7 @@ end
             x; sharding=Sharding.NamedSharding(mesh, ("data", "model"))
         )
 
-        @test Array(@jit shardy_passes = :xla_default sum(x_ra; dims=2)) ≈ sum(x; dims=2)
+        @test Array(@jit shardy_passes = :none sum(x_ra; dims=2)) ≈ sum(x; dims=2)
         @test Array(@jit shardy_passes = :to_mhlo_shardings sum(x_ra; dims=2)) ≈
             sum(x; dims=2)
 
@@ -271,7 +271,7 @@ end
             x; sharding=Sharding.NamedSharding(mesh, ("data", "model"))
         )
 
-        @test Array(@jit shardy_passes = :xla_default fn_test2(x_ra)) ≈ fn_test2(x)
+        @test Array(@jit shardy_passes = :none fn_test2(x_ra)) ≈ fn_test2(x)
         @test Array(@jit shardy_passes = :to_mhlo_shardings fn_test2(x_ra)) ≈ fn_test2(x)
 
         @testset "Handle Sub-Axis Info" begin
@@ -332,7 +332,7 @@ end
         x_ra_arr = Array(x_ra)
         z_ra_arr = fn(x_ra_arr, y_ra_arr)
 
-        z_ra = @jit shardy_passes = :xla_default fn(x_ra, y_ra)
+        z_ra = @jit shardy_passes = :none fn(x_ra, y_ra)
         y_ra_final = Array(y_ra)
 
         @test z_ra_arr ≈ Array(z_ra)


### PR DESCRIPTION
As per discussion with @GleasonK on slack, we can't safely run `canonicalize` just after propagation.

* For `xla_default` we are still running propagation outside XLA since we need to extract the sdy shardings (xref #1020). (changed the name because :default wasn't our "default" :P)
* `to_mhlo_shardings` goes all the way and does the full export and drops the sdy attributes (and runs cse, being added upstream to sdy pipeline as well)
* `:none` doesn't run any passes and exists to allow a nicer printing of the generated mlir for end users