### PR TITLE
Add degree-based trigonometric and inverse-trigonometric wrappers for TracedRNumber

### DIFF
--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -505,6 +505,31 @@ for (jlop, hloop) in (
     @eval $(jlop)(@nospecialize(lhs::TracedRNumber)) = @opcall $(hloop)(lhs)
 end
 
+# Degree-based trigonometric wrappers for TracedRNumber:
+
+# These convert to radians internally so Reactant/XLA can lower to StableHLO-supported radian trigonometric operations.
+
+# --- Basic trigonometric functions ---
+Base.sind(x::TracedRNumber) = sin(deg2rad(x))
+Base.cosd(x::TracedRNumber) = cos(deg2rad(x))
+Base.tand(x::TracedRNumber) = tan(deg2rad(x))
+Base.cscd(x::TracedRNumber) = 1 / sind(x)
+Base.secd(x::TracedRNumber) = 1 / cosd(x)
+Base.cotd(x::TracedRNumber) = 1 / tand(x)
+
+# --- Inverse trigonometric functions ---
+Base.asind(x::TracedRNumber) = rad2deg(asin(x))
+Base.acosd(x::TracedRNumber) = rad2deg(acos(x))
+Base.atand(x::TracedRNumber) = rad2deg(atan(x))
+
+# Two-argument atan in degrees
+Base.atand(y::TracedRNumber, x::TracedRNumber) = rad2deg(atan(y, x))
+
+# Derived inverse functions using trigonometric identities
+Base.acscd(x::TracedRNumber) = rad2deg(asin(1 / x))
+Base.asecd(x::TracedRNumber) = rad2deg(acos(1 / x))
+Base.acotd(x::TracedRNumber) = rad2deg(atan(1 / x))
+
 for (jlop, hloop) in (
     (:(Base.sin), :sine),
     (:(Base.cos), :cosine),


### PR DESCRIPTION
This PR adds degree-based trigonometric and inverse-trigonometric function support for `TracedRNumber`, implemented as simple radian conversions so that `Reactant/XLA` can correctly trace and lower them through `StableHLO`.