### PR TITLE
Add a new method of getindex

### DIFF
--- a/ext/ReactantOffsetArraysExt.jl
+++ b/ext/ReactantOffsetArraysExt.jl
@@ -44,6 +44,13 @@ function Base.getindex(
     return getindex(parent(x), offset_indices)
 end
 
+function Base.getindex(
+    x::OffsetVector{Reactant.TracedRNumber{T}, Reactant.TracedRArray{T, 1}}, indices::Base.OneTo{Int}
+) where {T}
+    offset_indices = indices .- x.offsets[1]
+    return getindex(parent(x), offset_indices)
+end
+
 parentindex(r::OffsetArrays.IdOffsetRange, i) = i .- r.offset
 function Base.getindex(
     a::OffsetArray{<:Reactant.TracedRNumber,N}, indices::Vararg{Union{Int,AbstractArray},N}


### PR DESCRIPTION
Added a new method of `getindex` for an OffsetVector of tracedRNumber and tracedRArray and Base.oneto

@wsmoses