### PR TITLE
[Compiler] Set `toolkit` to `XLA.CUDA_DATA_DIR`

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1190,10 +1190,7 @@ function compile_mlir!(
 
     optimize isa Bool && (optimize = ifelse(optimize, :all, :none))
 
-    toolkit = ""
-    if isdefined(Reactant_jll, :ptxas_path)
-        toolkit = Reactant_jll.ptxas_path[1:(end - length("/bin/ptxas"))]
-    end
+    toolkit = XLA.CUDA_DATA_DIR[]
 
     if backend == "cpu" || backend == "tpu"
         kern = "lower-kernel{backend=cpu},canonicalize"


### PR DESCRIPTION
I'm not even sure this variable is used for anything concrete, it's used in https://github.com/EnzymeAD/Reactant.jl/blob/dc0863066313faf7181bbda6e6eed9e2186128b9/src/Compiler.jl#L1216 and https://github.com/EnzymeAD/Reactant.jl/blob/dc0863066313faf7181bbda6e6eed9e2186128b9/src/Compiler.jl#L1223 but as far as I can tell that `toolkitPath` doesn't do much.