### PR TITLE
feat: xla/mhlo export passes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Reactant"
 uuid = "3c362404-f566-11ee-1572-e11a4b42c853"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>", "Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>", "Paul Berg <paul@plutojl.org>", "Avik Pal <avikpal@mit.edu>", "Mosè Giordano <mose@gnu.org>"]
-version = "0.2.145"
+version = "0.2.146"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -90,7 +90,7 @@ PythonCall = "0.9.25"
 Random = "1.10"
 Random123 = "1.7"
 ReactantCore = "0.1.15"
-Reactant_jll = "0.0.218"
+Reactant_jll = "0.0.219"
 ScopedValues = "1.3.0"
 Scratch = "1.2"
 Sockets = "1.10"

--- a/src/xla/HloModule.jl
+++ b/src/xla/HloModule.jl
@@ -11,6 +11,14 @@ function free_hlo_module(hlo_module)
     @ccall MLIR.API.mlir_c.FreeHloModule(hlo_module.ptr::Ptr{Cvoid})::Cvoid
 end
 
+function HloModule(mod::MLIR.IR.Module)
+    return HloModule(
+        @ccall MLIR.API.mlir_c.convertMlirModuleToHloModule(
+            mod::MLIR.API.MlirModule
+        )::Ptr{Cvoid}
+    )
+end
+
 function Base.show(io::IO, hlo_module::HloModule)
     GC.@preserve hlo_module begin
         str = @ccall MLIR.API.mlir_c.HloModuleToString(hlo_module.ptr::Ptr{Cvoid})::Cstring

--- a/test/buffer_donation.jl
+++ b/test/buffer_donation.jl
@@ -25,7 +25,7 @@ end
     hlo = @code_hlo(donate_fill_x_with_2(a, b))
     @test length(findall("tf.aliasing_output = 0", repr(hlo))) == 1
 
-    (; preserved_args) = Reactant.Compiler.compile_xla(donate_fill_x_with_2, (a, b))[3]
+    (; preserved_args) = Reactant.Compiler.compile_xla(donate_fill_x_with_2, (a, b))[4]
     preserved_args_idx = last.(preserved_args)
     @test preserved_args_idx == [1] # only `y`(i.e. `b`) is preserved
 
@@ -36,7 +36,7 @@ end
     hlo = @code_hlo(donate_inplace_mul(a, b))
     @test length(findall("tf.aliasing_output = 0", repr(hlo))) == 1
 
-    (; preserved_args) = Reactant.Compiler.compile_xla(donate_inplace_mul, (a, b))[3]
+    (; preserved_args) = Reactant.Compiler.compile_xla(donate_inplace_mul, (a, b))[4]
     preserved_args_idx = last.(preserved_args)
     @test preserved_args_idx == [1] # only `y`(i.e. `b`) is preserved
 
@@ -71,7 +71,7 @@ end
     z = Reactant.to_rarray(ones(3))
 
     @code_hlo assert_nonallocating = true update_inplace!(x, y, z)
-    (; preserved_args) = Reactant.Compiler.compile_xla(update_inplace!, (x, y, z))[3]
+    (; preserved_args) = Reactant.Compiler.compile_xla(update_inplace!, (x, y, z))[4]
     preserved_args_idx = last.(preserved_args)
     @test preserved_args_idx == [1, 2] # y and z are both preserved (preserved_args is 0-indexed)
 

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -240,6 +240,6 @@ end
 
 @testset "chlo legalize" begin
     x_ra = Reactant.to_rarray(rand(Float32, 128))
-    hlo = @code_hlo legalize_chlo_to_stablehlo=true fn_test(x_ra)
+    hlo = @code_hlo legalize_chlo_to_stablehlo = true fn_test(x_ra)
     @test occursin("mhlo.topk", repr(hlo))
 end


### PR DESCRIPTION
- [x] `legalize_chlo_to_stablehlo` needs additional passes to actually be performant
- [x] xla before optimizations HLO
- [x] `@code_mhlo` without running XLA compile
- [x] https://github.com/EnzymeAD/Enzyme-JAX/pull/1165
- [x] Separate out the JLL changes
- [x] new jll
