### PR TITLE
feat: use `traced_call` when unrolling iterators and generators

### DIFF
--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -156,7 +156,10 @@ end
 end
 
 @reactant_overlay @noinline function Base.mapreduce(
-    f, op, A::Union{AbstractArray,Base.Iterators.Zip,Base.Iterators.Enumerate}; kwargs...
+    f,
+    op,
+    A::Union{AbstractArray,Base.Iterators.Zip,Base.Iterators.Enumerate,Base.Generator};
+    kwargs...,
 )
     if use_overlayed_version(A)
         return TracedRArrayOverrides.overloaded_mapreduce(f, op, A; kwargs...)

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -178,22 +178,27 @@ include("TracedRArray.jl")
 
 include("ConcreteRArray.jl")
 
-use_overlayed_version(x) = false
-function use_overlayed_version(x::F) where {F<:Function}
+Base.@nospecializeinfer use_overlayed_version(x) = false
+Base.@nospecializeinfer function use_overlayed_version(
+    @nospecialize(x::F)
+) where {F<:Function}
     return Base.inferencebarrier(any)(
         use_overlayed_version, getfield.(Ref(x), fieldnames(F))
     )
 end
-function use_overlayed_version(x::Base.Generator)
+Base.@nospecializeinfer function use_overlayed_version(@nospecialize(x::Base.Generator))
     return use_overlayed_version(x.f) || use_overlayed_version(x.iter)
 end
-function use_overlayed_version(x::Base.Iterators.Zip)
+Base.@nospecializeinfer function use_overlayed_version(@nospecialize(x::Base.Iterators.Zip))
     return Base.inferencebarrier(any)(use_overlayed_version, x.is)
 end
-use_overlayed_version(x::Base.Iterators.Enumerate) = use_overlayed_version(x.itr)
-use_overlayed_version(x::Vector) = Base.inferencebarrier(any)(use_overlayed_version, x)
-use_overlayed_version(iter::Tuple) = Base.inferencebarrier(any)(use_overlayed_version, iter)
-function use_overlayed_version(iter::NamedTuple)
+Base.@nospecializeinfer use_overlayed_version(@nospecialize(x::Base.Iterators.Enumerate)) =
+    use_overlayed_version(x.itr)
+Base.@nospecializeinfer use_overlayed_version(@nospecialize(x::Vector)) =
+    Base.inferencebarrier(any)(use_overlayed_version, x)
+Base.@nospecializeinfer use_overlayed_version(@nospecialize(iter::Tuple)) =
+    Base.inferencebarrier(any)(use_overlayed_version, iter)
+Base.@nospecializeinfer function use_overlayed_version(@nospecialize(iter::NamedTuple))
     return Base.inferencebarrier(any)(use_overlayed_version, values(iter))
 end
 use_overlayed_version(::TracedRArray) = true

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -178,27 +178,28 @@ include("TracedRArray.jl")
 
 include("ConcreteRArray.jl")
 
-Base.@nospecializeinfer use_overlayed_version(x) = false
-Base.@nospecializeinfer function use_overlayed_version(
-    @nospecialize(x::F)
-) where {F<:Function}
+use_overlayed_version(x) = false
+function use_overlayed_version(x::F) where {F<:Function}
     return Base.inferencebarrier(any)(
         use_overlayed_version, getfield.(Ref(x), fieldnames(F))
     )
 end
-Base.@nospecializeinfer function use_overlayed_version(@nospecialize(x::Base.Generator))
+function use_overlayed_version(x::Base.Generator)
     return use_overlayed_version(x.f) || use_overlayed_version(x.iter)
 end
-Base.@nospecializeinfer function use_overlayed_version(@nospecialize(x::Base.Iterators.Zip))
+function use_overlayed_version(x::Base.Iterators.Zip)
     return Base.inferencebarrier(any)(use_overlayed_version, x.is)
 end
-Base.@nospecializeinfer use_overlayed_version(@nospecialize(x::Base.Iterators.Enumerate)) =
-    use_overlayed_version(x.itr)
-Base.@nospecializeinfer use_overlayed_version(@nospecialize(x::Vector)) =
-    Base.inferencebarrier(any)(use_overlayed_version, x)
-Base.@nospecializeinfer use_overlayed_version(@nospecialize(iter::Tuple)) =
-    Base.inferencebarrier(any)(use_overlayed_version, iter)
-Base.@nospecializeinfer function use_overlayed_version(@nospecialize(iter::NamedTuple))
+function use_overlayed_version(x::Base.Iterators.Enumerate)
+    return use_overlayed_version(x.itr)
+end
+function use_overlayed_version(x::Vector)
+    return Base.inferencebarrier(any)(use_overlayed_version, x)
+end
+function use_overlayed_version(iter::Tuple)
+    return Base.inferencebarrier(any)(use_overlayed_version, iter)
+end
+function use_overlayed_version(iter::NamedTuple)
     return Base.inferencebarrier(any)(use_overlayed_version, values(iter))
 end
 use_overlayed_version(::TracedRArray) = true

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -60,6 +60,7 @@ function _parent end
 _parent_type(::Type{Array}) = Array
 _parent_type(::Type{Array{T}}) where {T} = Array{T}
 _parent_type(::Type{Array{T,N}}) where {T,N} = Array{T,N}
+_parent_type(::Type{<:Slices{P}}) where {P} = P
 
 include("accelerators/Accelerators.jl")
 
@@ -209,7 +210,6 @@ function looped_any(f::F, itr) where {F}
 end
 
 # StdLib Overloads
-
 include("stdlibs/LinearAlgebra.jl")
 include("stdlibs/Random.jl")
 include("stdlibs/Base.jl")

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -686,7 +686,7 @@ function Broadcast.copy(bc::Broadcasted{<:AbstractReactantArrayStyle})
     elseif ElType == Any
         ElType = eltype(fn(map(first_scalar, bc.args)...))
     end
-    @assert ElType != Union{} && ElType != Any
+    @assert ElType != Any && ElType != Union{}
     sim = similar(bc, ElType)
     return copyto!(sim, bc)
 end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -686,7 +686,7 @@ function Broadcast.copy(bc::Broadcasted{<:AbstractReactantArrayStyle})
     elseif ElType == Any
         ElType = eltype(fn(map(first_scalar, bc.args)...))
     end
-    @assert ElType != Any && ElType != Union{}
+    @assert ElType != Union{} && ElType != Any
     sim = similar(bc, ElType)
     return copyto!(sim, bc)
 end
@@ -1525,6 +1525,10 @@ function unwrapped_broadcast(f::F, x::Base.Iterators.Enumerate) where {F}
     else
         return unwrapped_broadcast_with_iterate(f, x)
     end
+end
+
+function unwrapped_broadcast(f::F, x::Base.Generator) where {F}
+    return unwrapped_broadcast_with_iterate(f, Base.Generator(TracedCall(x.f), x.iter))
 end
 
 unwrapped_broadcast(f::F, xs) where {F} = unwrapped_broadcast_with_iterate(f, xs)

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -660,7 +660,7 @@ function finalize_mlir_fn(
     skipped_results = Reactant.TracedType[]
     for (k, v) in seen_results
         v isa Reactant.TracedType || continue
-        if any(Base.Fix1(===, k), skipped_args)
+        if Reactant.looped_any(Base.Fix1(===, k), skipped_args)
             push!(skipped_results, v)
 
             _, argpath = get_argidx(v, argprefix)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1599,19 +1599,15 @@ end
     @test @jit(clamp!(x_ra, 0.5, Inf32)) ≈ clamp!(x, 0.5, Inf32)
 end
 
-@testset "Base.Generator" begin end
+@testset "Base.Generator" begin
+    points = [rand(Float32, 2) for _ in 1:5]
+    params = rand(Float32, 4, 2)
+    points_ra = Reactant.to_rarray(points)
+    params_ra = Reactant.to_rarray(params)
 
-using Reactant
+    function f_generator(points, params)
+        return sum(params * point for point in points)
+    end
 
-points = [rand(Float32, 2), rand(Float32, 2)]
-params = rand(Float32, 4, 2)
-points_ra = Reactant.to_rarray(points)
-params_ra = Reactant.to_rarray(params)
-
-function f_generator(points, params)
-    gen = (params * point for point in points)
-    @show typeof(gen)
-    return sum(gen)
+    @code_hlo f_generator(points_ra, params_ra)
 end
-
-@code_hlo f_generator(points_ra, params_ra)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1600,7 +1600,7 @@ end
 end
 
 @testset "Base.Generator" begin
-    points = [rand(Float32, 2) for _ in 1:5]
+    points = eachcol(rand(Float32, 2, 6))
     params = rand(Float32, 4, 2)
     points_ra = Reactant.to_rarray(points)
     params_ra = Reactant.to_rarray(params)
@@ -1609,5 +1609,5 @@ end
         return sum(params * point for point in points)
     end
 
-    @code_hlo f_generator(points_ra, params_ra)
+    @test @jit(f_generator(points_ra, params_ra)) ≈ f_generator(points, params)
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1598,3 +1598,20 @@ end
     x_ra = Reactant.to_rarray(x)
     @test @jit(clamp!(x_ra, 0.5, Inf32)) ≈ clamp!(x, 0.5, Inf32)
 end
+
+@testset "Base.Generator" begin end
+
+using Reactant
+
+points = [rand(Float32, 2), rand(Float32, 2)]
+params = rand(Float32, 4, 2)
+points_ra = Reactant.to_rarray(points)
+params_ra = Reactant.to_rarray(params)
+
+function f_generator(points, params)
+    gen = (params * point for point in points)
+    @show typeof(gen)
+    return sum(gen)
+end
+
+@code_hlo f_generator(points_ra, params_ra)


### PR DESCRIPTION
not yet finished but tries to tame the codegen for `mapreduce` when we need to unroll the computation

fixes #1616 