### PR TITLE
[CI] Disambiguate formatting jobs even more

### DIFF
--- a/.github/workflows/format-pr-bazel.yml
+++ b/.github/workflows/format-pr-bazel.yml
@@ -24,7 +24,7 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: Format code
+        commit-message: Format Bazel code
         title: 'Format Bazel code of branch "main"'
         branch: format-main-bazel
         delete-branch: true

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -1,4 +1,4 @@
-name: Format 'main'
+name: Format Julia code on 'main'
 
 on:
   schedule:
@@ -34,7 +34,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Format code
+          commit-message: Format Julia code
           title: 'Format Julia code of branch "main"'
           branch: format-main-julia
           delete-branch: true


### PR DESCRIPTION
Minor follow up to #1430: disambiguate also the commit message, besides the PR title.  Also, change name of workflow for the Julia formatting job, for clarity (but the workflow name was already different from the Bazel one)