### PR TITLE
feat: define a `@opcall` macro for better debug info

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -10,6 +10,8 @@ import KernelAbstractions as KA
 using LLVM: LLVM
 using Libdl
 
+using Reactant.Ops: @opcall
+
 const ReactantKernelAbstractionsExt = Base.get_extension(
     Reactant, :ReactantKernelAbstractionsExt
 )
@@ -469,7 +471,7 @@ function Adapt.adapt_storage(ka::ReactantKernelAdaptor, xs::DenseCuArray)
     return Adapt.adapt_storage(ka, Array(xs))
 end
 function Adapt.adapt_storage(ka::ReactantKernelAdaptor, xs::Array)
-    return Adapt.adapt_storage(ka, Reactant.Ops.constant(xs))
+    return Adapt.adapt_storage(ka, @opcall(constant(xs)))
 end
 function Adapt.adapt_structure(
     to::ReactantKernelAdaptor, bc::Broadcast.Broadcasted{Style,<:Any,Type{T}}

--- a/ext/ReactantNNlibExt/Ops.jl
+++ b/ext/ReactantNNlibExt/Ops.jl
@@ -12,17 +12,19 @@ function reduce_window(
 
     padding = collect(Int64, reshape([padding..., 0, 0, 0, 0], (2, N))')
 
-    return Ops.reduce_window(
-        f,
-        [materialize_traced_array(x)],
-        [Ops.constant(T(init))];
-        window_dimensions=[kernel_size..., 1, 1],
-        window_strides=[stride..., 1, 1],
-        window_dilations=[dilation..., 1, 1],
-        padding_low=padding[:, 1],
-        padding_high=padding[:, 2],
-        output_shape=Int[output_spatial_shapes..., size(x, N - 1), size(x, N)],
-        base_dilations=ones(Int, N),
+    return @opcall(
+        reduce_window(
+            f,
+            [materialize_traced_array(x)],
+            [@opcall(constant(T(init)))];
+            window_dimensions=[kernel_size..., 1, 1],
+            window_strides=[stride..., 1, 1],
+            window_dilations=[dilation..., 1, 1],
+            padding_low=padding[:, 1],
+            padding_high=padding[:, 2],
+            output_shape=Int[output_spatial_shapes..., size(x, N - 1), size(x, N)],
+            base_dilations=ones(Int, N),
+        )
     )[1]
 end
 
@@ -31,7 +33,7 @@ function upsample_linear(
 ) where {T}
     W, _, _ = size(x)
 
-    out_idxs = Ops.iota(Int32, [out_size[1]]; iota_dimension=1)
+    out_idxs = @opcall iota(Int32, [out_size[1]]; iota_dimension=1)
     iw0, iw1, w0_λ, w1_λ = source_idx_and_λ(rwidth, out_idxs, align_corners, W)
 
     x0 = x[iw0, :, :]
@@ -45,8 +47,8 @@ function upsample_linear(
 ) where {T}
     W, H, _, _ = size(x)
 
-    out_width = Ops.iota(Int32, [out_size[1]]; iota_dimension=1)
-    out_height = Ops.iota(Int32, [out_size[2]]; iota_dimension=1)
+    out_width = @opcall iota(Int32, [out_size[1]]; iota_dimension=1)
+    out_height = @opcall iota(Int32, [out_size[2]]; iota_dimension=1)
 
     iw0, iw1, w0_λ, w1_λ = source_idx_and_λ(rwidth, out_width, align_corners, W)
     ih0, ih1, h0_λ, h1_λ = source_idx_and_λ(rheight, out_height, align_corners, H)
@@ -72,9 +74,9 @@ function upsample_linear(
 ) where {T}
     W, H, D, _, _ = size(x)
 
-    out_width = Ops.iota(Int32, [out_size[1]]; iota_dimension=1)
-    out_height = Ops.iota(Int32, [out_size[2]]; iota_dimension=1)
-    out_depth = Ops.iota(Int32, [out_size[3]]; iota_dimension=1)
+    out_width = @opcall iota(Int32, [out_size[1]]; iota_dimension=1)
+    out_height = @opcall iota(Int32, [out_size[2]]; iota_dimension=1)
+    out_depth = @opcall iota(Int32, [out_size[3]]; iota_dimension=1)
 
     iw0, iw1, w0_λ, w1_λ = source_idx_and_λ(rwidth, out_width, align_corners, W)
     ih0, ih1, h0_λ, h1_λ = source_idx_and_λ(rheight, out_height, align_corners, H)

--- a/ext/ReactantNNlibExt/ReactantNNlibExt.jl
+++ b/ext/ReactantNNlibExt/ReactantNNlibExt.jl
@@ -7,6 +7,7 @@ using Reactant:
 
 using Reactant.TracedUtils:
     TracedUtils, materialize_traced_array, get_mlir_data, set_mlir_data!
+using Reactant.Ops: @opcall
 
 using ReactantCore: @trace
 using LinearAlgebra: LinearAlgebra, triu

--- a/ext/ReactantOneHotArraysExt.jl
+++ b/ext/ReactantOneHotArraysExt.jl
@@ -3,6 +3,7 @@ module ReactantOneHotArraysExt
 using OneHotArrays
 using Reactant
 using Reactant: TracedRArray, TracedRNumber, TracedUtils, Ops
+using Reactant.Ops: @opcall
 
 function Reactant.traced_type_inner(
     @nospecialize(_::Type{OneHotArrays.OneHotArray{T,N,Np1,I}}),
@@ -35,9 +36,9 @@ function TracedUtils.materialize_traced_array(r::OneHotArrays.OneHotArray)
 
     linear_indices =
         TracedUtils.promote_to(TracedRArray{Int64,ndims(r.indices)}, indices) .+
-        Ops.iota(Int64, [B]; iota_dimension=1) .* N
+        @opcall(iota(Int64, [B]; iota_dimension=1)) .* N
 
-    z = Ops.fill(false, (N, B))
+    z = @opcall(fill(false, (N, B)))
     z[linear_indices] = fill(true, length(linear_indices))
     return reshape(z, size(r))
 end

--- a/ext/ReactantPythonCallExt/ReactantPythonCallExt.jl
+++ b/ext/ReactantPythonCallExt/ReactantPythonCallExt.jl
@@ -2,6 +2,7 @@ module ReactantPythonCallExt
 
 using PythonCall
 using Reactant: Reactant, TracedRArray
+using Reactant.Ops: @opcall
 
 const jaxptr = Ref{Py}()
 const jnpptr = Ref{Py}()

--- a/ext/ReactantPythonCallExt/pycall.jl
+++ b/ext/ReactantPythonCallExt/pycall.jl
@@ -12,7 +12,7 @@ function PythonCall.pycall(f::Py, arg0::TracedRArray, argNs::TracedRArray...; kw
     end
 
     lowered = jax.jit(f).lower(inputs...)
-    res = Reactant.Ops.hlo_call(pyconvert(String, lowered.as_text()), arg0, argNs...)
+    res = @opcall hlo_call(pyconvert(String, lowered.as_text()), arg0, argNs...)
 
     return length(res) == 0 ? nothing : res[1]
 end

--- a/ext/ReactantSpecialFunctionsExt.jl
+++ b/ext/ReactantSpecialFunctionsExt.jl
@@ -2,16 +2,17 @@ module ReactantSpecialFunctionsExt
 using SpecialFunctions
 using Reactant: Ops, Reactant, TracedRNumber, ReactantFloat, ReactantInt, ReactantFloatInt
 using Reactant.TracedRNumberOverrides: float
+using Reactant.Ops: @opcall
 
 for fn in [:digamma, :erf, :erfc, (:loggamma, :lgamma)]
     (fns, fno) = fn isa Tuple ? fn : (fn, fn)
     @eval(function SpecialFunctions.$fns(x::TracedRNumber{<:ReactantFloatInt})
-        return Ops.$fno(float(x))
+        return @opcall $fno(float(x))
     end)
 end
 
 function SpecialFunctions.gamma(x::TracedRNumber{<:ReactantFloat})
-    return exp(Ops.lgamma(float(x)))
+    return exp(@opcall(lgamma(float(x))))
 end
 
 function SpecialFunctions.gamma(n::TracedRNumber{<:ReactantInt})
@@ -29,13 +30,14 @@ end
 # SpecialFunctions.invdigamma
 
 function SpecialFunctions.trigamma(x::TracedRNumber{<:ReactantFloatInt})
-    return Ops.polygamma(Ops.constant(Float64(1)), float(x))#TODO: change Ops definition
+    #TODO: change Ops definition
+    return @opcall(polygamma(@opcall(constant(Float64(1))), float(x)))
 end
 
 function SpecialFunctions.polygamma(
     n::TracedRNumber{<:ReactantFloatInt}, x::TracedRNumber{<:ReactantFloatInt}
 )
-    return Ops.polygamma(float(n), float(x))
+    return @opcall polygamma(float(n), float(x))
 end
 
 # SpecialFunctions.gamma_inc
@@ -112,7 +114,7 @@ end
 function SpecialFunctions.zeta(
     z::TracedRNumber{T}, s::TracedRNumber{T}
 ) where {T<:ReactantFloatInt}
-    return Ops.zeta(z, s)
+    return @opcall zeta(z, s)
 end
 
 end # module ReactantSpecialFunctionsExt

--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -750,7 +750,7 @@ function Base.fill(
 )
     output_shardings = Sharding.is_sharded(sharding) ? Dict(1 => sharding) : nothing
     fn = Reactant.compile((); output_shardings) do
-        return Ops.fill(val, collect(Int64, dims))
+        return @opcall fill(val, collect(Int64, dims))
     end
     return fn()
 end

--- a/src/ControlFlow.jl
+++ b/src/ControlFlow.jl
@@ -1,11 +1,11 @@
 function ReactantCore.traced_if(
     cond::TracedRNumber{Bool}, true_fn::TFn, false_fn::FFn, args; track_numbers=Number
 ) where {TFn,FFn}
-    return Ops.if_condition(cond, true_fn, false_fn, args...; track_numbers)
+    return @opcall if_condition(cond, true_fn, false_fn, args...; track_numbers)
 end
 
 function ReactantCore.traced_call(f::Function, args...)
-    return Ops.call(f, args...)
+    return @opcall call(f, args...)
 end
 
 function ReactantCore.traced_while(
@@ -17,7 +17,7 @@ function ReactantCore.traced_while(
     checkpointing=false,
     mincut=false,
 ) where {CFn,BFn}
-    return Ops.while_loop(
+    return @opcall while_loop(
         cond_fn, body_fn, args...; track_numbers, verify_arg_names, checkpointing, mincut
     )
 end

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1,6 +1,6 @@
 # This module reflects the HLO ops defined in the openxla/stablehlo repo (plus some extras).
 # If you want to add some check or test, the StableHLO spec should be taken as the source of truth, not the Julia or Reactant semantics.
-# Julia and Reactant semantics should be considered on the higher abstractions that use these ops.
+# Julia and Reactant semantics should be considered on the higher abstractions that use these 
 module Ops
 using ..MLIR: MLIR
 using ..MLIR.Dialects: stablehlo, chlo, enzyme, enzymexla
@@ -13,6 +13,72 @@ using ..Reactant:
     MissingTracedValue,
     unwrapped_eltype
 using ReactantCore: ReactantCore
+
+function _function_macro_error()
+    throw(ArgumentError("`caller_function` is not available in this context"))
+end
+
+macro caller_function()
+    return esc(
+        quote
+            $(Expr(:isdefined, :var"#self#")) || $(_function_macro_error)()
+            var"#self#"
+        end,
+    )
+end
+
+"""
+    @opcall fn(args...; kwargs...)
+
+This call is expanded to `Reactant.Ops.fn(args...; kwargs..., location)` with the location
+of the callsite. This enables better debug info to be propagated about the source location
+of different  It is recommended to use this macro for calling into any function in
+`Reactant.Ops.<function name>`.
+"""
+macro opcall(expr)
+    if !isa(expr, Expr) || expr.head != :call
+        error("@opcall expects a function call")
+    end
+
+    # Extract function name and arguments
+    func = expr.args[1]
+    args = expr.args[2:end]
+
+    # Generate location info at the callsite
+    location_expr = :($(mlir_stacktrace)(
+        joinpath(string(var"#self#"), $(string(func))),
+        $(string(__source__.file)),
+        $(__source__.line),
+    ))
+
+    # Separate positional and keyword arguments
+    pos_args = []
+    kw_args = []
+
+    for arg in args
+        if isa(arg, Expr) && arg.head == :kw
+            push!(kw_args, arg)
+        elseif isa(arg, Expr) && arg.head == :parameters
+            append!(kw_args, arg.args)
+        else
+            push!(pos_args, arg)
+        end
+    end
+
+    # Add location as a keyword argument
+    push!(kw_args, Expr(:kw, :location, location_expr))
+
+    # Reconstruct the call expression
+    func_full = getproperty(Ops, func)
+
+    if isempty(kw_args)
+        new_expr = Expr(:call, func_full, pos_args...)
+    else
+        new_expr = Expr(:call, func_full, Expr(:parameters, kw_args...), pos_args...)
+    end
+
+    return esc(new_expr)
+end
 
 function mlir_type(x::Union{RNumber,RArray})::MLIR.IR.Type
     return MLIR.IR.TensorType(collect(Int, size(x)), MLIR.IR.Type(unwrapped_eltype(x)))
@@ -691,7 +757,7 @@ end
 
     if type ∈ ("FFT", "IFFT")
         if !(T <: Complex)
-            x = Ops.complex(x, fill(T(0), size(x); location); location)
+            x = complex(x, fill(T(0), size(x); location); location)
         end
         Tout = Base.complex(T)
         rsize = size(x)
@@ -704,7 +770,7 @@ end
         end
     elseif type == "IRFFT"
         if !(T <: Complex)
-            x = Ops.complex(x, fill(T(0), size(x); location); location)
+            x = complex(x, fill(T(0), size(x); location); location)
         end
         Tout = Base.real(T)
         rsize = let rsize = collect(Int64, size(x))
@@ -1321,9 +1387,7 @@ end
     )
     new_shape = collect(Int64, size(x))
     new_shape[dimension] = 1
-    return (
-        Ops.reshape(values, new_shape; location), Ops.reshape(indices, new_shape; location)
-    )
+    return (reshape(values, new_shape; location), reshape(indices, new_shape; location))
 end
 
 @noinline function iota(
@@ -1425,11 +1489,13 @@ end
             fill(uT(nbits - Reactant.nmantissa(T)), size(output); location);
             location,
         ),
-        fill(reinterpret(uT, T(1)), size(output); location),
+        fill(reinterpret(uT, T(1)), size(output); location);
+        location,
     )
     output = subtract(
         bitcast_convert(TracedRArray{T,length(shape)}, float_bits; location),
-        fill(T(1), size(output); location),
+        fill(T(1), size(output); location);
+        location,
     )
     return (; output_state, output)
 end
@@ -1620,14 +1686,14 @@ function _hlo_call_name(orig_name, module_suffix)
 end
 
 """
-    Ops.hlo_call(mlir_code::String, args::Vararg{AnyTracedRArray}...; func_name::String="main") -> NTuple{N, AnyTracedRArray}
+    hlo_call(mlir_code::String, args::Vararg{AnyTracedRArray}...; func_name::String="main") -> NTuple{N, AnyTracedRArray}
 
 Given a MLIR module given as a string, calls the function identified by the `func_name` keyword parameter (default "main")
 with the provided arguments and return a tuple for each result of the call.
 
 ```julia-repl
 julia> Reactant.@jit(
-          Ops.hlo_call(
+          hlo_call(
               \"\"\"
               module {
                 func.func @main(%arg0: tensor<3xf32>, %arg1: tensor<3xf32>) -> tensor<3xf32> {
@@ -1954,6 +2020,7 @@ end
     verify_arg_names=nothing,
     checkpointing=false,
     mincut=false,
+    location=mlir_stacktrace("while_loop", @__FILE__, @__LINE__),
 ) where {CFn,BFn}
     # TODO: detect and prevent mutation within the condition
 
@@ -2018,6 +2085,7 @@ end
         result_0=input_types,
         cond=cond_reg,
         body=body_reg,
+        location,
     )
 
     if !mincut
@@ -2034,7 +2102,12 @@ end
 end
 
 @noinline function if_condition(
-    cond::TracedRNumber{Bool}, true_fn::TFn, false_fn::FFn, args...; track_numbers
+    cond::TracedRNumber{Bool},
+    true_fn::TFn,
+    false_fn::FFn,
+    args...;
+    track_numbers,
+    location=mlir_stacktrace("if_condition", @__FILE__, @__LINE__),
 ) where {TFn,FFn}
     true_fn_names = (gensym(:true_fn_args), gensym(:true_result), gensym(:true_fn_resargs))
     false_fn_names = (
@@ -2155,7 +2228,7 @@ end
 
     false_fn_args = false_fn_names[1]
     MLIR.IR.activate!(false_fn_body)
-    Ops.activate_constant_context!(false_fn_body)
+    activate_constant_context!(false_fn_body)
     fb_result = try
         for (i, arg) in enumerate(fb_linear_args)
             # find the right path to index the traced arg.
@@ -2179,7 +2252,7 @@ end
         end
         Reactant.call_with_reactant(false_fn, fb_traced_args...)
     finally
-        Ops.deactivate_constant_context!(false_fn_body)
+        deactivate_constant_context!(false_fn_body)
         MLIR.IR.deactivate!(false_fn_body)
     end
 
@@ -2261,7 +2334,7 @@ end
 
     # finalize the true branch by adding the missing values
     MLIR.IR.activate!(true_fn_body)
-    Ops.activate_constant_context!(true_fn_body)
+    activate_constant_context!(true_fn_body)
     tb_corrected_linear_results = Reactant.TracedType[]
     try
         for (i, path) in enumerate(tb_paths)
@@ -2273,12 +2346,12 @@ end
         end
     finally
         MLIR.IR.deactivate!(true_fn_body)
-        Ops.deactivate_constant_context!(true_fn_body)
+        deactivate_constant_context!(true_fn_body)
     end
 
     # finalize the false branch by adding the missing values
     MLIR.IR.activate!(false_fn_body)
-    Ops.activate_constant_context!(false_fn_body)
+    activate_constant_context!(false_fn_body)
     fb_corrected_linear_results = Reactant.TracedType[]
     try
         for (i, path) in enumerate(fb_paths)
@@ -2290,7 +2363,7 @@ end
         end
     finally
         MLIR.IR.deactivate!(false_fn_body)
-        Ops.deactivate_constant_context!(false_fn_body)
+        deactivate_constant_context!(false_fn_body)
     end
 
     # All MissingTracedValues must be replaced with zeroes
@@ -2311,23 +2384,23 @@ end
         elseif tr isa MissingTracedValue
             @assert !(fr isa MissingTracedValue)
             MLIR.IR.activate!(true_fn_body)
-            Ops.activate_constant_context!(true_fn_body)
+            activate_constant_context!(true_fn_body)
             try
                 tb_corrected_linear_results[i] = zero(fr)
             finally
                 MLIR.IR.deactivate!(true_fn_body)
-                Ops.deactivate_constant_context!(true_fn_body)
+                deactivate_constant_context!(true_fn_body)
             end
             fr
         elseif fr isa MissingTracedValue
             @assert !(tr isa MissingTracedValue)
             MLIR.IR.activate!(false_fn_body)
-            Ops.activate_constant_context!(false_fn_body)
+            activate_constant_context!(false_fn_body)
             try
                 fb_corrected_linear_results[i] = zero(tr)
             finally
                 MLIR.IR.deactivate!(false_fn_body)
-                Ops.deactivate_constant_context!(false_fn_body)
+                deactivate_constant_context!(false_fn_body)
             end
             tr
         else
@@ -2342,29 +2415,29 @@ end
     @assert length(all_paths) == length(result_types) + length(both_missing)
 
     MLIR.IR.activate!(true_fn_body)
-    Ops.activate_constant_context!(true_fn_body)
+    activate_constant_context!(true_fn_body)
     try
         vals = MLIR.IR.Value[
             Reactant.TracedUtils.get_mlir_data(res) for
             res in tb_corrected_linear_results if !(res isa MissingTracedValue)
         ]
-        MLIR.Dialects.stablehlo.return_(vals)
+        MLIR.Dialects.stablehlo.return_(vals; location)
     finally
         MLIR.IR.deactivate!(true_fn_body)
-        Ops.deactivate_constant_context!(true_fn_body)
+        deactivate_constant_context!(true_fn_body)
     end
 
     MLIR.IR.activate!(false_fn_body)
-    Ops.activate_constant_context!(false_fn_body)
+    activate_constant_context!(false_fn_body)
     try
         vals = MLIR.IR.Value[
             Reactant.TracedUtils.get_mlir_data(res) for
             res in fb_corrected_linear_results if !(res isa MissingTracedValue)
         ]
-        MLIR.Dialects.stablehlo.return_(vals)
+        MLIR.Dialects.stablehlo.return_(vals; location)
     finally
         MLIR.IR.deactivate!(false_fn_body)
-        Ops.deactivate_constant_context!(false_fn_body)
+        deactivate_constant_context!(false_fn_body)
     end
 
     # With the corrected results, we can compile the true and false branches
@@ -2412,7 +2485,11 @@ end
 
     @assert length(all_paths) == length(result_types) + length(both_missing)
     if_compiled = MLIR.Dialects.stablehlo.if_(
-        cond.mlir_data; true_branch=tb_region, false_branch=fb_region, result_0=result_types
+        cond.mlir_data;
+        true_branch=tb_region,
+        false_branch=fb_region,
+        result_0=result_types,
+        location,
     )
 
     corrected_traced_results =
@@ -2446,7 +2523,7 @@ end
     return corrected_traced_results
 end
 
-@noinline function call(f, args...)
+@noinline function call(f, args...; location=mlir_stacktrace("call", @__FILE__, @__LINE__))
     seen = Reactant.OrderedIdDict()
     cache_key = []
     Reactant.make_tracer(seen, (f, args...), cache_key, Reactant.TracedToTypes)
@@ -2512,6 +2589,7 @@ end
         mlir_caller_args;
         result_0=mlir_result_types,
         callee=MLIR.IR.FlatSymbolRefAttribute(f_name),
+        location,
     )
 
     seen_results = Reactant.OrderedIdDict()
@@ -2885,14 +2963,14 @@ end
         permutation[i + length(batch_dims)] = d
     end
 
-    res = only(batch(f, [Ops.transpose(A, permutation; location)], batch_shape; location))
+    res = only(batch(f, [transpose(A, permutation; location)], batch_shape; location))
     if ndims(res) != length(permutation)
-        res = Ops.reshape(
+        res = reshape(
             res,
             vcat(collect(Int64, size(res)), ones(Int64, length(permutation) - ndims(res))),
         )
     end
-    return Ops.transpose(res, invperm(permutation); location)
+    return transpose(res, invperm(permutation); location)
 end
 
 @noinline function batch(

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1592,7 +1592,8 @@ end
 @noinline function select(
     pred::Union{TracedRArray{Bool,N},TracedRNumber{Bool}},
     on_true::TracedRArray{T,N},
-    on_false::TracedRArray{T,N},
+    on_false::TracedRArray{T,N};
+    location=mlir_stacktrace("select", @__FILE__, @__LINE__),
 ) where {T,N}
     @assert size(on_true) == size(on_false) "`on_true` and `on_false` must have the same size"
     @assert size(pred) == size(on_true) || size(pred) == () "`pred` must have the same size as `on_true`/`on_false` or be a scalar"
@@ -1603,13 +1604,17 @@ end
             on_true.mlir_data,
             on_false.mlir_data;
             result=mlir_type(TracedRArray{T,N}, size(on_true)),
+            location,
         ),
     )
     return TracedRArray{T,N}((), res, size(on_true))
 end
 
 @noinline function select(
-    pred::TracedRNumber{Bool}, on_true::TracedRNumber{T}, on_false::TracedRNumber{T}
+    pred::TracedRNumber{Bool},
+    on_true::TracedRNumber{T},
+    on_false::TracedRNumber{T};
+    location=mlir_stacktrace("select", @__FILE__, @__LINE__),
 ) where {T}
     res = MLIR.IR.result(
         stablehlo.select(
@@ -1617,6 +1622,7 @@ end
             on_true.mlir_data,
             on_false.mlir_data;
             result=mlir_type(TracedRArray{T,0}, ()),
+            location,
         ),
     )
     return TracedRNumber{T}((), res)

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -844,9 +844,9 @@ end
 end
 
 @noinline function clamp(
-    min::T, x::Union{TracedRArray{T,N},TracedRNumber{T}}, max::T
+    min::T, x::Union{TracedRArray{T,N},TracedRNumber{T}}, max::T; kwargs...
 ) where {T,N}
-    return clamp(constant(min), x, constant(max))
+    return clamp(constant(min), x, constant(max); kwargs...)
 end
 
 # function convolution(

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -81,19 +81,6 @@ export Sharding
 
 include("utils.jl")
 
-function TracedRArray{T}(data::MLIR.IR.Value) where {T}
-    data_type = MLIR.IR.type(data)
-    if T == eltype(MLIR.IR.julia_type(data_type))
-        return TracedRArray{T,ndims(data_type)}((), data, size(data_type))
-    end
-    tdata = TracedRArray(data)
-    return Ops.convert(TracedRArray{T,ndims(data_type)}, tdata)
-end
-
-function TracedRArray(data::MLIR.IR.Value)
-    return TracedRArray{eltype(MLIR.IR.julia_type(MLIR.IR.type(data)))}(data)
-end
-
 isa_traced_soa(_) = false
 isa_traced_soa(::TracedRArray) = true
 isa_traced_soa(::AbstractRange{<:TracedRNumber}) = true
@@ -109,6 +96,23 @@ unwrapped_eltype(::TracedRNumber{T}) where {T} = T
 unwrapped_eltype(::Type{<:AbstractArray{T,N}}) where {T,N} = unwrapped_eltype(T)
 unwrapped_eltype(::AbstractArray{T,N}) where {T,N} = unwrapped_eltype(T)
 
+include("Ops.jl")
+
+using .Ops: @opcall
+
+function TracedRArray{T}(data::MLIR.IR.Value) where {T}
+    data_type = MLIR.IR.type(data)
+    if T == eltype(MLIR.IR.julia_type(data_type))
+        return TracedRArray{T,ndims(data_type)}((), data, size(data_type))
+    end
+    tdata = TracedRArray(data)
+    return @opcall convert(TracedRArray{T,ndims(data_type)}, tdata)
+end
+
+function TracedRArray(data::MLIR.IR.Value)
+    return TracedRArray{eltype(MLIR.IR.julia_type(MLIR.IR.type(data)))}(data)
+end
+
 promote_traced_type(a::Type, b::Type) = Base.promote_type(a, b)
 
 aos_to_soa(x::AbstractArray) = x
@@ -123,7 +127,7 @@ function aos_to_soa(x::Array{TracedRNumber{T}}) where {T}
             x[i] = TracedUtils.promote_to(TracedRNumber{T}, 0)
         end
     end
-    return Ops.reshape(vcat(x...), size(x)...)
+    return @opcall reshape(vcat(x...), size(x)...)
 end
 
 function aos_to_soa(x::AbstractArray{<:ConcretePJRTNumber{T}}) where {T}
@@ -161,7 +165,6 @@ function aos_to_soa(x::AbstractArray{<:ConcreteIFRTNumber{T}}) where {T}
     return x_c
 end
 
-include("Ops.jl")
 include("TracedUtils.jl")
 
 include("TracedRNumber.jl")

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -1353,18 +1353,20 @@ function scan_impl!(
     padding_low = zeros(Int64, N)
     padding_low[dims] = size(input, dims) - 1
 
-    reduction_result = @opcall(reduce_window(
-        op,
-        [materialize_traced_array(input)],
-        [init];
-        window_dimensions=window_dimensions,
-        window_strides=ones(Int64, N),
-        base_dilations=ones(Int64, N),
-        window_dilations=ones(Int64, N),
-        padding_low=padding_low,
-        padding_high=zeros(Int64, N),
-        output_shape=collect(Int64, size(output)),
-    ))[1]
+    reduction_result = @opcall(
+        reduce_window(
+            op,
+            [materialize_traced_array(input)],
+            [init];
+            window_dimensions=window_dimensions,
+            window_strides=ones(Int64, N),
+            base_dilations=ones(Int64, N),
+            window_dilations=ones(Int64, N),
+            padding_low=padding_low,
+            padding_high=zeros(Int64, N),
+            output_shape=collect(Int64, size(output)),
+        )
+    )[1]
     copyto!(output, reduction_result)
 
     return output

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -2,6 +2,7 @@ module TracedRNumberOverrides
 
 using ..Reactant:
     Reactant, TracedRNumber, TracedRArray, TracedUtils, Ops, MLIR, unwrapped_eltype
+using ..Ops: @opcall
 using ReactantCore
 using Adapt
 
@@ -38,7 +39,7 @@ end
 function Base.isfinite(x::TracedRNumber{<:Complex})
     return isfinite(real(x)) & isfinite(imag(x))
 end
-Base.isfinite(x::TracedRNumber{<:AbstractFloat}) = Ops.is_finite(x)
+Base.isfinite(x::TracedRNumber{<:AbstractFloat}) = @opcall is_finite(x)
 
 function Base.isnan(x::TracedRNumber{<:Complex})
     return isnan(real(x)) | isnan(imag(x))
@@ -48,7 +49,7 @@ function Base.isnan(x::TracedRNumber{T}) where {T<:AbstractFloat}
 end
 
 Base.isinf(x::TracedRNumber{<:Complex}) = isinf(real(x)) | isinf(imag(x))
-Base.isinf(x::TracedRNumber{<:AbstractFloat}) = Ops.is_inf(x)
+Base.isinf(x::TracedRNumber{<:AbstractFloat}) = @opcall is_inf(x)
 Base.isinf(::TracedRNumber{<:Integer}) = false
 
 function Base.show(io::IOty, X::TracedRNumber{T}) where {T,IOty<:Union{IO,IOContext}}
@@ -103,7 +104,7 @@ end
 function TracedUtils.promote_to(::Type{TracedRNumber{T}}, rhs) where {T}
     if rhs isa TracedRNumber
         rhs isa TracedRNumber{T} && return rhs
-        return Ops.convert(TracedRNumber{T}, rhs)
+        return @opcall convert(TracedRNumber{T}, rhs)
     end
     if rhs isa TracedRArray{<:Any,0}
         return TracedUtils.promote_to(
@@ -111,8 +112,8 @@ function TracedUtils.promote_to(::Type{TracedRNumber{T}}, rhs) where {T}
             TracedRNumber{Reactant.unwrapped_eltype(rhs)}((), rhs.mlir_data),
         )
     end
-    rhs isa Number && return TracedUtils.promote_to(TracedRNumber{T}, Ops.fill(T(rhs)))
-    return TracedUtils.promote_to(TracedRNumber{T}, Ops.constant(collect(rhs)))
+    rhs isa Number && return TracedUtils.promote_to(TracedRNumber{T}, @opcall fill(T(rhs)))
+    return TracedUtils.promote_to(TracedRNumber{T}, @opcall constant(collect(rhs)))
 end
 
 function TracedUtils.promote_to(::TracedRNumber{T}, rhs) where {T}
@@ -128,11 +129,11 @@ for (aT, bT) in (
         T = promote_type(unwrapped_eltype(a), unwrapped_eltype(b))
         a = TracedUtils.promote_to(TracedRNumber{T}, a)
         b = TracedUtils.promote_to(TracedRNumber{T}, b)
-        return Ops.complex(a, b)
+        return @opcall complex(a, b)
     end
 end
 
-Base.Complex(x::TracedRNumber{<:Real}) = Ops.complex(x, zero(x))
+Base.Complex(x::TracedRNumber{<:Real}) = @opcall complex(x, zero(x))
 Base.Complex(x::TracedRNumber{<:Complex}) = x
 
 for (jlop, hloop) in (
@@ -148,19 +149,19 @@ for (jlop, hloop) in (
     @eval function $(jlop)(
         @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::TracedRNumber{T})
     ) where {T}
-        return Ops.$(hloop)(lhs, rhs)
+        return @opcall $(hloop)(lhs, rhs)
     end
 end
 
 function Base.rem(
     @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::Number)
 ) where {T}
-    return Ops.remainder(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
+    return @opcall remainder(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
 end
 function Base.rem(
     @nospecialize(lhs::Number), @nospecialize(rhs::TracedRNumber{T})
 ) where {T}
-    return Ops.remainder(TracedUtils.promote_to(TracedRNumber{T}, lhs), rhs)
+    return @opcall remainder(TracedUtils.promote_to(TracedRNumber{T}, lhs), rhs)
 end
 
 # Based on https://github.com/JuliaLang/julia/blob/39255d47db7657950ff1c82137ecec5a70bae622/base/float.jl#L608-L617
@@ -182,13 +183,13 @@ function Base.mod(
 end
 
 function Base.div(@nospecialize(lhs::TracedRNumber{T}), rhs) where {T<:Integer}
-    return Ops.divide(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
+    return @opcall divide(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
 end
 
 function Base.div(
     @nospecialize(lhs::TracedRNumber{T}), rhs, ::typeof(RoundDown)
 ) where {T<:Integer}
-    return Ops.divide(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
+    return @opcall divide(lhs, TracedUtils.promote_to(TracedRNumber{T}, rhs))
 end
 
 function Base.:/(
@@ -210,7 +211,7 @@ for (jlop, hloop, hlocomp) in (
         function $(jlop)(
             @nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs::TracedRNumber{T})
         ) where {T}
-            return Ops.compare(lhs, rhs; comparison_direction=$(hlocomp))
+            return @opcall compare(lhs, rhs; comparison_direction=$(hlocomp))
         end
 
         function $(jlop)(@nospecialize(lhs::TracedRNumber{T}), @nospecialize(rhs)) where {T}
@@ -271,7 +272,7 @@ function Base.ifelse(
     @nospecialize(x::TracedRNumber{T}),
     @nospecialize(y::TracedRNumber{T})
 ) where {T}
-    return Ops.select(pred, x, y)
+    return @opcall select(pred, x, y)
 end
 
 function Base.ifelse(
@@ -325,60 +326,60 @@ for (T1, T2) in zip((Bool, Integer), (Bool, Integer))
     T = promote_type(T1, T2)
     @eval begin
         function Base.:&(x::TracedRNumber{<:$(T1)}, y::TracedRNumber{<:$(T2)})
-            return Ops.and(
+            return @opcall and(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.:&(x::TracedRNumber{<:$(T1)}, y::$(T2))
-            return Ops.and(
+            return @opcall and(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.:&(x::$(T1), y::TracedRNumber{<:$(T2)})
-            return Ops.and(
+            return @opcall and(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.:|(x::TracedRNumber{<:$(T1)}, y::TracedRNumber{<:$(T2)})
-            return Ops.or(
+            return @opcall or(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.:|(x::TracedRNumber{<:$(T1)}, y::$(T2))
-            return Ops.or(
+            return @opcall or(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.:|(x::$(T1), y::TracedRNumber{<:$(T2)})
-            return Ops.or(
+            return @opcall or(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.xor(x::TracedRNumber{<:$(T1)}, y::TracedRNumber{<:$(T2)})
-            return Ops.xor(
+            return @opcall xor(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.xor(x::TracedRNumber{<:$(T1)}, y::$(T2))
-            return Ops.xor(
+            return @opcall xor(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
         function Base.xor(x::$(T1), y::TracedRNumber{<:$(T2)})
-            return Ops.xor(
+            return @opcall xor(
                 TracedUtils.promote_to(TracedRNumber{$(T)}, x),
                 TracedUtils.promote_to(TracedRNumber{$(T)}, y),
             )
         end
-        Base.:!(x::TracedRNumber{<:$(T1)}) = Ops.not(x)
+        Base.:!(x::TracedRNumber{<:$(T1)}) = @opcall not(x)
     end
 end
 
@@ -413,7 +414,7 @@ for (jlop, hloop) in (
     (:(Base.real), :real),
     (:(Base.imag), :imag),
 )
-    @eval $(jlop)(@nospecialize(lhs::TracedRNumber)) = Ops.$(hloop)(lhs)
+    @eval $(jlop)(@nospecialize(lhs::TracedRNumber)) = @opcall $(hloop)(lhs)
 end
 
 for (jlop, hloop) in (
@@ -435,15 +436,19 @@ for (jlop, hloop) in (
     (:(Base.atan), :atan),
     (:(Base.atanh), :atanh),
 )
-    @eval $(jlop)(@nospecialize(lhs::TracedRNumber{<:Integer})) = Ops.$(hloop)(float(lhs))
+    @eval $(jlop)(@nospecialize(lhs::TracedRNumber{<:Integer})) =
+        @opcall $(hloop)(float(lhs))
 end
 
 for (jlop, hloop) in
     ((:(Base.sinpi), :sine), (:(Base.cospi), :cosine), (:(Base.tanpi), :tan))
-    @eval $(jlop)(@nospecialize(lhs::TracedRNumber{T})) where {T} = Ops.$(hloop)(T(π) * lhs)
+    @eval $(jlop)(@nospecialize(lhs::TracedRNumber{T})) where {T} =
+        @opcall $(hloop)(T(π) * lhs)
 end
 
-Base.sincospi(x::TracedRNumber{T}) where {T} = Ops.sine(T(π) * x), Ops.cosine(T(π) * x)
+function Base.sincospi(x::TracedRNumber{T}) where {T}
+    return @opcall(sine(T(π) * x)), @opcall(cosine(T(π) * x))
+end
 
 Base.isreal(::TracedRNumber) = false
 Base.isreal(::TracedRNumber{<:Real}) = true
@@ -461,7 +466,7 @@ end
 for (minT, maxT) in Iterators.product((Number, TracedRNumber), (Number, TracedRNumber))
     @eval function Base.clamp(x::TracedRNumber, min::$(minT), max::$(maxT))
         T = promote_type(unwrapped_eltype(x), unwrapped_eltype(min), unwrapped_eltype(max))
-        return Ops.clamp(
+        return @opcall clamp(
             TracedUtils.promote_to(TracedRNumber{T}, min),
             TracedUtils.promote_to(TracedRNumber{T}, x),
             TracedUtils.promote_to(TracedRNumber{T}, max),
@@ -482,17 +487,17 @@ end
 
 using Reactant: ReactantFloat, ReactantInt
 
-Base.round(A::TracedRNumber{<:ReactantFloat}) = Ops.round_nearest_even(A)
+Base.round(A::TracedRNumber{<:ReactantFloat}) = @opcall round_nearest_even(A)
 Base.round(A::TracedRNumber{<:ReactantInt}) = A
-Base.floor(A::TracedRNumber{<:ReactantFloat}) = Ops.floor(A)
+Base.floor(A::TracedRNumber{<:ReactantFloat}) = @opcall floor(A)
 Base.floor(A::TracedRNumber{<:ReactantInt}) = A
-Base.ceil(A::TracedRNumber{<:ReactantFloat}) = Ops.ceil(A)
+Base.ceil(A::TracedRNumber{<:ReactantFloat}) = @opcall ceil(A)
 Base.ceil(A::TracedRNumber{<:ReactantInt}) = A
 
 function Base.unsafe_trunc(
     T::Type{<:Reactant.ReactantInt}, x::TracedRNumber{<:Reactant.ReactantFloat}
 )
-    return Ops.convert(TracedRNumber{T}, x)
+    return @opcall convert(TracedRNumber{T}, x)
 end
 
 for Ti in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UInt128)
@@ -623,9 +628,9 @@ TracedUnitRange(r::AbstractUnitRange) = TracedUnitRange(first(r), last(r))
     a = Base.oneunit(Base.zero(stop) - Base.zero(start))
     if a isa Signed
         # Signed are allowed to go negative
-        Ops.select(stop >= start, a + stop - start, a)
+        @opcall select(stop >= start, a + stop - start, a)
     else
-        Ops.select(stop >= start, a + stop - start, zero(a))
+        @opcall select(stop >= start, a + stop - start, zero(a))
     end
 end
 
@@ -928,7 +933,7 @@ end
 for (Ti, Tf) in ((Int16, Float16), (Int32, Float32), (Int64, Float64))
     @eval begin
         Base.signbit(x::TracedRNumber{$(Ti)}) = x < 0
-        Base.signbit(x::TracedRNumber{$(Tf)}) = signbit(Ops.bitcast_convert($(Ti), x))
+        Base.signbit(x::TracedRNumber{$(Tf)}) = signbit(@opcall(bitcast_convert($(Ti), x)))
     end
 end
 Base.signbit(::TracedRNumber{<:Unsigned}) = ConcretePJRTNumber(false)

--- a/src/stdlibs/Random.jl
+++ b/src/stdlibs/Random.jl
@@ -6,6 +6,7 @@ module TracedRandom
 
 using ..Reactant:
     Reactant, TracedRArray, TracedRNumber, ReactantRNG, AnyTracedRArray, TracedUtils, Ops
+using ..Reactant.Ops: @opcall
 using Random: Random, AbstractRNG
 
 @noinline make_seed(rng::AbstractRNG=Random.RandomDevice()) =
@@ -46,7 +47,7 @@ end
     rng::ReactantRNG{<:TracedRArray}, A::AnyTracedRArray{T,N}
 ) where {T,N}
     length(A) == 0 && return A
-    res = Ops.rng_bit_generator(T, rng.seed, [size(A)...]; rng.algorithm)
+    res = @opcall rng_bit_generator(T, rng.seed, [size(A)...]; rng.algorithm)
     copyto!(rng.seed, res.output_state)
     TracedUtils.set_mlir_data!(A, res.output.mlir_data)
     return A
@@ -56,7 +57,7 @@ end
     rng::ReactantRNG{<:TracedRArray}, A::AnyTracedRArray{T,N}
 ) where {T,N}
     length(A) == 0 && return A
-    res = Ops.randn(T, rng.seed, [size(A)...]; rng.algorithm)
+    res = @opcall randn(T, rng.seed, [size(A)...]; rng.algorithm)
     copyto!(rng.seed, res.output_state)
     TracedUtils.set_mlir_data!(A, res.output.mlir_data)
     return A
@@ -66,7 +67,7 @@ end
     rng::ReactantRNG{<:TracedRArray}, A::AnyTracedRArray{T,N}
 ) where {T,N}
     length(A) == 0 && return A
-    res = Ops.randexp(T, rng.seed, [size(A)...]; rng.algorithm)
+    res = @opcall randexp(T, rng.seed, [size(A)...]; rng.algorithm)
     copyto!(rng.seed, res.output_state)
     TracedUtils.set_mlir_data!(A, res.output.mlir_data)
     return A

--- a/test/integration/random.jl
+++ b/test/integration/random.jl
@@ -189,7 +189,7 @@ end
 rand_sample(rng, x) = rand(rng, eltype(x), size(x))
 
 function rand_on_device()
-    x = Reactant.Ops.fill(0.0f0, (3, 4, 5))
+    x = Reactant.@opcall fill(0.0f0, (3, 4, 5))
     rand!(x)
     return x
 end

--- a/test/optimize_comm.jl
+++ b/test/optimize_comm.jl
@@ -9,7 +9,7 @@ function rotate(x)
     return nothing
 end
 function pad(x)
-    return Reactant.Ops.pad(x, eltype(x)(0); low=[5, 0], high=[15, 0], interior=[0, 0])
+    return Reactant.@opcall pad(x, eltype(x)(0); low=[5, 0], high=[15, 0], interior=[0, 0])
 end
 
 function dus(x, y)

--- a/test/sharding.jl
+++ b/test/sharding.jl
@@ -202,7 +202,7 @@ end
 
         function fn_with_constraint(x)
             y = x .+ x
-            return Reactant.Ops.sharding_constraint(y, constraint)
+            return Reactant.@opcall sharding_constraint(y, constraint)
         end
 
         hlo = @code_hlo shardy_passes = :none fn_with_constraint(x_ra)


### PR DESCRIPTION
```julia
julia> show(IOContext(stdout, :debug => true), @code_hlo(rand_on_device()))
module @reactant_rand_on... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
  func.func @main() -> tensor<5x4x3xf32> {
    %cst = stablehlo.constant dense<1.000000e+00> : tensor<3x4x5xf32> loc(#loc)
    %c = stablehlo.constant dense<1065353216> : tensor<3x4x5xui32> loc(#loc3)
    %c_0 = stablehlo.constant dense<9> : tensor<3x4x5xui32> loc(#loc3)
    %c_1 = stablehlo.constant dense<[8678943858956034215, 12805955118569472548]> : tensor<2xui64> loc(#loc4)
    %output_state, %output = stablehlo.rng_bit_generator %c_1, algorithm =  DEFAULT : (tensor<2xui64>) -> (tensor<2xui64>, tensor<3x4x5xui32>) loc(#loc3)
    %0 = stablehlo.shift_right_logical %output, %c_0 : tensor<3x4x5xui32> loc(#loc3)
    %1 = stablehlo.or %0, %c : tensor<3x4x5xui32> loc(#loc3)
    %2 = stablehlo.bitcast_convert %1 : (tensor<3x4x5xui32>) -> tensor<3x4x5xf32> loc(#loc3)
    %3 = stablehlo.subtract %2, %cst : tensor<3x4x5xf32> loc(#loc3)
    %4 = stablehlo.transpose %3, dims = [2, 1, 0] : (tensor<3x4x5xf32>) -> tensor<5x4x3xf32> loc(#loc3)
    return %4 : tensor<5x4x3xf32> loc(#loc)
  } loc(#loc)
} loc(#loc)
#loc = loc(unknown)
#loc1 = loc("/mnt/software/lux/Reactant.jl/src/stdlibs/Random.jl":50:0)
#loc2 = loc("/mnt/software/lux/Reactant.jl/src/TracedRArray.jl":61:0)
#loc3 = loc("internal_overload_rand!/rng_bit_generator"(#loc1))
#loc4 = loc("convert/constant"(#loc2))1382
```