### PR TITLE
allow tobatch !== nothing if shapes match

### DIFF
--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -1303,7 +1303,7 @@ Base.@nospecializeinfer function make_tracer(
         end
         res = if toscalar
             TracedRNumber{T}((path,), nothing)
-        elseif tobatch !== nothing
+        elseif tobatch !== nothing && prev.shape != tobatch
             error("This should not happen...")
         else
             TracedRArray{T,N}((path,), prev.mlir_data, size(prev))


### PR DESCRIPTION
`error("This should not happen...")` got hit with automatic function call insertion and this seemed to fix it.
@avik-pal am I correct in thinking that all is well if the shape matches, I'm not understanding the tobatch logic fully.