### PR TITLE
Add test cases for add operation in NNlib.scatter

### DIFF
--- a/test/nn/nnlib.jl
+++ b/test/nn/nnlib.jl
@@ -631,9 +631,10 @@ end
     end
 
     @testset "scatter gradient" begin
-
-        dst = Float32[3 3 4 4 5
-                     5 5 6 6 7]
+        dst = Float32[
+            3 3 4 4 5
+            5 5 6 6 7
+        ]
         dst_ca = Reactant.to_rarray(dst)
 
         src = ones(Float32, 2, 5)
@@ -657,14 +658,12 @@ end
             return derivs, val
         end
 
-        test_gradient_compiled = @compile test_gradient(test_scatter, dst_ca, src_ca, idx_ca)
+        test_gradient_compiled = @compile test_gradient(
+            test_scatter, dst_ca, src_ca, idx_ca
+        )
 
         grads_enz, loss_enz = Enzyme.gradient(
-            Enzyme.ReverseWithPrimal,
-            Const(test_scatter),
-            dst,
-            src,
-            idx
+            Enzyme.ReverseWithPrimal, Const(test_scatter), dst, src, idx
         )
         grads_ca, loss_ca = test_gradient_compiled(test_scatter, dst_ca, src_ca, idx_ca)
 


### PR DESCRIPTION
This PR implements test cases to confirm the functionality of the add operation in the reverse diff of the scatter operation.
See this PR for details:
https://github.com/EnzymeAD/Enzyme-JAX/pull/1299