### PR TITLE
A comic number of backslashes to support rewriting patch files define…

### DIFF
--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -20,6 +20,11 @@ http_archive(
     sha256 = ENZYMEXLA_SHA256,
     strip_prefix = "Enzyme-JAX-" + ENZYMEXLA_COMMIT,
     urls = ["https://github.com/EnzymeAD/Enzyme-JAX/archive/{commit}.tar.gz".format(commit = ENZYMEXLA_COMMIT)],
+    patch_cmds = [
+    """
+sed -i.bak0 "s/\\\\\\\\\\\\\\\\\\/\\\\\\\\\\\\\\\\\\/:patches/@enzyme_ad\\\\\\\\\\\\\\\\\\/\\\\\\\\\\\\\\\\\\/:patches/g" workspace.bzl
+""",
+    ]
 )
 
 CUPTI_OLD = [


### PR DESCRIPTION
…d in enzyme-jax

will let https://github.com/EnzymeAD/Enzyme-JAX/pull/1337 and future patches pass