### PR TITLE
Fix jl-generators for AttrSizedOperandSegments string

### DIFF
--- a/deps/ReactantExtra/tblgen/jl-generators.cc
+++ b/deps/ReactantExtra/tblgen/jl-generators.cc
@@ -293,7 +293,7 @@ end
           operandname = "operand_" + std::to_string(i);
         }
         if (named_operand.isOptional()) {
-          operandsegmentsizes += "(" + operandname + "==nothing) ? 0 : 1";
+          operandsegmentsizes += "(" + operandname + "==nothing) ? 0 : 1, ";
           continue;
         }
         operandsegmentsizes += named_operand.isVariadic()


### PR DESCRIPTION
It originally can produce something like
```
push!(attributes, operandsegmentsizes([length(inputs), 1, (mass==nothing) ? 0 : 1(step_size==nothing) ? 0 : 1(num_steps==nothing) ? 0 : 1]))
```
which lacks commas when I have optional MLIR operands like `mass`, `step_size`, and `num_steps`