### PR TITLE
Don't overlay mul! for sparse arrays

### DIFF
--- a/ext/ReactantSparseArraysExt/ReactantSparseArraysExt.jl
+++ b/ext/ReactantSparseArraysExt/ReactantSparseArraysExt.jl
@@ -7,4 +7,6 @@ using SparseArrays:
 include("Errors.jl")
 include("ReadOnly.jl")
 
+Reactant.use_overlayed_version(::AbstractSparseArray) = false
+
 end

--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -114,8 +114,8 @@ end
 ## `mul!` goes through too many layers of abstractions and we aren't able to overload
 ## without specializing on every possible combination of types
 for (cT, aT, bT) in (
-    (:AbstractVector, :AbstractMatrix, :AbstractVector),
-    (:AbstractMatrix, :AbstractMatrix, :AbstractVecOrMat),
+    (:AbstractVector, :DenseMatrix, :AbstractVector),
+    (:AbstractMatrix, :DenseMatrix, :AbstractVecOrMat),
 )
     @eval begin
         @reactant_overlay @noinline function LinearAlgebra.mul!(

--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -133,7 +133,7 @@ for (cT, aT, bT) in (
                 # Inference barrier is required when calling function recursively within
                 # overload. This is required since otherwise type inference will think this
                 # is a recursive edge rather than a call to the base method
-                Base.inferencebarrier(LinearAlgebra.mul!)(C, A, B, α, β)
+                Base.inferencebarrier(LinearAlgebra.mul!)(C2, A2, B2, α, β)
             end
             return C
         end


### PR DESCRIPTION
The `mul!` should not be overlayed for sparse arrays, as they require custom methods.

This PR fixes #1296