### PR TITLE
Update Clang compatibility version to 0.19

### DIFF
--- a/deps/ReactantExtra/Project.toml
+++ b/deps/ReactantExtra/Project.toml
@@ -3,7 +3,7 @@ Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 BinaryBuilderBase = "7f725544-6523-48cd-82d1-3fa08ff4056e"
 
 [compat]
-Clang = "0.18"
+Clang = "0.19"
 
 [sources]
 Clang = {url = "https://github.com/wsmoses/Clang.jl", rev = "patch-1"}


### PR DESCRIPTION
The job is failing because of the compat bound, but someone should really tests the script still works (I'm really not familiar with the binding generation stuff), since it's a breaking change _some_ breakage should be expected 