### PR TITLE
Fix typedef and undef ctors for ConcreteRArray and ConcreteRNumber

### DIFF
--- a/ext/ReactantKernelAbstractionsExt.jl
+++ b/ext/ReactantKernelAbstractionsExt.jl
@@ -26,7 +26,7 @@ function Base.getproperty(x::ReactantBackend, sym::Symbol)
 end
 
 function KA.allocate(::ReactantBackend, ::Type{T}, dims::Tuple) where {T}
-    return ConcreteRArray(undef, T, dims)
+    return ConcreteRArray{T}(undef, dims)
 end
 
 function KA.zeros(b::ReactantBackend, ::Type{T}, dims::Tuple) where {T}

--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -378,8 +378,8 @@ end
     device::Union{Nothing,XLA.PJRT.Device}=nothing,
     sharding::Sharding.AbstractSharding=Sharding.NoSharding(),
 ) where {S}
-    return ConcretePJRTArray(
-        undef, S, dims; client=client, idx=idx, device=device, sharding=sharding
+    return ConcretePJRTArray{S}(
+        undef, dims; client=client, idx=idx, device=device, sharding=sharding
     )
 end
 
@@ -410,7 +410,7 @@ function Base.similar(a::ConcreteIFRTArray{T}, ::Type{S}=T, dims::Dims=size(a)) 
 end
 Base.similar(a::ConcreteIFRTArray, dims::Dims) = similar(a, eltype(a), dims)
 function Base.similar(::Type{ConcreteIFRTArray{T}}, dims) where {T}
-    return ConcreteIFRTArray(undef, T, dims)
+    return ConcreteIFRTArray{T}(undef, dims)
 end
 
 # Broadcasting interface

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -440,10 +440,6 @@ end
     ::UndefInitializer, shape::Integer...; kwargs...
 ) where {T<:Number} = ConcreteRArray{T}(undef, Dims(shape); kwargs...)
 
-@deprecate ConcreteRArray(
-    ::UndefInitializer, ::Type{T}, shape::Dims; kwargs...
-) where {T<:Number} ConcreteRArray{T}(undef, shape; kwargs...)
-
 """
     ConcreteRNumber(
         x::Number;

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -478,7 +478,7 @@ function ConcretePJRTArray{T}(
     idx::Union{Int,Nothing}=nothing,
     device::Union{Nothing,XLA.AbstractDevice}=nothing,
     sharding::Sharding.AbstractSharding=Sharding.NoSharding(),
-) where {T<:Number}
+) where {T}
     theclient, thedevice = _select_client_and_device(client, idx, device, sharding)
     sharded_data, shardinfo = sharding(theclient, thedevice, T, shape)
     N = length(shape)
@@ -493,7 +493,7 @@ function ConcreteIFRTArray{T}(
     idx::Union{Int,Nothing}=nothing,
     device::Union{Nothing,XLA.AbstractDevice}=nothing,
     sharding::Sharding.AbstractSharding=Sharding.NoSharding(),
-) where {T<:Number}
+) where {T}
     theclient, thedevice = _select_client_and_device(client, idx, device, sharding)
     N = length(shape)
     # ToDo: How to avoid allocating dummy array on host?

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -452,18 +452,16 @@ Depending on the Reactant `xla_runtime` preference setting, `ConcreteRArray`
 is an alias for `ConcretePJRTNumber` or `ConcreteIFRTNumber`. User code should
 use `ConcreteRNumber`.
 """
-const ConcreteRNumber = @static if XLA.REACTANT_XLA_RUNTIME == "PJRT"
-    ConcretePJRTNumber
+const ConcreteRNumber{T} = @static if XLA.REACTANT_XLA_RUNTIME == "PJRT"
+    ConcretePJRTNumber{T}
 elseif XLA.REACTANT_XLA_RUNTIME == "IFRT"
-    ConcreteIFRTNumber
+    ConcreteIFRTNumber{T}
 end
 
 ## Other Aliases based on the set preferences
 @static if XLA.REACTANT_XLA_RUNTIME == "PJRT"
-    const ConcreteRNumber = ConcretePJRTNumber
     const AnyConcreteRArray = AnyConcretePJRTArray
 elseif XLA.REACTANT_XLA_RUNTIME == "IFRT"
-    const ConcreteRNumber = ConcreteIFRTNumber
     const AnyConcreteRArray = AnyConcreteIFRTArray
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -430,15 +430,14 @@ Depending on the Reactant `xla_runtime` preference setting, `ConcreteRArray`
 is an alias for `ConcretePJRTArray` or `ConcreteIFRTArray`. User code should
 use `ConcreteRArray`.
 """
-const ConcreteRArray{T,N} = @static if XLA.REACTANT_XLA_RUNTIME == "PJRT"
-    ConcretePJRTArray{T,N}
+const ConcreteRArray = @static if XLA.REACTANT_XLA_RUNTIME == "PJRT"
+    ConcretePJRTArray
 elseif XLA.REACTANT_XLA_RUNTIME == "IFRT"
-    ConcreteIFRTArray{T,N}
+    ConcreteIFRTArray
 end
 
-@inline ConcreteRArray{T}(
-    ::UndefInitializer, shape::Integer...; kwargs...
-) where {T<:Number} = ConcreteRArray{T}(undef, Dims(shape); kwargs...)
+@inline ConcreteRArray{T}(::UndefInitializer, shape::Integer...; kwargs...) where {T} =
+    ConcreteRArray{T}(undef, Dims(shape); kwargs...)
 
 """
     ConcreteRNumber(
@@ -458,10 +457,10 @@ Depending on the Reactant `xla_runtime` preference setting, `ConcreteRArray`
 is an alias for `ConcretePJRTNumber` or `ConcreteIFRTNumber`. User code should
 use `ConcreteRNumber`.
 """
-const ConcreteRNumber{T} = @static if XLA.REACTANT_XLA_RUNTIME == "PJRT"
-    ConcretePJRTNumber{T}
+const ConcreteRNumber = @static if XLA.REACTANT_XLA_RUNTIME == "PJRT"
+    ConcretePJRTNumber
 elseif XLA.REACTANT_XLA_RUNTIME == "IFRT"
-    ConcreteIFRTNumber{T}
+    ConcreteIFRTNumber
 end
 
 ## Other Aliases based on the set preferences

--- a/test/layout.jl
+++ b/test/layout.jl
@@ -17,10 +17,6 @@ using Test
         undef, Int32(100), Int16(10); client=client, idx=idx, device=device
     ) isa ConcreteRArray{Float32,2}
 
-    @test_deprecated ConcreteRArray(
-        undef, Float32, (100, 10); client=client, idx=idx, device=device
-    ) isa ConcreteRArray{Float32,2}
-
     @test ConcreteRNumber(Float32(4.2)) isa ConcreteRNumber{Float32}
 
     @test ConcreteRNumber(Float16(4.2); client=client, idx=idx, device=device) isa

--- a/test/layout.jl
+++ b/test/layout.jl
@@ -10,16 +10,29 @@ using Test
     @test ConcreteRArray{Float32}(undef, (100, 10)) isa ConcreteRArray{Float32,2}
 
     @test ConcreteRArray{Float32}(
-        undef, (100, 10); idx=idx, client=client, device=device
+        undef, (100, 10); client=client, idx=idx, device=device
     ) isa ConcreteRArray{Float32,2}
 
     @test ConcreteRArray{Float32}(
-        undef, Int32(100), Int16(10); idx=idx, client=client, device=device
+        undef, Int32(100), Int16(10); client=client, idx=idx, device=device
     ) isa ConcreteRArray{Float32,2}
 
     @test_deprecated ConcreteRArray(
-        undef, Float32, (100, 10); idx=idx, client=client, device=device
+        undef, Float32, (100, 10); client=client, idx=idx, device=device
     ) isa ConcreteRArray{Float32,2}
+
+    @test ConcreteRNumber(Float32(4.2)) isa ConcreteRNumber{Float32}
+
+    @test ConcreteRNumber(Float16(4.2); client=client, idx=idx, device=device) isa
+        ConcreteRNumber{Float16}
+
+    @test ConcreteRNumber{Float32}(Float32(4.2); client=client, idx=idx, device=device) isa
+        ConcreteRNumber{Float32}
+
+    @test ConcreteRNumber{Float16}(Float32(4.2)) isa ConcreteRNumber{Float16}
+
+    @test ConcreteRNumber{Float32}(Float16(4.2); client=client, idx=idx, device=device) isa
+        ConcreteRNumber{Float32}
 
     x = reshape([1.0, 2.0, 3.0, 4.0], (2, 2))
 

--- a/test/layout.jl
+++ b/test/layout.jl
@@ -2,6 +2,25 @@ using Reactant
 using Test
 
 @testset "Layout" begin
+    client = Reactant.XLA.default_backend()
+    device = Reactant.XLA.default_device()
+    sharding = Sharding.NoSharding()
+    idx = 0
+
+    @test ConcreteRArray{Float32}(undef, (100, 10)) isa ConcreteRArray{Float32,2}
+
+    @test ConcreteRArray{Float32}(
+        undef, (100, 10); idx=idx, client=client, device=device
+    ) isa ConcreteRArray{Float32,2}
+
+    @test ConcreteRArray{Float32}(
+        undef, Int32(100), Int16(10); idx=idx, client=client, device=device
+    ) isa ConcreteRArray{Float32,2}
+
+    @test_deprecated ConcreteRArray(
+        undef, Float32, (100, 10); idx=idx, client=client, device=device
+    ) isa ConcreteRArray{Float32,2}
+
     x = reshape([1.0, 2.0, 3.0, 4.0], (2, 2))
 
     y = Reactant.to_rarray(x)


### PR DESCRIPTION
I don't know what I was thinking in #1558, but Julia convention is of course
`ArrayType{T}(undef, dims)` and `ArrayType{T}(undef, dims...)`, but *not* `ArrayType(undef, T, dims)`.

Also, the typedef for `ConcreteRArray` was missing `T` and `N` parameters and the typedefs for `ConcreteRNumber` was missing `T`,

This PR fixes that (with deprecation for `ConcreteRArray(undef, T, dims; kwargs...)`) and adds tests.