### PR TITLE
Don't use `fmap` in traced ifs

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -13,7 +13,6 @@ using ..Reactant:
     MissingTracedValue,
     unwrapped_eltype
 using ReactantCore: ReactantCore
-using Functors: fmap
 
 function mlir_type(x::Union{RNumber,RArray})::MLIR.IR.Type
     return MLIR.IR.TensorType(collect(Int, size(x)), MLIR.IR.Type(unwrapped_eltype(x)))
@@ -2376,7 +2375,7 @@ end
         cond.mlir_data; true_branch=tb_region, false_branch=fb_region, result_0=result_types
     )
 
-    corrected_traced_results = fmap(traced_false_results, traced_true_results) do fr, tr
+    corrected_traced_results = map(zip(traced_false_results, traced_true_results)) do (fr, tr)
         if fr isa MissingTracedValue && tr isa MissingTracedValue
             return fr
         elseif fr isa MissingTracedValue


### PR DESCRIPTION
`MissingTracedValue`s are only created as top-level objects in the if-else return tuple AFAICT. This means we don't need to recurse through the whole object structure and can simply map the outer level directly.
(@glou-nes)