### PR TITLE
feat: print bytes using format_bytes

### DIFF
--- a/src/xla/Stats.jl
+++ b/src/xla/Stats.jl
@@ -13,6 +13,9 @@ struct JLAllocatorStats
     peak_pool_bytes::Int64
 end
 
+_format_bytes(x) = Base.format_bytes(x)
+_format_bytes(x::Nothing) = x
+
 """
   AllocatorStats()
 
@@ -51,17 +54,17 @@ function Base.show(io::IO, ::MIME"text/plain", stats::AllocatorStats)
         """
         AllocatorStats
         --------------
-        num_allocs: $(stats.num_allocs)
-        bytes_in_use: $(stats.bytes_in_use)
-        peak_bytes_in_use: $(stats.peak_bytes_in_use)
-        largest_alloc_size: $(stats.largest_alloc_size)
-        bytes_limit: $(stats.bytes_limit)
-        bytes_reserved: $(stats.bytes_reserved)
-        peak_bytes_reserved: $(stats.peak_bytes_reserved)
-        bytes_reservable_limit: $(stats.bytes_reservable_limit)
-        largest_free_block_bytes: $(stats.largest_free_block_bytes)
-        pool_bytes: $(stats.pool_bytes)
-        peak_pool_bytes: $(stats.peak_pool_bytes)
+        Num Allocs: $(stats.num_allocs)
+        In Use: $(_format_bytes(stats.bytes_in_use))
+        Peak In Use: $(_format_bytes(stats.peak_bytes_in_use))
+        Largest Alloc Size: $(_format_bytes(stats.largest_alloc_size))
+        Limit: $(_format_bytes(stats.bytes_limit))
+        Reserved: $(_format_bytes(stats.bytes_reserved))
+        Peak Reserved: $(_format_bytes(stats.peak_bytes_reserved))
+        Reservable Limit: $(_format_bytes(stats.bytes_reservable_limit))
+        Largest Free Block: $(_format_bytes(stats.largest_free_block_bytes))
+        Pool: $(_format_bytes(stats.pool_bytes))
+        Peak Pool: $(_format_bytes(stats.peak_pool_bytes))
         """,
     )
 end
@@ -118,14 +121,14 @@ function Base.show(io::IO, ::MIME"text/plain", cost_analysis::HloCostAnalysisPro
         -------------------------
         FLOPS: $(cost_analysis.flops)
         Transcendentals: $(cost_analysis.transcendentals)
-        Bytes Accessed: $(cost_analysis.bytes_accessed)
+        Bytes Accessed: $(_format_bytes(cost_analysis.bytes_accessed))
         Optimal Seconds: $(cost_analysis.optimal_seconds)
         Utilization: $(cost_analysis.utilization)
         Operand 0 Utilization: $(cost_analysis.operand0_utilization)
         Operand 1 Utilization: $(cost_analysis.operand1_utilization)
-        Operand 0 Bytes Accessed: $(cost_analysis.operand0_bytes_accessed)
-        Operand 1 Bytes Accessed: $(cost_analysis.operand1_bytes_accessed)
-        Output Root Bytes Accessed: $(cost_analysis.output_root_bytes_accessed)
+        Operand 0 Bytes Accessed: $(_format_bytes(cost_analysis.operand0_bytes_accessed))
+        Operand 1 Bytes Accessed: $(_format_bytes(cost_analysis.operand1_bytes_accessed))
+        Output Root Bytes Accessed: $(_format_bytes(cost_analysis.output_root_bytes_accessed))
         Reserved 0: $(cost_analysis.reserved0)
         """,
     )


### PR DESCRIPTION
fixes https://github.com/EnzymeAD/Reactant.jl/issues/1646

## Before

```julia
julia> Reactant.XLA.allocatorstats()
AllocatorStats
--------------
num_allocs: 75
bytes_in_use: 18688
peak_bytes_in_use: 18944
largest_alloc_size: 512
bytes_limit: 4538351616
bytes_reserved: 0
peak_bytes_reserved: 0
bytes_reservable_limit: nothing
largest_free_block_bytes: 0
pool_bytes: 4538351616
peak_pool_bytes: 4538351616
```

## After

```julia
julia> Reactant.XLA.allocatorstats()
AllocatorStats
--------------
num_allocs: 75
bytes_in_use: 18.250 KiB
peak_bytes_in_use: 18.500 KiB
largest_alloc_size: 512
bytes_limit: 4.227 GiB
bytes_reserved: 0 bytes
peak_bytes_reserved: 0 bytes
bytes_reservable_limit: nothing
largest_free_block_bytes: 0 bytes
pool_bytes: 4.227 GiB
peak_pool_bytes: 4.227 GiB
```