### PR TITLE
fix: don't delete the compiled function

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1520,9 +1520,6 @@ function compile_mlir!(
                 )
             end
 
-            MLIR.API.mlirOperationDestroy(compiled_f.operation)
-            compiled_f.operation = MLIR.API.MlirOperation(C_NULL)
-
             compiled_f = func_with_padding
             in_tys = in_tys_padded
         end


### PR DESCRIPTION
the compiled function might not get inlined