### PR TITLE
Create ROCm client via plugin

### DIFF
--- a/src/accelerators/Accelerators.jl
+++ b/src/accelerators/Accelerators.jl
@@ -2,5 +2,6 @@ module Accelerators
 
 include("TPU.jl")
 include("Metal.jl")
+include("ROCm.jl")
 
 end

--- a/src/accelerators/ROCm.jl
+++ b/src/accelerators/ROCm.jl
@@ -1,0 +1,62 @@
+module ROCm
+
+using Reactant: Reactant
+using Scratch: @get_scratch!
+using Downloads
+
+const rocm_pjrt_plugin_dir = Ref{Union{Nothing,String}}(nothing)
+
+function __init__()
+    @static if Sys.islinux()
+        Reactant.precompiling() || setup_rocm_pjrt_plugin!()
+    end
+end
+
+has_rocm() = true
+
+function setup_rocm_pjrt_plugin!()
+    path_from_env = get(ENV, "ROCM_LIBRARY_PATH", nothing)
+    if path_from_env !== nothing && ispath(path_from_env)
+        rocm_pjrt_plugin_dir[] = path_from_env
+    else
+        rocm_pjrt_plugin_dir[] = @get_scratch!("pjrt_rocm_plugin")
+    end
+    # download_rocm_pjrt_plugin_if_needed(rocm_pjrt_plugin_dir[])
+    return nothing
+end
+
+get_rocm_pjrt_plugin_dir() = rocm_pjrt_plugin_dir[]
+
+function get_rocm_pjrt_plugin_path()
+    return joinpath(get_rocm_pjrt_plugin_dir(), "xla_rocm_plugin.so")
+end
+
+# function download_rocm_pjrt_plugin_if_needed(path=nothing)
+#     path === nothing && (path = get_rocm_pjrt_plugin_dir())
+#     @assert path !== nothing "rocm_pjrt_plugin_dir is not set!"
+
+#     rocm_pjrt_plugin_path = joinpath(path, "pjrt_plugin_rocm_14.dylib")
+#     if !isfile(rocm_pjrt_plugin_path)
+#         zip_file_path = joinpath(path, "pjrt-plugin-rocm.zip")
+#         tmp_dir = joinpath(path, "tmp")
+#         Downloads.download(
+#             if Sys.ARCH === :aarch64
+#                 "https://files.pythonhosted.org/packages/09/dc/6d8fbfc29d902251cf333414cf7dcfaf4b252a9920c881354584ed36270d/jax_rocm-0.1.1-py3-none-macosx_13_0_arm64.whl"
+#             elseif Sys.ARCH === :x86_64
+#                 "https://files.pythonhosted.org/packages/87/ec/9bb7f7f0ffd06c3fb89813126b2f698636ac7a4263ed7bdd1ff7d7c94f8f/jax_rocm-0.1.1-py3-none-macosx_10_14_x86_64.whl"
+#             else
+#                 error("Unsupported architecture: $(Sys.ARCH)")
+#             end,
+#             zip_file_path,
+#         )
+#         run(`unzip -qq $(zip_file_path) -d $(tmp_dir)`)
+#         mv(
+#             joinpath(tmp_dir, "jax_plugins", "rocm_plugin", "pjrt_plugin_rocm_14.dylib"),
+#             rocm_pjrt_plugin_path,
+#         )
+#         rm(tmp_dir; recursive=true)
+#         rm(zip_file_path; recursive=true)
+#     end
+# end
+
+end # module ROCm

--- a/src/xla/IFRT/Client.jl
+++ b/src/xla/IFRT/Client.jl
@@ -115,12 +115,14 @@ const cpu_client_count = Ref(0)
 const cuda_client_count = Ref(0)
 const tpu_client_count = Ref(0)
 const metal_client_count = Ref(0)
+const rocm_client_count = Ref(0)
 
 for (backend, counter) in (
     (:CPUClient, :cpu_client_count),
     (:CUDAClient, :cuda_client_count),
     (:TPUClient, :tpu_client_count),
     (:MetalClient, :metal_client_count),
+    (:ROCmClient, :rocm_client_count),
 )
     main_fn = Symbol(:MakeIFRTPJRT, backend)
     @eval function $(backend)(args...; checkcount::Bool=true, kwargs...)
@@ -213,6 +215,22 @@ function MakeIFRTPJRTMetalClient(;
         metal_pjrt_plugin_path,
         "metal",
         "METAL";
+        node_id,
+        num_nodes,
+        distributed_runtime_client,
+    )
+end
+
+function MakeIFRTPJRTROCmClient(;
+    rocm_pjrt_plugin_path::String,
+    node_id::Integer=0,
+    num_nodes::Integer=1,
+    distributed_runtime_client::Union{Nothing,XLA.DistributedRuntimeClient}=nothing,
+)
+    return MakeIFRTPJRTClientViaPluginAPI(
+        rocm_pjrt_plugin_path,
+        "rocm",
+        "ROCM";
         node_id,
         num_nodes,
         distributed_runtime_client,

--- a/src/xla/PJRT/Client.jl
+++ b/src/xla/PJRT/Client.jl
@@ -110,12 +110,14 @@ const cpu_client_count = Ref(0)
 const cuda_client_count = Ref(0)
 const tpu_client_count = Ref(0)
 const metal_client_count = Ref(0)
+const rocm_client_count = Ref(0)
 
 for (backend, counter) in (
     (:CPUClient, :cpu_client_count),
     (:CUDAClient, :cuda_client_count),
     (:TPUClient, :tpu_client_count),
     (:MetalClient, :metal_client_count),
+    (:ROCmClient, :rocm_client_count),
 )
     main_fn = Symbol(:Make, backend)
     @eval function $(backend)(args...; checkcount::Bool=true, kwargs...)
@@ -205,6 +207,20 @@ function MakeMetalClient(;
                                                     distributed_runtime_client"
 
     return MakeClientUsingPluginAPI(metal_pjrt_plugin_path, "metal", "METAL")
+end
+
+function MakeROCmClient(;
+    rocm_pjrt_plugin_path::String,
+    node_id::Integer=0,
+    num_nodes::Integer=1,
+    distributed_runtime_client::Union{Nothing,XLA.DistributedRuntimeClient}=nothing,
+)
+    @assert node_id == 0 "`PJRT.MakeROCmClient` does not support node_id"
+    @assert num_nodes == 1 "`PJRT.MakeROCmClient` does not support num_nodes > 1"
+    @assert distributed_runtime_client === nothing "`PJRT.MakeROCmClient` does not support \
+                                                    distributed_runtime_client"
+
+    return MakeClientUsingPluginAPI(rocm_pjrt_plugin_path, "rocm", "ROCM")
 end
 
 function MakeClientUsingPluginAPI(

--- a/src/xla/XLA.jl
+++ b/src/xla/XLA.jl
@@ -221,6 +221,22 @@ for runtime in (:PJRT, :IFRT)
                     catch e
                         println(stdout, e)
                     end
+                elseif Accelerators.ROCm.has_rocm()
+                    try
+                        if was_initialized && haskey(state.clients, "rocm")
+                            XLA.free_client(state.clients["rocm"])
+                            XLA.$(runtime).rocm_client_count[] -= 1
+                        end
+                        gpu = $(runtime).ROCmClient(
+                            ;
+                            rocm_pjrt_plugin_path=Accelerators.ROCm.get_rocm_pjrt_plugin_path(),
+                            common_kwargs...
+                        )
+                        state.clients["rocm"] = gpu
+                        state.default_client = gpu
+                    catch e
+                        println(stdout, e)
+                    end
                 else
                     try
                         if was_initialized && haskey(state.clients, "cuda")


### PR DESCRIPTION
This is ***very*** preliminary at the moment, but I managed to get access to the devices, so it looks promising:
```julia-repl
julia> Reactant.devices()
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1756985457.845658 3031425 pjrt_api.cc:118] GetPjrtApi was found for rocm at /cosma/home/do006/dc-gior1/tmp/pjrt-plugin/jax_plugins/xla_rocm60/xla_rocm_plugin.so
I0000 00:00:1756985457.863487 3031425 pjrt_api.cc:96] PJRT_Api is set for device type rocm
I0000 00:00:1756985457.863510 3031425 pjrt_api.cc:167] The PJRT plugin has PJRT API version 0.55. The framework PJRT API version is 0.75.
I0000 00:00:1756985463.767717 3031425 pjrt_c_api_client.cc:133] PjRtCApiClient created.
4-element Vector{Reactant.XLA.PJRT.Device}:
 Reactant.XLA.PJRT.Device(Ptr{Nothing} @0x000000001bc36820, "ROCM:0 AMD Instinct MI300A")
 Reactant.XLA.PJRT.Device(Ptr{Nothing} @0x000000001bc36c70, "ROCM:1 AMD Instinct MI300A")
 Reactant.XLA.PJRT.Device(Ptr{Nothing} @0x000000001bc36fb0, "ROCM:2 AMD Instinct MI300A")
 Reactant.XLA.PJRT.Device(Ptr{Nothing} @0x000000001bc372f0, "ROCM:3 AMD Instinct MI300A")
```

For the record, for some reason the env var `ROCM_PATH` wasn't set in my environment and I had to manually do it to help XLA find libdevice, otherwise I was getting errors like
```
INTERNAL: bitcode module not found at ./opencl.bc
```
As usual, setting the environment variables
```sh
TF_CPP_MIN_VLOG_LEVEL=0
TF_CPP_MAX_VLOG_LEVEL=3
```
was very useful for debugging.