### PR TITLE
fix: specialize on abstractmatrix and abstractvector for repeat outer

### DIFF
--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1552,3 +1552,10 @@ map_test_1(i, xᵢ, yᵢ) = xᵢ + yᵢ + max(xᵢ, yᵢ)
     @test z ≈ z_ra
     @test z_ra ≈ gt
 end
+
+@testset "repeat specialize" begin
+    x_ra = Reactant.to_rarray(rand(Float32, 2, 3))
+
+    hlo = repr(@code_hlo(repeat(x_ra, 2, 3)))
+    @test !contains(hlo, "stablehlo.dynamic_update_slice")
+end


### PR DESCRIPTION
It was falling back to an unrolled loop (which we are excellent at folding)

```mlir
module @reactant_GridEmb... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
  func.func @main(%arg0: tensor<4x3x4x4xf32>) -> tensor<4x5x4x4xf32> {
    %cst = stablehlo.constant dense<"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ABAAAA3EABAAAA3EABAAAA3EABAAAA3E00000000000000000000000000000000ABAA2A3FABAA2A3FABAA2A3FABAA2A3F000000000000000000000000000000000000803F0000803F0000803F0000803FABAAAA3EABAAAA3EABAAAA3EABAAAA3E00000000000000000000000000000000ABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAAAA3EABAAAA3EABAAAA3EABAAAA3E0000803F0000803F0000803F0000803FABAA2A3FABAA2A3FABAA2A3FABAA2A3F00000000000000000000000000000000ABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAAAA3EABAAAA3EABAAAA3EABAAAA3EABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3FABAA2A3F0000803F0000803F0000803F0000803F0000803F0000803F0000803F0000803F000000000000000000000000000000000000803F0000803F0000803F0000803FABAAAA3EABAAAA3EABAAAA3EABAAAA3E0000803F0000803F0000803F0000803FABAA2A3FABAA2A3FABAA2A3FABAA2A3F0000803F0000803F0000803F0000803F0000803F0000803F0000803F0000803F"> : tensor<4x4x2x4xf32>
    %0 = stablehlo.transpose %arg0, dims = [3, 2, 1, 0] : (tensor<4x3x4x4xf32>) -> tensor<4x4x3x4xf32>
    %1 = stablehlo.concatenate %cst, %0, dim = 2 : (tensor<4x4x2x4xf32>, tensor<4x4x3x4xf32>) -> tensor<4x4x5x4xf32>
    %2 = stablehlo.transpose %1, dims = [3, 2, 1, 0] : (tensor<4x4x5x4xf32>) -> tensor<4x5x4x4xf32>
    return %2 : tensor<4x5x4x4xf32>
  }
}
```

But now we generate a more sensible code

```mlir
module @reactant_GridEmb... attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
  func.func @main(%arg0: tensor<4x3x5x5xf32>) -> tensor<4x5x5x5xf32> {
    %cst = stablehlo.constant dense<1.000000e+00> : tensor<5xf32>
    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<5xf32>
    %cst_1 = stablehlo.constant dense<[0.000000e+00, 1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<5xf32>
    %cst_2 = stablehlo.constant dense<4.000000e+00> : tensor<5xf32>
    %0 = stablehlo.divide %cst_1, %cst_2 : tensor<5xf32>
    %1 = stablehlo.subtract %cst, %0 : tensor<5xf32>
    %2 = stablehlo.multiply %1, %cst_0 : tensor<5xf32>
    %3 = stablehlo.add %2, %0 : tensor<5xf32>
    %4 = stablehlo.broadcast_in_dim %3, dims = [0] : (tensor<5xf32>) -> tensor<5x5x1xf32>
    %5 = stablehlo.broadcast_in_dim %3, dims = [1] : (tensor<5xf32>) -> tensor<5x5x1xf32>
    %6 = stablehlo.concatenate %4, %5, dim = 2 : (tensor<5x5x1xf32>, tensor<5x5x1xf32>) -> tensor<5x5x2xf32>
    %7 = stablehlo.broadcast_in_dim %6, dims = [3, 2, 1] : (tensor<5x5x2xf32>) -> tensor<4x2x5x5xf32>
    %8 = stablehlo.concatenate %7, %arg0, dim = 1 : (tensor<4x2x5x5xf32>, tensor<4x3x5x5xf32>) -> tensor<4x5x5x5xf32>
    return %8 : tensor<4x5x5x5xf32>
  }
}
```