### PR TITLE
refactor: standardize use of `promote_to` and `broadcast_to_size`

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1287,10 +1287,7 @@ Reactant.@reactant_overlay @noinline function (func::LLVMFunc{F,tt})(
     blk_operands = MLIR.IR.Value[]
     for idx in
         (blockdim.x, blockdim.y, blockdim.z, threaddim.x, threaddim.y, threaddim.z, shmem)
-        push!(
-            blk_operands,
-            Reactant.TracedUtils.promote_to(Reactant.TracedRNumber{Int}, idx).mlir_data,
-        )
+        push!(blk_operands, Reactant.promote_to(Reactant.TracedRNumber{Int}, idx).mlir_data)
     end
 
     @assert length(restys) == length(aliases)

--- a/ext/ReactantFillArraysExt.jl
+++ b/ext/ReactantFillArraysExt.jl
@@ -92,21 +92,19 @@ end
 
 # Materialize into a dense array
 function ReactantCore.materialize_traced_array(x::Fill{T}) where {T}
-    return TracedUtils.broadcast_to_size(
-        TracedUtils.promote_to(TracedRNumber{unwrapped_eltype(T)}, x.value), size(x)
-    )
+    return Reactant.broadcast_to_size(unwrapped_eltype(T)(x.value), size(x))
 end
 
 function ReactantCore.materialize_traced_array(x::Ones{T}) where {T}
-    return TracedUtils.broadcast_to_size(unwrapped_eltype(T)(1), size(x))
+    return Reactant.broadcast_to_size(unwrapped_eltype(T)(1), size(x))
 end
 
 function ReactantCore.materialize_traced_array(x::Zeros{T}) where {T}
-    return TracedUtils.broadcast_to_size(unwrapped_eltype(T)(0), size(x))
+    return Reactant.broadcast_to_size(unwrapped_eltype(T)(0), size(x))
 end
 
 function ReactantCore.materialize_traced_array(x::OneElement{T}) where {T}
-    y = TracedUtils.broadcast_to_size(unwrapped_eltype(T)(0), size(x))
+    y = Reactant.broadcast_to_size(unwrapped_eltype(T)(0), size(x))
     @allowscalar setindex!(y, x.val, x.ind...)
     return y
 end
@@ -114,7 +112,7 @@ end
 # some functions to avoid bad performance
 for AT in (Fill, Ones, Zeros, OneElement)
     @eval function Base.similar(x::$AT{<:TracedRNumber}, ::Type{T}, dims::Dims) where {T}
-        return TracedUtils.broadcast_to_size(unwrapped_eltype(T)(0), dims)
+        return Reactant.broadcast_to_size(unwrapped_eltype(T)(0), dims)
     end
 end
 

--- a/ext/ReactantFillArraysExt.jl
+++ b/ext/ReactantFillArraysExt.jl
@@ -92,7 +92,9 @@ end
 
 # Materialize into a dense array
 function ReactantCore.materialize_traced_array(x::Fill{T}) where {T}
-    return Reactant.broadcast_to_size(unwrapped_eltype(T)(x.value), size(x))
+    return Reactant.broadcast_to_size(
+        Reactant.promote_to(TracedRNumber{unwrapped_eltype(T)}, x.value), size(x)
+    )
 end
 
 function ReactantCore.materialize_traced_array(x::Ones{T}) where {T}

--- a/ext/ReactantNNlibExt/Implementations.jl
+++ b/ext/ReactantNNlibExt/Implementations.jl
@@ -418,11 +418,13 @@ end
 function NNlib.pad_constant(
     x::AnyTracedRArray{T,N}, pad::NTuple{N,Tuple{Int,Int}}, value
 ) where {T,N}
-    value = Reactant.promote_to(TracedRNumber{T}, value)
-    low = [i[1] for i in pad]
-    high = [i[2] for i in pad]
-    interior = [0 for i in pad]
-    return @opcall pad(materialize_traced_array(x), value; low, high, interior)
+    return @opcall pad(
+        materialize_traced_array(x),
+        Reactant.promote_to(TracedRNumber{T}, value);
+        low=[i[1] for i in pad],
+        high=[i[2] for i in pad],
+        interior=[0 for i in pad],
+    )
 end
 
 # Gather

--- a/ext/ReactantOneHotArraysExt.jl
+++ b/ext/ReactantOneHotArraysExt.jl
@@ -38,6 +38,8 @@ function ReactantCore.materialize_traced_array(r::OneHotArrays.OneHotArray)
     return reshape(z, size(r))
 end
 
+Reactant._parent(r::OneHotArrays.OneHotArray) = r.indices
+
 function Base.Array(
     r::OneHotArrays.OneHotArray{T,N,Np1,<:Reactant.AbstractConcreteArray}
 ) where {T,N,Np1}

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -2080,20 +2080,12 @@ function compile_mlir!(
                     res = linear_results[i]
                     padding = padded_inputs[res]
 
-                    pad_op = MLIR.Dialects.stablehlo.pad(
+                    pad_op = Reactant.@opcall pad(
                         results[i],
-                        Reactant.TracedUtils.promote_to(
+                        Reactant.promote_to(
                             TracedRNumber{Reactant.unwrapped_eltype(res)}, 0
-                        ).mlir_data;
-                        edge_padding_low=MLIR.IR.DenseArrayAttribute(
-                            fill(0, length(padding))
-                        ),
-                        edge_padding_high=MLIR.IR.DenseArrayAttribute(
-                            collect(reverse(padding))
-                        ),
-                        interior_padding=MLIR.IR.DenseArrayAttribute(
-                            fill(0, length(padding))
-                        ),
+                        );
+                        high=collect(reverse(padding)),
                     )
 
                     results[i] = MLIR.IR.result(pad_op, 1)

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -2080,12 +2080,20 @@ function compile_mlir!(
                     res = linear_results[i]
                     padding = padded_inputs[res]
 
-                    pad_op = Reactant.@opcall pad(
+                    pad_op = MLIR.Dialects.stablehlo.pad(
                         results[i],
-                        Reactant.promote_to(
+                        Reactant.TracedUtils.promote_to(
                             TracedRNumber{Reactant.unwrapped_eltype(res)}, 0
-                        );
-                        high=collect(reverse(padding)),
+                        ).mlir_data;
+                        edge_padding_low=MLIR.IR.DenseArrayAttribute(
+                            fill(0, length(padding))
+                        ),
+                        edge_padding_high=MLIR.IR.DenseArrayAttribute(
+                            collect(reverse(padding))
+                        ),
+                        interior_padding=MLIR.IR.DenseArrayAttribute(
+                            fill(0, length(padding))
+                        ),
                     )
 
                     results[i] = MLIR.IR.result(pad_op, 1)

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -64,8 +64,8 @@ function Enzyme.onehot(x::TracedRArray{T,N}) where {T,N}
     # TODO: Ideally we do it as a scatter -> slice but we don't implement constant
     #       folding for scatter yet.
     results = Vector{TracedRArray{T,N}}(undef, length(x))
-    pad_value = TracedUtils.promote_to(TracedRNumber{T}, 0)
-    base_value = TracedUtils.broadcast_to_size(T(1), (1,))
+    pad_value = Reactant.promote_to(TracedRNumber{T}, 0)
+    base_value = Reactant.promote_to(TracedRArray{T,1}, one(T))
     for i in eachindex(x)
         results[i] = @opcall(
             reshape(

--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -65,7 +65,7 @@ function Enzyme.onehot(x::TracedRArray{T,N}) where {T,N}
     #       folding for scatter yet.
     results = Vector{TracedRArray{T,N}}(undef, length(x))
     pad_value = Reactant.promote_to(TracedRNumber{T}, 0)
-    base_value = Reactant.promote_to(TracedRArray{T,1}, one(T))
+    base_value = Reactant.broadcast_to_size(one(T), (1,))
     for i in eachindex(x)
         results[i] = @opcall(
             reshape(

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1178,8 +1178,8 @@ end
     sample_inputs = Vector{TracedRNumber}(undef, length(xs) * 2)
     for i in eachindex(xs)
         T = Reactant.unwrapped_eltype(xs[i])
-        sample_inputs[2i - 1] = Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0)
-        sample_inputs[2i] = Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0)
+        sample_inputs[2i - 1] = Reactant.promote_to(TracedRNumber{T}, 0)
+        sample_inputs[2i] = Reactant.promote_to(TracedRNumber{T}, 0)
     end
     func =
         Reactant.TracedUtils.make_mlir_fn(
@@ -1243,10 +1243,10 @@ end
         Reactant.TracedUtils.make_mlir_fn(
             comparator,
             (
-                Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0),
-                Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0),
-                Reactant.TracedUtils.promote_to(TracedRNumber{Int32}, 0),
-                Reactant.TracedUtils.promote_to(TracedRNumber{Int32}, 0),
+                Reactant.promote_to(TracedRNumber{T}, 0),
+                Reactant.promote_to(TracedRNumber{T}, 0),
+                Reactant.promote_to(TracedRNumber{Int32}, 0),
+                Reactant.promote_to(TracedRNumber{Int32}, 0),
             ),
             (),
             "comparator",
@@ -1353,8 +1353,8 @@ end
             x, iota(Int64, collect(Int64, size(x)); iota_dimension=dimension, location)
         ],
         TracedRNumber[
-            Reactant.TracedUtils.promote_to(TracedRNumber{Bool}, false),
-            Reactant.TracedUtils.promote_to(TracedRNumber{Int64}, typemax(Int64)),
+            Reactant.promote_to(TracedRNumber, false),
+            Reactant.promote_to(TracedRNumber, typemax(Int64)),
         ],
         [dimension],
         function (x, i, y, j)
@@ -1376,8 +1376,8 @@ end
             x, iota(Int64, collect(Int64, size(x)); iota_dimension=dimension, location)
         ],
         TracedRNumber[
-            Reactant.TracedUtils.promote_to(TracedRNumber{T}, typemin(T)),
-            Reactant.TracedUtils.promote_to(TracedRNumber{Int64}, -1),
+            Reactant.promote_to(TracedRNumber{T}, typemin(T)),
+            Reactant.promote_to(TracedRNumber{Int64}, -1),
         ],
         [dimension],
         function (a₁, i₁, a₂, i₂)
@@ -1851,8 +1851,8 @@ end
     kwargs...,
 ) where {F,T,N}
     sample_inputs = (
-        Reactant.TracedUtils.promote_to(TracedRNumber{T}, zero(T)),
-        Reactant.TracedUtils.promote_to(TracedRNumber{T}, zero(T)),
+        Reactant.promote_to(TracedRNumber, zero(T)),
+        Reactant.promote_to(TracedRNumber, zero(T)),
     )
 
     compiled_fn =
@@ -2792,8 +2792,8 @@ Produces a [`Reactant.MLIR.Dialects.sdy.sharding_constraint`](@ref) operation wi
 end
 
 function _construct_reduce_function(f::F, Ts::Type...) where {F}
-    inputs_1 = [Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0) for T in Ts]
-    inputs_2 = [Reactant.TracedUtils.promote_to(TracedRNumber{T}, 0) for T in Ts]
+    inputs_1 = [Reactant.promote_to(TracedRNumber{T}, 0) for T in Ts]
+    inputs_2 = [Reactant.promote_to(TracedRNumber{T}, 0) for T in Ts]
     func =
         Reactant.TracedUtils.make_mlir_fn(
             f,
@@ -2910,11 +2910,9 @@ function standardize_start_index(
     sz::Int, start_index::Union{Integer,TracedRNumber{<:Integer}}
 )
     if (start_index isa Integer && start_index ≤ typemax(Int32)) || sz ≤ typemax(Int32)
-        start_index = Reactant.TracedUtils.promote_to(TracedRNumber{Int32}, start_index)
+        start_index = Reactant.promote_to(TracedRNumber{Int32}, start_index)
     elseif start_index isa Integer
-        start_index = Reactant.TracedUtils.promote_to(
-            TracedRNumber{eltype(start_index)}, start_index
-        )
+        start_index = Reactant.promote_to(TracedRNumber, start_index)
     end
 
     start_index = start_index - Reactant.unwrapped_eltype(start_index)(1)

--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -28,7 +28,7 @@ end
 
 @reactant_overlay @noinline function TracedRandom.default_rng()
     return ReactantRNG(
-        TracedUtils.promote_to(TracedRArray{UInt64,1}, TracedRandom.make_seed()), "DEFAULT"
+        Reactant.promote_to(TracedRArray{UInt64,1}, TracedRandom.make_seed()), "DEFAULT"
     )
 end
 

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -31,7 +31,7 @@ struct ReactantABI <: Enzyme.EnzymeCore.ABI end
 include("PrimitiveTypes.jl")
 
 function ancestor(x::AbstractArray)
-    p_x = parent(x)
+    p_x = applicable(_parent, x) ? _parent(x) : parent(x)
     p_x === x && return x
     return ancestor(p_x)
 end
@@ -55,6 +55,9 @@ end
 # A lot of packages don't define `Adapt.parent_type`. We use `_parent_type` as a way to
 # define the parent type of an array without type-piracy.
 function _parent_type end
+function _parent end
+
+_parent_type(::Array{T,N}) where {T,N} = Array{T,N}
 
 include("accelerators/Accelerators.jl")
 

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -57,7 +57,9 @@ end
 function _parent_type end
 function _parent end
 
-_parent_type(::Array{T,N}) where {T,N} = Array{T,N}
+_parent_type(::Type{Array}) = Array
+_parent_type(::Type{Array{T}}) where {T} = Array{T}
+_parent_type(::Type{Array{T,N}}) where {T,N} = Array{T,N}
 
 include("accelerators/Accelerators.jl")
 

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -124,7 +124,7 @@ function aos_to_soa(x::Array{TracedRNumber{T}}) where {T}
     isa_traced_soa(ancestor(x)) && return x
     for i in eachindex(x)
         if !isassigned(x, i)
-            x[i] = TracedUtils.promote_to(TracedRNumber{T}, 0)
+            x[i] = Reactant.promote_to(TracedRNumber{T}, 0)
         end
     end
     return @opcall reshape(vcat(x...), size(x)...)
@@ -165,6 +165,7 @@ function aos_to_soa(x::AbstractArray{<:ConcreteIFRTNumber{T}}) where {T}
     return x_c
 end
 
+include("TracedPromotion.jl")
 include("TracedUtils.jl")
 
 include("TracedRNumber.jl")

--- a/src/TracedPromotion.jl
+++ b/src/TracedPromotion.jl
@@ -1,0 +1,102 @@
+# convert julia types to traced types
+## Promote to a Traced Type
+promote_to(::TracedRArray{T,N}, rhs) where {T,N} = promote_to(TracedRArray{T,N}, rhs)
+promote_to(::TracedRNumber{T}, rhs) where {T} = promote_to(TracedRNumber{T}, rhs)
+
+## Array types
+function promote_to(::Type{TracedRArray}, rhs)
+    return promote_to(TracedRArray{unwrapped_eltype(rhs),ndims(rhs)}, rhs)
+end
+function promote_to(::Type{TracedRArray{T}}, rhs) where {T}
+    return promote_to(TracedRArray{T,ndims(rhs)}, rhs)
+end
+
+promote_to(::Type{TracedRArray{T,N}}, rhs::TracedRArray{T,N}) where {T,N} = rhs
+function promote_to(::Type{TracedRArray{T,N}}, rhs::TracedRArray{T2,N}) where {T,T2,N}
+    return @opcall convert(TracedRArray{T,N}, rhs)
+end
+
+function promote_to(
+    ::Type{TracedRArray{T,N}}, rhs::AbstractArray{<:TracedRNumber,N}
+) where {T,N}
+    return @opcall convert(TracedRArray{T,N}, aos_to_soa(materialize_traced_array(rhs)))
+end
+
+function promote_to(
+    ::Type{TracedRArray{T,1}}, rhs::Union{UnitRange,UnitRange{<:TracedRNumber}}
+) where {T}
+    return @opcall add(
+        @opcall(iota(eltype(rhs), [length(rhs)]; iota_dimension=1)),
+        @opcall(fill(first(rhs), [length(rhs)])),
+    )
+end
+
+function promote_to(
+    ::Type{TracedRArray{T,1}},
+    rhs::Union{
+        StepRange,StepRangeLen,StepRange{<:TracedRNumber},StepRangeLen{<:TracedRNumber}
+    },
+) where {T}
+    step_arr = broadcast_to_size(step(rhs), (length(rhs),))
+    iota = @opcall iota(unwrapped_eltype(rhs), [length(rhs)]; iota_dimension=1)
+    first_arr = broadcast_to_size(first(rhs), (length(rhs),))
+    return @opcall add(@opcall(multiply(step_arr, iota)), first_arr)
+end
+
+function promote_to(::Type{TracedRArray{T,1}}, rhs::Base.OneTo) where {T}
+    return promote_to(TracedRArray{T,1}, 1:last(rhs))
+end
+
+function promote_to(::Type{TracedRArray{T,N}}, rhs::AbstractArray{<:Any,N}) where {T,N}
+    if ancestor(rhs) isa AnyTracedRArray
+        return promote_to(TracedRArray{T,N}, materialize_traced_array(rhs))
+    end
+    ## fallback option, almost certainly will emit a really bad IR
+    return promote_to(TracedRArray{T,N}, @opcall(constant(rhs)))
+end
+
+## Number types
+function promote_to(::Type{TracedRNumber}, rhs)
+    return promote_to(TracedRNumber{unwrapped_eltype(rhs)}, rhs)
+end
+
+promote_to(::Type{TracedRNumber{T}}, rhs::TracedRNumber{T}) where {T} = rhs
+function promote_to(::Type{TracedRNumber{T}}, rhs::TracedRNumber{T2}) where {T,T2}
+    return @opcall convert(TracedRNumber{T}, rhs)
+end
+
+function promote_to(::Type{TracedRArray{T,0}}, rhs::TracedRNumber{T2}) where {T,T2}
+    return TracedRArray{T,0}((), @opcall(convert(TracedRNumber{T}, rhs)).mlir_data, ())
+end
+function promote_to(::Type{TracedRNumber{T}}, rhs::TracedRArray{T2,0}) where {T,T2}
+    return TracedRNumber{T}((), @opcall(convert(TracedRArray{T,0}, rhs)).mlir_data)
+end
+
+function promote_to(::Type{TracedRNumber{T}}, rhs::Number) where {T}
+    return promote_to(TracedRNumber{T}, @opcall(fill(T(rhs))))
+end
+
+## Promote to a Traced Type and broadcast to a given size
+function broadcast_to_size(arg::AbstractArray, rsize)
+    return broadcast_to_size(promote_to(TracedRArray, arg), rsize)
+end
+
+function broadcast_to_size(arg::Number, rsize)
+    return broadcast_to_size(promote_to(TracedRNumber, arg), rsize)
+end
+
+broadcast_to_size(arg::TracedRNumber, ::Tuple{}) = arg
+broadcast_to_size(arg::TracedRNumber, rsize) = @opcall fill(arg, collect(Int64, rsize))
+
+function broadcast_to_size(arg::TracedRArray, rsize)
+    return @opcall broadcast_in_dim(
+        arg, collect(Int64, 1:ndims(arg)), collect(Int64, rsize)
+    )
+end
+
+function broadcast_to_size(arg::Broadcast.Extruded, rsize)
+    rsize2 = (keep ? rsizev : 1 for (keep, rsizev) in zip(arg.keeps, rsize))
+    return broadcast_to_size(broadcast_to_size(arg.x, rsize2), rsize)
+end
+
+broadcast_to_size(arg::Base.RefValue, rsize) = arg

--- a/src/TracedPromotion.jl
+++ b/src/TracedPromotion.jl
@@ -57,7 +57,8 @@ end
 
 ## Number types
 function promote_to(::Type{TracedRNumber}, rhs)
-    return promote_to(TracedRNumber{unwrapped_eltype(rhs)}, rhs)
+    T = rhs isa AbstractIrrational ? Float64 : unwrapped_eltype(rhs)
+    return promote_to(TracedRNumber{T}, rhs)
 end
 
 promote_to(::Type{TracedRNumber{T}}, rhs::TracedRNumber{T}) where {T} = rhs

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -322,7 +322,9 @@ function _setindex_scalar!(
             @opcall(
                 dynamic_update_slice(
                     a,
-                    Reactant.broadcast_to_size(T(v), ntuple(Returns(1), N)),
+                    Reactant.broadcast_to_size(
+                        Reactant.promote_to(TracedRNumber{T}, v), ntuple(Returns(1), N)
+                    ),
                     collect(scalar_index_to_cartesian(index, size(a))),
                 )
             ),

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -37,29 +37,7 @@ Base.IndexStyle(::Type{<:TracedRArray}) = Base.IndexLinear()
 
 # This is required otherwise we will copy a tracedrarray each time
 # we use it
-function Base.convert(::Type{TracedRArray}, x::TracedRArray)
-    return x
-end
-
-function Base.convert(::Type{TracedRArray}, x::AnyTracedRArray)
-    return Base.convert(TracedRArray{unwrapped_eltype(x),ndims(x)}, x)
-end
-
-function Base.convert(::Type{TracedRArray}, x::AbstractArray)
-    return Base.convert(TracedRArray{eltype(x),ndims(x)}, x)
-end
-
-function Base.convert(::Type{TracedRArray{T,N}}, x::AbstractArray) where {T,N}
-    @assert ndims(x) == N
-    if x isa TracedRArray
-        eltype(x) == T && return x
-        return @opcall convert(TracedRArray{T,N}, x)
-    end
-    if eltype(x) <: TracedRNumber
-        return convert(TracedRArray{T,N}, aos_to_soa(materialize_traced_array(x)))
-    end
-    return convert(TracedRArray{T,N}, @opcall constant(collect(x)))
-end
+Base.convert(T::Type{<:TracedRArray}, x::AbstractArray) = Reactant.promote_to(T, x)
 
 # Base.complex
 Base.complex(x::TracedRArray{<:Real}) = complex.(x)
@@ -83,7 +61,7 @@ end
 function generate_index_list(i1, is...)
     list = reshape(i1, :, 1)
     for i in is
-        i = TracedUtils.broadcast_to_size(i, (length(i), 1))
+        i = Reactant.broadcast_to_size(i, (length(i), 1))
         lorig = size(list, 1)
         list = repeat(list, size(i, 1), 1)
         i = repeat(i; inner=(lorig, 1))
@@ -163,7 +141,7 @@ function _getindex_linear(a::TracedRArray{T,N}, indices::AbstractArray) where {T
     if !(indices isa Reactant.TracedType)
         if length(indices) == 1 && first(indices) isa CartesianIndex
             # fast-path else we will end up with a gather
-            return TracedUtils.broadcast_to_size(
+            return Reactant.broadcast_to_size(
                 @allowscalar(_getindex_cartesian(a, first(indices))), (1,)
             )
         end
@@ -190,7 +168,7 @@ function _getindex_linear(a::TracedRArray{T,N}, indices::AbstractArray) where {T
     if !(indices isa TracedRArray)
         indices = collect(indices)
         eltype(indices) <: CartesianIndex && (indices = LinearIndices(size(a))[indices])
-        indices = TracedUtils.promote_to(TracedRArray{Int,ndims(indices)}, indices)
+        indices = Reactant.promote_to(TracedRArray{Int}, indices)
     end
     return @opcall(
         reshape(
@@ -344,9 +322,7 @@ function _setindex_scalar!(
             @opcall(
                 dynamic_update_slice(
                     a,
-                    TracedUtils.broadcast_to_size(
-                        TracedUtils.promote_to(TracedRNumber{T}, v), ntuple(Returns(1), N)
-                    ),
+                    Reactant.broadcast_to_size(T(v), ntuple(Returns(1), N)),
                     collect(scalar_index_to_cartesian(index, size(a))),
                 )
             ),
@@ -376,7 +352,7 @@ function Base.setindex!(a::TracedRArray{T,N}, v, index::CartesianIndex{N}) where
             @opcall(
                 dynamic_update_slice(
                     a,
-                    TracedUtils.broadcast_to_size(T(v), ntuple(Returns(1), N)),
+                    Reactant.broadcast_to_size(T(v), ntuple(Returns(1), N)),
                     collect(Int64, index.I),
                 )
             ),
@@ -394,10 +370,7 @@ function _setindex_linear!(a::TracedRArray{T,N}, v, indices::AbstractArray) wher
                 @opcall(
                     dynamic_update_slice(
                         materialize_traced_array(vec(a)),
-                        TracedUtils.broadcast_to_size(
-                            TracedUtils.promote_to(TracedRArray{T,1}, vec(v)),
-                            (length(indices),),
-                        ),
+                        Reactant.broadcast_to_size(T.(vec(v)), (length(indices),)),
                         [first(indices)],
                     )
                 ),
@@ -411,12 +384,12 @@ function _setindex_linear!(a::TracedRArray{T,N}, v, indices::AbstractArray) wher
     if !(indices isa TracedRArray)
         indices = collect(indices)
         eltype(indices) <: CartesianIndex && (indices = LinearIndices(size(a))[indices])
-        indices = TracedUtils.promote_to(TracedRArray{Int,ndims(indices)}, indices)
+        indices = Reactant.promote_to(TracedRArray{Int,ndims(indices)}, indices)
     end
     res = @opcall scatter_setindex(
         a,
         scalar_index_to_cartesian(vec(indices), size(a)),
-        TracedUtils.promote_to(TracedRArray{T,1}, materialize_traced_array(vec(v))),
+        Reactant.promote_to(TracedRArray{T,1}, materialize_traced_array(vec(v))),
     )
     set_mlir_data!(a, get_mlir_data(res))
     return a
@@ -436,7 +409,7 @@ function Base.setindex!(a::TracedRArray{T,N}, v, indices::Vararg{Any,N}) where {
         # Base.setindex!(a::TracedRArray{T,N}, v, ::Colon) where {T,N}
         # ```
         # signature, which would be confused with this one for N=1.
-        v = TracedUtils.broadcast_to_size(v, size(a))
+        v = Reactant.broadcast_to_size(v, size(a))
         set_mlir_data!(a, get_mlir_data(v))
         return a
     end
@@ -469,7 +442,7 @@ function Base.setindex!(a::TracedRArray{T,N}, v, indices::Vararg{Any,N}) where {
 
         v = @opcall convert(
             TracedRArray{T,ndims(v)},
-            TracedUtils.promote_to(TracedRArray{unwrapped_eltype(v),ndims(v)}, v),
+            Reactant.promote_to(TracedRArray{unwrapped_eltype(v),ndims(v)}, v),
         )
 
         updates = @opcall transpose(v, invperm(gather_dims.permutation))
@@ -498,16 +471,16 @@ function Base.setindex!(a::TracedRArray{T,N}, v, indices::Vararg{Any,N}) where {
     end
 
     if v isa Number
-        v = TracedUtils.broadcast_to_size(v, length.(indices))
-        v = TracedUtils.promote_to(TracedRArray{T,N}, v)
+        v = Reactant.broadcast_to_size(v, length.(indices))
+        v = Reactant.promote_to(TracedRArray{T,N}, v)
     else
-        v = TracedUtils.promote_to(TracedRArray{T,ndims(v)}, v)
+        v = Reactant.promote_to(TracedRArray{T,ndims(v)}, v)
         non_integer_indices = [
             !(idx isa Union{Integer,TracedRNumber{<:Integer}}) for idx in indices
         ]
         broadcast_dims = findall(non_integer_indices)
         if length(broadcast_dims) == N
-            v = TracedUtils.broadcast_to_size(v, length.(indices))
+            v = Reactant.broadcast_to_size(v, length.(indices))
         else
             v = @opcall broadcast_in_dim(
                 materialize_traced_array(v),
@@ -548,22 +521,10 @@ end
 
 function Base.show(io::IOty, X::TracedRArray{T,N}) where {T,N,IOty<:Union{IO,IOContext}}
     return print(io, "TracedRArray{", T, ",", N, "N}(", X.paths, ", size=", size(X), ")")
-    # TODO this line segfaults if MLIR IR has not correctly been generated
-    # return print(io, X.mlir_data, ")")
 end
 
 function Base.permutedims(A::AnyTracedRArray{T,N}, perm) where {T,N}
     return @opcall transpose(materialize_traced_array(A), Int64[perm...])
-end
-
-TracedUtils.promote_to(::Type{TracedRArray{T,N}}, rhs) where {T,N} = TracedRArray{T,N}(rhs)
-function TracedUtils.promote_to(::TracedRArray{T,N}, rhs) where {T,N}
-    return TracedUtils.promote_to(TracedRArray{T,N}, rhs)
-end
-function TracedUtils.promote_to(
-    ::Type{TracedRArray{T,0}}, rhs::TracedRNumber{T2}
-) where {T,T2}
-    return TracedRArray{T,0}((), @opcall(convert(TracedRNumber{T}, rhs)).mlir_data, ())
 end
 
 for (jlop, hloop, hlocomp, merge) in
@@ -620,7 +581,7 @@ function overloaded_mapreduce(
         op_in_T = typeof(reduce_init)
         A = typeof(reduce_init).(A)
     end
-    reduce_init = TracedUtils.promote_to(TracedRNumber{op_in_T}, reduce_init)
+    reduce_init = Reactant.promote_to(TracedRNumber{op_in_T}, reduce_init)
 
     reduce_input = materialize_traced_array(TracedUtils.elem_apply(f, A))
 
@@ -656,15 +617,13 @@ function Base.mapreducedim!(
 end
 
 function Base.fill!(A::AnyTracedRArray{T,N}, x) where {T,N}
-    bcast = TracedUtils.broadcast_to_size(T(x), size(A))
+    bcast = Reactant.broadcast_to_size(T(x), size(A))
     set_mlir_data!(A, get_mlir_data(bcast))
     return A
 end
 
 function Base.fill!(A::AnyTracedRArray{T,N}, x::TracedRNumber{T2}) where {T,N,T2}
-    bcast = TracedUtils.broadcast_to_size(
-        TracedUtils.promote_to(TracedRNumber{T}, x), size(A)
-    )
+    bcast = Reactant.broadcast_to_size(Reactant.promote_to(TracedRNumber{T}, x), size(A))
     set_mlir_data!(A, get_mlir_data(bcast))
     return A
 end
@@ -763,7 +722,7 @@ function Base.copyto!(
 end
 
 function Base.copyto!(dest::AnyTracedRArray{T,N}, src::Array{T2,N}) where {T,T2,N}
-    return copyto!(dest, TracedUtils.promote_to(TracedRArray{T2,N}, src))
+    return copyto!(dest, Reactant.promote_to(TracedRArray{T2,N}, src))
 end
 
 function _copyto!(dest::AnyTracedRArray, bc::Broadcasted)
@@ -772,9 +731,9 @@ function _copyto!(dest::AnyTracedRArray, bc::Broadcasted)
 
     bc = Broadcast.preprocess(dest, bc)
 
-    args = (TracedUtils.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
+    args = (Reactant.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
 
-    res = TracedUtils.promote_to(
+    res = Reactant.promote_to(
         TracedRArray{unwrapped_eltype(dest),ndims(dest)},
         TracedUtils.elem_apply(bc.f, args...),
     )
@@ -788,7 +747,7 @@ function _copyto!(dest::Array{<:TracedRNumber}, bc::Broadcasted)
 
     bc = Broadcast.preprocess(dest, bc)
 
-    args = (TracedUtils.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
+    args = (Reactant.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
 
     res = TracedUtils.elem_apply(bc.f, args...)
     for I in 1:length(dest)
@@ -866,7 +825,7 @@ function Base._cat_t(dims, ::Type{T}, X::TracedRArray...) where {T}
     RT = unwrapped_eltype(Base.promote_eltype(T, X...))
 
     # convert to the target eltype
-    X = map(Base.Fix1(TracedUtils.promote_to, TracedRArray{RT,length(shape)}), X)
+    X = map(Base.Fix1(Reactant.promote_to, TracedRArray{RT,length(shape)}), X)
 
     return TracedRArray{RT,length(shape)}(
         (),
@@ -903,7 +862,7 @@ function repeat_outer_overloaded(x::AnyTracedRArray{T,N}, counts::Dims{N}) where
     broadcast_target_size = interleaved_size
     broadcast_target_size[2:2:(2N)] .= counts
 
-    x_broadcasted = TracedUtils.broadcast_to_size(x_interleaved, broadcast_target_size)
+    x_broadcasted = Reactant.broadcast_to_size(x_interleaved, broadcast_target_size)
 
     # (d1, r1, d2, r2, ..., dP, rP) -> (d1*r1, d2*r2, ..., dP*rP)
     final_size = vec(prod(reshape(broadcast_target_size, 2, :); dims=1))
@@ -943,7 +902,7 @@ function Base._RepeatInnerOuter.repeat_inner(
     broadcast_target_size = interleaved_size
     broadcast_target_size[1:2:(2N)] .= counts
 
-    x_broadcasted = TracedUtils.broadcast_to_size(x_interleaved, broadcast_target_size)
+    x_broadcasted = Reactant.broadcast_to_size(x_interleaved, broadcast_target_size)
 
     # (r1, d1, r2, d2, ..., rP, dP) -> (d1*r1, d2*r2, ..., dP*rP)
     final_size = vec(prod(reshape(broadcast_target_size, 2, :); dims=1))
@@ -1272,7 +1231,7 @@ function overloaded_map(f, x::AbstractArray, xs::AbstractArray...)
         if input isa AnyTracedRArray
             input = Reactant.materialize_traced_array(input)
         else
-            input = TracedUtils.promote_to(TracedRArray{eltype(input),ndims(input)}, input)
+            input = Reactant.promote_to(TracedRArray{eltype(input),ndims(input)}, input)
         end
         inputs = (inputs..., input)
     end
@@ -1387,7 +1346,7 @@ function scan_impl!(
     end
 
     init = something(init) # unwrap Some
-    init = TracedUtils.promote_to(TracedRNumber{unwrapped_eltype(init)}, init)
+    init = Reactant.promote_to(TracedRNumber{unwrapped_eltype(init)}, init)
 
     window_dimensions = ones(Int64, N)
     window_dimensions[dims] = size(input, dims)
@@ -1506,7 +1465,7 @@ end
 function Base.circshift!(
     dest::AnyTracedRArray{T,N}, src, shiftamt::Base.DimsInteger
 ) where {T,N}
-    src = TracedUtils.promote_to(TracedRArray{T,N}, materialize_traced_array(src))
+    src = Reactant.promote_to(TracedRArray{T,N}, materialize_traced_array(src))
     shiftamt = Base.fill_to_length(shiftamt, 0, Val(N))
 
     for i in 1:N

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -1106,7 +1106,7 @@ function elem_apply(f, args::Vararg{Any,Nargs}) where {Nargs}
         invmap[v] = k
     end
 
-    keys_seen = [k for k in keys(seen_args) if k isa Reactant.TracedType]
+    keys_seen = Reactant.TracedType[k for k in keys(seen_args) if k isa Reactant.TracedType]
     input_shapes = size.(keys_seen)
     # by the time we reach here all args must have same size
     @assert allequal(input_shapes) "input shapes are $(input_shapes)"

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -13,7 +13,9 @@ using ..Reactant:
     MissingTracedValue,
     OrderedIdDict,
     ReactantPrimitive,
-    Ops
+    Ops,
+    promote_to, # keep this to avoid breaking external code
+    broadcast_to_size # keep this to avoid breaking external code
 using ..Ops: @opcall
 using ReactantCore: ReactantCore
 using ReactantCore:
@@ -1021,8 +1023,6 @@ function elem_apply(::Type{T}, x::TracedRArray) where {T<:Reactant.ReactantPrimi
     return elem_apply(TypeCast{T}(), x)
 end
 
-function promote_to end
-
 function get_attribute_by_name(operation, name)
     return MLIR.IR.Attribute(MLIR.API.mlirOperationGetAttributeByName(operation, name))
 end
@@ -1176,93 +1176,6 @@ function elem_apply(f, args::Vararg{Any,Nargs}) where {Nargs}
     func2.operation = MLIR.API.MlirOperation(C_NULL)
 
     return traced2_result
-end
-
-function broadcast_to_size(arg::AnyTracedRArray, rsize)
-    if Reactant.isa_traced_soa(Reactant.ancestor(arg))
-        return broadcast_to_size(materialize_traced_array(arg), rsize)
-    end
-    x = Reactant.aos_to_soa(arg)
-    x === arg && return broadcast_to_size(materialize_traced_array(arg), rsize)
-    return broadcast_to_size(x, rsize)
-end
-
-broadcast_to_size(arg::TracedRArray, rsize) = broadcast_to_size_internal(arg, rsize)
-
-function broadcast_to_size(arg::AbstractArray, rsize)
-    return broadcast_to_size(@opcall(constant(arg)), rsize)
-end
-
-function broadcast_to_size(arg::AbstractRange{<:TracedRNumber}, rsize)
-    return broadcast_to_size(collect(arg), rsize)
-end
-broadcast_to_size(arg::AbstractRange, rsize) = broadcast_to_size(collect(arg), rsize)
-
-function broadcast_to_size(arg::Union{StepRange,StepRangeLen}, rsize)
-    x = @opcall(
-        add(
-            @opcall(
-                multiply(
-                    broadcast_to_size(step(arg), (length(arg),)),
-                    @opcall(
-                        iota(
-                            Reactant.unwrapped_eltype(arg), [length(arg)]; iota_dimension=1
-                        )
-                    )
-                )
-            ),
-            broadcast_to_size(first(arg), (length(arg),)),
-        )
-    )
-    return broadcast_to_size(x, rsize)
-end
-
-function broadcast_to_size(arg::UnitRange{<:TracedRNumber}, rsize)
-    return @invoke broadcast_to_size(arg::UnitRange, rsize)
-end
-function broadcast_to_size(arg::UnitRange, rsize)
-    # For small inputs this will be automatically optimized away, and for large ranges
-    # helps reduce the IR size
-    x = @opcall add(
-        @opcall(iota(eltype(arg), [length(arg)]; iota_dimension=1)),
-        @opcall(fill(first(arg), [length(arg)])),
-    )
-    return broadcast_to_size(x, rsize)
-end
-broadcast_to_size(arg::Base.OneTo, rsize) = broadcast_to_size(1:last(arg), rsize)
-
-function broadcast_to_size(arg::Base.RefValue, rsize)
-    # XXX: don't we want to expand here to rsize?
-    return arg
-end
-
-function broadcast_to_size(arg::AbstractIrrational, rsize)
-    return broadcast_to_size(Base.convert(Float64, arg), rsize)
-end
-
-function broadcast_to_size(arg::ReactantPrimitive, rsize)
-    return @opcall fill(arg, rsize)
-end
-
-function broadcast_to_size(arg::TracedRNumber{T}, rsize) where {T}
-    length(rsize) == 0 && return arg
-    return broadcast_to_size_internal(TracedRArray{T,0}((), get_mlir_data(arg), ()), rsize)
-end
-
-function broadcast_to_size(arg::AbstractArray{TracedRNumber{T},0}, rsize) where {T}
-    arg = materialize_traced_array(arg)
-    return broadcast_to_size(TracedRNumber{T}((), get_mlir_data(arg)), rsize)
-end
-
-function broadcast_to_size(arg::Broadcast.Extruded, rsize)
-    rsize2 = (keep ? rsizev : 1 for (keep, rsizev) in zip(arg.keeps, rsize))
-    x = broadcast_to_size(arg.x, rsize2)
-    size(x) == rsize && return x
-    return broadcast_to_size_internal(x, rsize)
-end
-
-@noinline function broadcast_to_size_internal(x::TracedRArray{T}, rsize) where {T}
-    return @opcall broadcast_in_dim(x, collect(Int64, 1:ndims(x)), collect(Int64, rsize))
 end
 
 function traced_indices(indices...)

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -1452,7 +1452,7 @@ Base.@nospecializeinfer function make_tracer(
         else
             if mode == TracedTrack || mode == NoStopTracedTrack
                 res = TracedRNumber{RT}(
-                    (path,), TracedUtils.broadcast_to_size(prev, ()).mlir_data
+                    (path,), Reactant.broadcast_to_size(prev, ()).mlir_data
                 )
                 if Base.ismutable(prev) && !haskey(seen, prev)
                     return seen[prev] = res
@@ -1462,7 +1462,7 @@ Base.@nospecializeinfer function make_tracer(
             elseif mode == TracedSetPath
                 haskey(seen, prev) && return seen[prev]
                 res = TracedRNumber{RT}(
-                    (path,), TracedUtils.broadcast_to_size(prev, ()).mlir_data
+                    (path,), Reactant.broadcast_to_size(prev, ()).mlir_data
                 )
                 seen[prev] = res
                 return res

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -240,8 +240,8 @@ function overloaded_mul!(
     α::Number=true,
     β::Number=false,
 )
-    A = TracedUtils.promote_to(TracedRArray{unwrapped_eltype(A),2}, A)
-    B = TracedUtils.promote_to(TracedRArray{unwrapped_eltype(B),2}, B)
+    A = Reactant.promote_to(TracedRArray, A)
+    B = Reactant.promote_to(TracedRArray, B)
 
     if size(C) != (size(A, 1), size(B, 2))
         throw(
@@ -265,11 +265,11 @@ function overloaded_mul!(
         if isone(α)
             tmp
         else
-            @opcall(multiply(tmp, TracedUtils.broadcast_to_size(T(α), size(C))))
+            @opcall(multiply(tmp, Reactant.broadcast_to_size(T(α), size(C))))
         end
     else
-        α_res = @opcall multiply(tmp, TracedUtils.broadcast_to_size(T(α), size(C)))
-        β_C = @opcall multiply(C, TracedUtils.broadcast_to_size(T(β), size(C)))
+        α_res = @opcall multiply(tmp, Reactant.broadcast_to_size(T(α), size(C)))
+        β_C = @opcall multiply(C, Reactant.broadcast_to_size(T(β), size(C)))
         @opcall add(α_res, β_C)
     end
     set_mlir_data!(C, get_mlir_data(res))
@@ -280,7 +280,7 @@ function LinearAlgebra.triu!(@nospecialize(X::TracedRArray{T,2}), k::Integer) wh
     iota_1 = @opcall iota(Int64, [size(X)...]; iota_dimension=1)
     iota_2 = @opcall subtract(
         @opcall(iota(Int64, [size(X)...]; iota_dimension=2)),
-        TracedUtils.broadcast_to_size(k, size(X)),
+        Reactant.broadcast_to_size(k, size(X)),
     )
     idxs = @opcall compare(iota_1, iota_2; comparison_direction="LE")
     X.mlir_data = @opcall(select(idxs, X, zero(X))).mlir_data
@@ -291,7 +291,7 @@ function LinearAlgebra.tril!(@nospecialize(X::TracedRArray{T,2}), k::Integer) wh
     iota_1 = @opcall iota(Int64, [size(X)...]; iota_dimension=1)
     iota_2 = @opcall subtract(
         @opcall(iota(Int64, [size(X)...]; iota_dimension=2)),
-        TracedUtils.broadcast_to_size(k, size(X)),
+        Reactant.broadcast_to_size(k, size(X)),
     )
     idxs = @opcall compare(iota_1, iota_2; comparison_direction="GE")
     X.mlir_data = @opcall(select(idxs, X, zero(X))).mlir_data
@@ -434,7 +434,7 @@ function LinearAlgebra.axpy!(α::Number, x::TracedRArray{T}, y::TracedRArray{T})
             ),
         )
     end
-    ax = @opcall multiply(x, TracedUtils.broadcast_to_size(T(α), size(x)))
+    ax = @opcall multiply(x, Reactant.broadcast_to_size(T(α), size(x)))
 
     set_mlir_data!(y, get_mlir_data(@opcall add(y, ax)))
     return y
@@ -450,8 +450,8 @@ function LinearAlgebra.axpby!(
             ),
         )
     end
-    ax = @opcall multiply(x, TracedUtils.broadcast_to_size(T(α), size(x)))
-    by = @opcall multiply(y, TracedUtils.broadcast_to_size(T(β), size(y)))
+    ax = @opcall multiply(x, Reactant.broadcast_to_size(T(α), size(x)))
+    by = @opcall multiply(y, Reactant.broadcast_to_size(T(β), size(y)))
 
     set_mlir_data!(y, get_mlir_data(@opcall add(ax, by)))
     return y
@@ -534,8 +534,8 @@ function LinearAlgebra.generic_trimatdiv!(
     @assert isunitc in ('N', 'U')
 
     res = @opcall triangular_solve(
-        TracedUtils.promote_to(TracedRArray{T,2}, materialize_traced_array(A)),
-        TracedUtils.promote_to(TracedRArray{T,ndims(B)}, materialize_traced_array(B));
+        Reactant.promote_to(TracedRArray{T}, A),
+        Reactant.promote_to(TracedRArray{T}, B);
         left_side=true,
         lower=(uploc == 'L'),
         transpose_a=tfun_to_char(tfun),
@@ -557,8 +557,8 @@ function LinearAlgebra.generic_mattridiv!(
     @assert isunitc in ('N', 'U')
 
     res = @opcall triangular_solve(
-        TracedUtils.promote_to(TracedRArray{T,2}, materialize_traced_array(B)),
-        TracedUtils.promote_to(TracedRArray{T,2}, materialize_traced_array(A));
+        Reactant.promote_to(TracedRArray{T}, B),
+        Reactant.promote_to(TracedRArray{T}, A);
         left_side=false,
         lower=(uploc == 'L'),
         transpose_a=tfun_to_char(tfun),

--- a/src/stdlibs/Random.jl
+++ b/src/stdlibs/Random.jl
@@ -126,8 +126,7 @@ for randfun in (:rand, :randn, :randexp, :rand!, :randn!, :randexp!)
     @eval begin
         @noinline function $(overload_randfun)(rng::AbstractRNG, args...)
             rng = ReactantRNG(
-                Reactant.promote_to(TracedRArray, make_seed(rng)),
-                rng_algorithm(rng),
+                Reactant.promote_to(TracedRArray, make_seed(rng)), rng_algorithm(rng)
             )
             return $(internal_overload_randfun)(rng, args...)
         end

--- a/src/stdlibs/Random.jl
+++ b/src/stdlibs/Random.jl
@@ -31,7 +31,7 @@ Base.copy(rng::ReactantRNG) = ReactantRNG(copy(rng.seed), rng.algorithm)
 
 @noinline function ReactantRNG()
     if Reactant.within_compile()
-        return ReactantRNG(TracedUtils.promote_to(TracedRArray{UInt64,1}, make_seed()))
+        return ReactantRNG(Reactant.promote_to(TracedRArray, make_seed()))
     else
         return ReactantRNG(Reactant.to_rarray(make_seed()))
     end
@@ -111,7 +111,7 @@ for randfun in (:rand, :randn, :randexp)
         @noinline function $(overload_randfun)(
             rng::ReactantRNG{<:TracedRArray}, ::Type{T}=Float64
         ) where {T}
-            A = TracedUtils.promote_to(TracedRArray{T,0}, fill(T(0)))
+            A = Reactant.promote_to(TracedRArray, fill(T(0)))
             $(overload_randfun!)(rng, A)
             return TracedRNumber{T}((), A.mlir_data)
         end
@@ -126,7 +126,7 @@ for randfun in (:rand, :randn, :randexp, :rand!, :randn!, :randexp!)
     @eval begin
         @noinline function $(overload_randfun)(rng::AbstractRNG, args...)
             rng = ReactantRNG(
-                TracedUtils.promote_to(TracedRArray{UInt64,1}, make_seed(rng)),
+                Reactant.promote_to(TracedRArray, make_seed(rng)),
                 rng_algorithm(rng),
             )
             return $(internal_overload_randfun)(rng, args...)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -579,9 +579,7 @@ end
 function f_row_major(x::AbstractArray{T}) where {T}
     y = [1 2; 3 4; 5 6]
     if x isa Reactant.TracedRArray
-        y = Reactant.promote_to(
-            Reactant.TracedRArray{Reactant.unwrapped_eltype(T),2}, y
-        )
+        y = Reactant.promote_to(Reactant.TracedRArray{Reactant.unwrapped_eltype(T),2}, y)
     end
     return x .+ y
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -579,7 +579,7 @@ end
 function f_row_major(x::AbstractArray{T}) where {T}
     y = [1 2; 3 4; 5 6]
     if x isa Reactant.TracedRArray
-        y = Reactant.TracedUtils.promote_to(
+        y = Reactant.promote_to(
             Reactant.TracedRArray{Reactant.unwrapped_eltype(T),2}, y
         )
     end
@@ -893,7 +893,7 @@ end
 end
 
 @testset "don't expand ranges by default" begin
-    fn(x) = Reactant.TracedUtils.broadcast_to_size(x, (length(x),))
+    fn(x) = Reactant.broadcast_to_size(x, (length(x),))
 
     hlo = repr(@code_hlo(fn(1:10000)))
     @test contains(hlo, "stablehlo.iota")

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -54,7 +54,7 @@ end
     y = ConcreteRNumber(x)
 
     f = Reactant.compile((y,)) do z
-        z + Reactant.TracedUtils.promote_to(
+        z + Reactant.promote_to(
             Reactant.TracedRNumber{ComplexF32}, ComplexF32(1.0 - 3.0im)
         )
     end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -54,9 +54,7 @@ end
     y = ConcreteRNumber(x)
 
     f = Reactant.compile((y,)) do z
-        z + Reactant.promote_to(
-            Reactant.TracedRNumber{ComplexF32}, ComplexF32(1.0 - 3.0im)
-        )
+        z + Reactant.promote_to(Reactant.TracedRNumber{ComplexF32}, ComplexF32(1.0 - 3.0im))
     end
 
     @test isapprox(f(y), ComplexF32(2.0 - 1.0im))

--- a/test/integration/cuda.jl
+++ b/test/integration/cuda.jl
@@ -1,4 +1,3 @@
-
 using Reactant
 using Test
 using CUDA


### PR DESCRIPTION
`broadcast_to_size` and `promote_to` were pretty distinct implementations, and we were having to duplicate certain logic. And we had to call `broadcast_to_size` to "promote" an array type to a traced array -- this inconsistency has now been resolved. `broadcast_in_size` redirects calls via `promote_to` so we should be able to minimize duplication