### PR TITLE
`@trace if` return nothing in branches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Reactant"
 uuid = "3c362404-f566-11ee-1572-e11a4b42c853"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>", "Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>", "Paul Berg <paul@plutojl.org>", "Avik Pal <avikpal@mit.edu>", "Mosè Giordano <mose@gnu.org>"]
-version = "0.2.113"
+version = "0.2.114"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -86,7 +86,7 @@ Preferences = "1.4"
 PythonCall = "0.9"
 Random = "1.10"
 Random123 = "1.7"
-ReactantCore = "0.1.9"
+ReactantCore = "0.1.10"
 Reactant_jll = "0.0.187"
 ScopedValues = "1.3.0"
 Scratch = "1.2"

--- a/lib/ReactantCore/Project.toml
+++ b/lib/ReactantCore/Project.toml
@@ -1,7 +1,7 @@
 name = "ReactantCore"
 uuid = "a3311ec8-5e00-46d5-b541-4f83e724a433"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>", "Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>", "Paul Berg <paul@plutojl.org>", "Avik Pal <avikpal@mit.edu>"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 ExpressionExplorer = "21656369-7473-754a-2065-74616d696c43"

--- a/lib/ReactantCore/src/ReactantCore.jl
+++ b/lib/ReactantCore/src/ReactantCore.jl
@@ -318,6 +318,7 @@ function trace_if(mod, expr; store_last_line=nothing, depth=0, track_numbers)
         end
     else
         expr.args[2]
+        nothing # explicitly return nothing to prevent branches from returning different types
     end
 
     true_branch_symbols = ExpressionExplorer.compute_symbols_state(true_block)
@@ -361,6 +362,7 @@ function trace_if(mod, expr; store_last_line=nothing, depth=0, track_numbers)
         end
     else
         else_block
+        nothing # explicitly return nothing to prevent branches from returning different types
     end
 
     false_branch_symbols = ExpressionExplorer.compute_symbols_state(false_block)


### PR DESCRIPTION
if the value if the result value in an if-statement is not required.
This is assuming use of the trace macro adheres to the docs:
```
  Currently Supported
  ===================

    •  if conditions (with elseif and other niceties) (@trace if ...)

    •  if statements with a preceeding assignment (@trace a = if ...) (note the positioning of the macro needs to be before the assignment and not before the if)
```