### PR TITLE
fix: despecialize sharding fields of ConcreteTypes

### DIFF
--- a/docs/src/tutorials/partial-evaluation.md
+++ b/docs/src/tutorials/partial-evaluation.md
@@ -36,7 +36,7 @@ addxy(x, y)
 
 # output
 
-ConcretePJRTNumber{Int64, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}(7)
+ConcretePJRTNumber{Int64, 1}(7)
 ```
 
 returns a result that depends on both arguments `x` and `y`:
@@ -46,7 +46,7 @@ addxy(ConcreteRNumber(7), ConcreteRNumber(8))
 
 # output
 
-ConcretePJRTNumber{Int64, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}(15)
+ConcretePJRTNumber{Int64, 1}(15)
 ```
 
 The StableHLO IR code generated here is:
@@ -76,7 +76,7 @@ addx4(x, 4)
 
 # output
 
-ConcretePJRTNumber{Int64, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}(7)
+ConcretePJRTNumber{Int64, 1}(7)
 ```
 
 will only change based on `x`, not on the non-Reactant argument `y`, we get
@@ -87,7 +87,7 @@ addx4(ConcreteRNumber(7), 8)
 
 # output
 
-ConcretePJRTNumber{Int64, 1, Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding, Nothing}}(11)
+ConcretePJRTNumber{Int64, 1}(11)
 ```
 
 The StableHLO code shows that the second argument has been replaced by a

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1379,16 +1379,9 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
     N = ndims(A)
     if mode == Reactant.ArrayToConcrete && T <: Reactant.ReactantPrimitive
         if runtime isa Val{:PJRT}
-            return Reactant.ConcretePJRTArray{
-                T,
-                N,
-                Reactant.Sharding.ndevices(sharding),
-                Reactant.Sharding.shard_type(typeof(sharding), N),
-            }
+            return Reactant.ConcretePJRTArray{T,N,Reactant.Sharding.ndevices(sharding)}
         elseif runtime isa Val{:IFRT}
-            return Reactant.ConcreteIFRTArray{
-                T,N,Reactant.Sharding.shard_type(typeof(sharding), N)
-            }
+            return Reactant.ConcreteIFRTArray{T,N}
         end
         error("Unsupported runtime $runtime")
     else

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -2302,11 +2302,15 @@ function compile_mlir!(
         ]
     end
 
-    result_shardings_after_masking = eltype(result_shardings)[]
-    for (i, present) in enumerate(results_mask)
-        if present
-            push!(result_shardings_after_masking, result_shardings[i])
+    if result_shardings !== missing
+        result_shardings_after_masking = eltype(result_shardings)[]
+        for (i, present) in enumerate(results_mask)
+            if present
+                push!(result_shardings_after_masking, result_shardings[i])
+            end
         end
+    else
+        result_shardings_after_masking = missing
     end
 
     func3 = MLIR.Dialects.func.func_(;

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -2302,6 +2302,13 @@ function compile_mlir!(
         ]
     end
 
+    result_shardings_after_masking = eltype(result_shardings)[]
+    for (i, present) in enumerate(results_mask)
+        if present
+            push!(result_shardings_after_masking, result_shardings[i])
+        end
+    end
+
     func3 = MLIR.Dialects.func.func_(;
         sym_name="main",
         function_type=MLIR.IR.FunctionType(in_tys, out_tys2),
@@ -2403,7 +2410,7 @@ function compile_mlir!(
         mlir_fn_res.unique_meshes,
         mlir_fn_res.mutated_args,
         use_shardy_partitioner,
-        result_shardings,
+        result_shardings_after_masking,
         mlir_fn_res.global_device_ids,
         donated_args_mask,
         Reactant.TracedUtils.is_pure(func3),

--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -23,8 +23,8 @@ function Base.copy(x::Union{AbstractConcreteArray,AbstractConcreteNumber})
     return fn(x)
 end
 
-function Base.copy(X::ConcreteIFRTArray{T,D,S,P}) where {T,D,S,P}
-    return ConcreteIFRTArray{T,D,S}(Base.copy(X.data), X.shape, X.sharding, X.padding)
+function Base.copy(X::ConcreteIFRTArray{T,D,P}) where {T,D,P}
+    return ConcreteIFRTArray{T,D}(Base.copy(X.data), X.shape, X.sharding, X.padding)
 end
 
 function Base.copy(X::ConcretePJRTArray)
@@ -422,8 +422,8 @@ function Base.similar(
 end
 
 function Base.similar(
-    a::ConcretePJRTArray{T,N,D,Sh}, ::Type{S}=T, dims::Dims=size(a)
-) where {S,T,Sh,N,D}
+    a::ConcretePJRTArray{T,N,D}, ::Type{S}=T, dims::Dims=size(a)
+) where {S,T,N,D}
     device_to_array_slices, sharding = Sharding.sharding_to_array_slices(
         a.sharding, dims; return_updated_sharding=Val(true), client=XLA.client(a)
     )
@@ -432,7 +432,7 @@ function Base.similar(
         Base.@_inline_meta
         similar(a.data[i], S, Dims(length.(device_to_array_slices[i])))
     end
-    return ConcretePJRTArray{S,length(dims),D,Sh}(sdata, dims, a.sharding)
+    return ConcretePJRTArray{S,length(dims),D}(sdata, dims, a.sharding)
 end
 
 Base.similar(a::ConcretePJRTArray, dims::Dims) = similar(a, eltype(a), dims)

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -17,7 +17,6 @@ using ..Reactant:
 using ..Ops: @opcall
 using ReactantCore: ReactantCore
 using ReactantCore: MissingTracedValue, is_traced, materialize_traced_array
-using Functors: Functors
 
 ReactantCore.materialize_traced_array(x::AbstractArray) = x
 

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -63,17 +63,15 @@ Base.@nospecializeinfer function traced_type_inner(
 )
     if mode == ArrayToConcrete && T <: track_numbers
         if runtime isa Val{:PJRT}
-            return ConcretePJRTNumber{
-                T,Sharding.ndevices(sharding),Sharding.shard_type(typeof(sharding), 0)
-            }
+            return ConcretePJRTNumber{T,Sharding.ndevices(sharding)}
         elseif runtime isa Val{:IFRT}
-            return ConcreteIFRTNumber{T,Sharding.shard_type(typeof(sharding), 0)}
+            return ConcreteIFRTNumber{T}
         else
             error("Unsupported runtime $runtime")
         end
     elseif (mode == NoStopTracedTrack || mode == TracedTrack || mode == TracedSetPath) &&
         T <: track_numbers
-        return TracedRNumber{T}
+        return TracedRNumber{T,Missing}
     end
     return T
 end
@@ -266,14 +264,12 @@ Base.@nospecializeinfer function traced_type_inner(
     end
 
     if mode == ConcreteToTraced
-        return TracedRNumber{T}
+        return TracedRNumber{T,Missing}
     elseif mode == TracedToConcrete
         return T0
     elseif mode == ArrayToConcrete
         @assert runtime isa Val{:PJRT}
-        return ConcretePJRTNumber{
-            T,Sharding.ndevices(sharding),Sharding.shard_type(typeof(sharding), 0)
-        }
+        return ConcretePJRTNumber{T,Sharding.ndevices(sharding)}
     else
         throw("Unsupported mode: $mode")
     end
@@ -290,12 +286,12 @@ Base.@nospecializeinfer function traced_type_inner(
     T = T0 isa UnionAll ? T0.body.parameters[1] : T0.parameters[1]
 
     if mode == ConcreteToTraced
-        return TracedRNumber{T}
+        return TracedRNumber{T,Missing}
     elseif mode == TracedToConcrete
         return T0
     elseif mode == ArrayToConcrete
         @assert runtime isa Val{:IFRT}
-        return ConcreteIFRTNumber{T,Sharding.shard_type(typeof(sharding), 0)}
+        return ConcreteIFRTNumber{T}
     else
         throw("Unsupported mode: $mode")
     end
@@ -320,14 +316,12 @@ Base.@nospecializeinfer function traced_type_inner(
     end
 
     if mode == ConcreteToTraced
-        return TracedRArray{elT,N}
+        return TracedRArray{elT,N,Missing}
     elseif mode == TracedToConcrete
         return T
     elseif mode == ArrayToConcrete
         @assert runtime isa Val{:PJRT}
-        return ConcretePJRTArray{
-            elT,N,Sharding.ndevices(sharding),Sharding.shard_type(typeof(sharding), N)
-        }
+        return ConcretePJRTArray{elT,N,Sharding.ndevices(sharding)}
     else
         throw("Unsupported mode: $mode")
     end
@@ -352,12 +346,12 @@ Base.@nospecializeinfer function traced_type_inner(
     end
 
     if mode == ConcreteToTraced
-        return TracedRArray{elT,N}
+        return TracedRArray{elT,N,Missing}
     elseif mode == TracedToConcrete
         return T
     elseif mode == ArrayToConcrete
         @assert runtime isa Val{:IFRT}
-        return ConcreteIFRTArray{elT,N,Sharding.shard_type(typeof(sharding), N)}
+        return ConcreteIFRTArray{elT,N}
     else
         throw("Unsupported mode: $mode")
     end
@@ -387,16 +381,12 @@ Base.@nospecializeinfer function traced_type_inner(
     elseif mode == TracedToConcrete
         if runtime isa Val{:PJRT}
             return ConcretePJRTArray{
-                T.parameters[1],
-                T.parameters[2],
-                Sharding.ndevices(sharding),
-                Sharding.shard_type(typeof(sharding), T.parameters[2]),
+                T.parameters[1],T.parameters[2],Sharding.ndevices(sharding)
             }
         elseif runtime isa Val{:IFRT}
             return ConcreteIFRTArray{
                 T.parameters[1],
                 T.parameters[2],
-                Sharding.shard_type(typeof(sharding), T.parameters[2]),
                 Nothing, # TODO: check if we can ensure no padding??
             }
         end
@@ -424,29 +414,15 @@ Base.@nospecializeinfer function traced_type_inner(
         if runtime isa Val{:PJRT}
             if T isa UnionAll
                 return UnionAll(
-                    T.var,
-                    ConcretePJRTNumber{
-                        T.var,
-                        Sharding.ndevices(sharding),
-                        Sharding.shard_type(typeof(sharding), 0),
-                    },
+                    T.var, ConcretePJRTNumber{T.var,Sharding.ndevices(sharding)}
                 )
             end
-            return ConcretePJRTNumber{
-                T.parameters[1],
-                Sharding.ndevices(sharding),
-                Sharding.shard_type(typeof(sharding), 0),
-            }
+            return ConcretePJRTNumber{T.parameters[1],Sharding.ndevices(sharding)}
         elseif runtime isa Val{:IFRT}
             if T isa UnionAll
-                return UnionAll(
-                    T.var,
-                    ConcreteIFRTNumber{T.var,Sharding.shard_type(typeof(sharding), 0)},
-                )
+                return UnionAll(T.var, ConcreteIFRTNumber{T.var})
             end
-            return ConcreteIFRTNumber{
-                T.parameters[1],Sharding.shard_type(typeof(sharding), 0)
-            }
+            return ConcreteIFRTNumber{T.parameters[1]}
         end
         error("Unsupported runtime $runtime")
     elseif mode == TracedToJAX
@@ -527,16 +503,13 @@ Base.@nospecializeinfer function traced_type_inner(
     else
         N = ndims(A)
         if mode == ArrayToConcrete && T <: ReactantPrimitive
-            runtime isa Val{:PJRT} && return ConcretePJRTArray{
-                T,N,Sharding.ndevices(sharding),Sharding.shard_type(typeof(sharding), N)
-            }
+            runtime isa Val{:PJRT} &&
+                return ConcretePJRTArray{T,N,Sharding.ndevices(sharding)}
             if runtime isa Val{:IFRT}
                 if !Sharding.is_sharded(sharding)
-                    return ConcreteIFRTArray{
-                        T,N,Sharding.shard_type(typeof(sharding), N),Nothing
-                    }
+                    return ConcreteIFRTArray{T,N,Nothing}
                 else
-                    return ConcreteIFRTArray{T,N,Sharding.shard_type(typeof(sharding), N)}
+                    return ConcreteIFRTArray{T,N}
                 end
             end
             error("Unsupported runtime $runtime")
@@ -743,11 +716,8 @@ Base.@nospecializeinfer function traced_type_inner(
     subParms = []
     for (i, SST) in enumerate(T.parameters)
         if wrapped_cpjrt_array && i == 1 && SST isa Type && SST <: ReactantPrimitive
-            # XXX: Sharding???
             TrT = traced_type_inner(
-                ConcretePJRTNumber{
-                    SST,Sharding.ndevices(sharding),Sharding.shard_type(typeof(sharding), 0)
-                },
+                ConcretePJRTNumber{SST,Sharding.ndevices(sharding)},
                 seen,
                 mode,
                 track_numbers,
@@ -756,14 +726,8 @@ Base.@nospecializeinfer function traced_type_inner(
             )
             push!(subParms, TrT)
         elseif wrapped_cifrt_array && i == 1 && SST isa Type && SST <: ReactantPrimitive
-            # XXX: Sharding???
             TrT = traced_type_inner(
-                ConcreteIFRTNumber{SST,Sharding.shard_type(typeof(sharding), 0)},
-                seen,
-                mode,
-                track_numbers,
-                sharding,
-                runtime,
+                ConcreteIFRTNumber{SST}, seen, mode, track_numbers, sharding, runtime
             )
             push!(subParms, TrT)
         elseif wrapped_tracedarray && i == 1 && SST isa Type && SST <: TracedRNumber
@@ -1335,7 +1299,7 @@ Base.@nospecializeinfer function make_tracer(
         if runtime isa Val{:PJRT}
             haskey(seen, prev) && return seen[prev]::ConcretePJRTArray{T,N}
             if !Sharding.is_sharded(sharding)
-                res = ConcretePJRTArray{T,N,1,Sharding.NoShardInfo}(
+                res = ConcretePJRTArray{T,N,1}(
                     (XLA.PJRT.AsyncEmptyBuffer,), size(prev), Sharding.NoShardInfo()
                 )
             else
@@ -1346,7 +1310,7 @@ Base.@nospecializeinfer function make_tracer(
         elseif runtime isa Val{:IFRT}
             haskey(seen, prev) && return seen[prev]::ConcreteIFRTArray{T,N}
             if !Sharding.is_sharded(sharding)
-                res = ConcreteIFRTArray{T,N,Sharding.NoShardInfo}(
+                res = ConcreteIFRTArray{T,N}(
                     XLA.IFRT.AsyncEmptyArray, size(prev), Sharding.NoShardInfo()
                 )
             else
@@ -1424,7 +1388,7 @@ Base.@nospecializeinfer function make_tracer(
         if runtime isa Val{:PJRT}
             haskey(seen, prev) && return seen[prev]::ConcretePJRTNumber{T}
             if !Sharding.is_sharded(sharding)
-                res = ConcretePJRTNumber{T,1,Sharding.NoShardInfo}(
+                res = ConcretePJRTNumber{T,1}(
                     (XLA.PJRT.AsyncEmptyBuffer,), Sharding.NoShardInfo()
                 )
             else
@@ -1435,7 +1399,7 @@ Base.@nospecializeinfer function make_tracer(
         elseif runtime isa Val{:IFRT}
             haskey(seen, prev) && return seen[prev]::ConcreteIFRTNumber{T}
             if !Sharding.is_sharded(sharding)
-                res = ConcreteIFRTNumber{T,Sharding.NoShardInfo}(
+                res = ConcreteIFRTNumber{T}(
                     XLA.IFRT.AsyncEmptyArray, Sharding.NoShardInfo()
                 )
             else

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -71,7 +71,7 @@ Base.@nospecializeinfer function traced_type_inner(
         end
     elseif (mode == NoStopTracedTrack || mode == TracedTrack || mode == TracedSetPath) &&
         T <: track_numbers
-        return TracedRNumber{T,Missing}
+        return TracedRNumber{T}
     end
     return T
 end
@@ -264,7 +264,7 @@ Base.@nospecializeinfer function traced_type_inner(
     end
 
     if mode == ConcreteToTraced
-        return TracedRNumber{T,Missing}
+        return TracedRNumber{T}
     elseif mode == TracedToConcrete
         return T0
     elseif mode == ArrayToConcrete
@@ -286,7 +286,7 @@ Base.@nospecializeinfer function traced_type_inner(
     T = T0 isa UnionAll ? T0.body.parameters[1] : T0.parameters[1]
 
     if mode == ConcreteToTraced
-        return TracedRNumber{T,Missing}
+        return TracedRNumber{T}
     elseif mode == TracedToConcrete
         return T0
     elseif mode == ArrayToConcrete
@@ -316,7 +316,7 @@ Base.@nospecializeinfer function traced_type_inner(
     end
 
     if mode == ConcreteToTraced
-        return TracedRArray{elT,N,Missing}
+        return TracedRArray{elT,N}
     elseif mode == TracedToConcrete
         return T
     elseif mode == ArrayToConcrete
@@ -346,7 +346,7 @@ Base.@nospecializeinfer function traced_type_inner(
     end
 
     if mode == ConcreteToTraced
-        return TracedRArray{elT,N,Missing}
+        return TracedRArray{elT,N}
     elseif mode == TracedToConcrete
         return T
     elseif mode == ArrayToConcrete

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -130,26 +130,24 @@ const AnyTracedRVecOrMat{T} = Union{AnyTracedRVector{T},AnyTracedRMatrix{T}}
 
 # Concrete Types
 ## ConcretePJRTNumber
-mutable struct ConcretePJRTNumber{T,D,S<:Sharding.ShardInfo} <: AbstractConcreteNumber{T}
+mutable struct ConcretePJRTNumber{T,D} <: AbstractConcreteNumber{T}
     data::NTuple{D,XLA.PJRT.AsyncBuffer}
-    sharding::S
+    sharding::Sharding.ShardInfo
     donated::Bool
 
-    function ConcretePJRTNumber{T,D,S}(
-        data::NTuple{D,XLA.PJRT.AsyncBuffer}, sharding::S
-    ) where {T,D,S}
-        return new{T,D,S}(data, sharding, false)
+    function ConcretePJRTNumber{T,D}(
+        data::NTuple{D,XLA.PJRT.AsyncBuffer}, sharding::Sharding.ShardInfo
+    ) where {T,D}
+        return new{T,D}(data, sharding, false)
     end
 end
 
-ConcretePJRTNumber{T,1,Sharding.NoShardInfo}(x::Number) where {T} = ConcretePJRTNumber{T}(x)
-
 function ConcretePJRTNumber{T}(data::Tuple{XLA.PJRT.AsyncBuffer}) where {T}
-    return ConcretePJRTNumber{T,1,Sharding.NoShardInfo}(data, Sharding.NoShardInfo())
+    return ConcretePJRTNumber{T,1}(data, Sharding.NoShardInfo())
 end
 
 function ConcretePJRTNumber{T}(data::NTuple{D,XLA.PJRT.AsyncBuffer}, sharding) where {T,D}
-    return ConcretePJRTNumber{T,D,typeof(sharding)}(data, sharding)
+    return ConcretePJRTNumber{T,D}(data, sharding)
 end
 
 @leaf ConcretePJRTNumber
@@ -157,15 +155,11 @@ end
 function ConcretePJRTNumber{T}(data::T2; kwargs...) where {T<:Number,T2<:Number}
     carray = ConcretePJRTArray(fill(convert(T, data)); kwargs...)
     if !Sharding.is_sharded(carray.sharding)
-        return ConcretePJRTNumber{T,1,typeof(carray.sharding)}(
-            (carray.data[1],), carray.sharding
-        )
+        return ConcretePJRTNumber{T,1}((carray.data[1],), carray.sharding)
     end
     @assert all(isnothing, carray.sharding.partition_spec) "ConcretePJRTNumber cannot be \
                                                             sharded"
-    return ConcretePJRTNumber{T,length(carray.data),typeof(carray.sharding)}(
-        carray.data, carray.sharding
-    )
+    return ConcretePJRTNumber{T,length(carray.data)}(carray.data, carray.sharding)
 end
 function ConcretePJRTNumber(data::T; kwargs...) where {T<:Number}
     return ConcretePJRTNumber{T}(data; kwargs...)
@@ -182,23 +176,25 @@ function ConcretePJRTNumber(data::ConcretePJRTNumber; kwargs...)
 end
 
 ## ConcretePJRTArray
-mutable struct ConcretePJRTArray{T,N,D,S<:Sharding.ShardInfo} <: AbstractConcreteArray{T,N}
+mutable struct ConcretePJRTArray{T,N,D} <: AbstractConcreteArray{T,N}
     data::NTuple{D,XLA.PJRT.AsyncBuffer}
     shape::NTuple{N,Int}
-    sharding::S
+    sharding::Sharding.ShardInfo
     donated::Bool
 
-    function ConcretePJRTArray{T,N,D,S}(
-        data::NTuple{D,XLA.PJRT.AsyncBuffer}, shape::NTuple{N,Int}, sharding::S
-    ) where {T,N,D,S}
-        return new{T,N,D,S}(data, shape, sharding, false)
+    function ConcretePJRTArray{T,N,D}(
+        data::NTuple{D,XLA.PJRT.AsyncBuffer},
+        shape::NTuple{N,Int},
+        sharding::Sharding.ShardInfo,
+    ) where {T,N,D}
+        return new{T,N,D}(data, shape, sharding, false)
     end
 end
 
 @leaf ConcretePJRTArray
 Adapt.parent_type(::Type{<:ConcretePJRTArray{T,N}}) where {T,N} = ConcretePJRTArray{T,N}
-function Adapt.parent_type(::Type{ConcretePJRTArray{T,N,D,S}}) where {T,N,D,S}
-    return ConcretePJRTArray{T,N,D,S}
+function Adapt.parent_type(::Type{ConcretePJRTArray{T,N,D}}) where {T,N,D}
+    return ConcretePJRTArray{T,N,D}
 end
 
 # XXX (Deprecated): remove in v0.3
@@ -209,14 +205,12 @@ Base.@deprecate ConcretePJRTArray(data::Number; kwargs...) ConcretePJRTNumber(
 function ConcretePJRTArray{T,N}(
     data::Tuple{XLA.PJRT.AsyncBuffer}, shape::NTuple{N,Int}
 ) where {T,N}
-    return ConcretePJRTArray{T,N,1,Sharding.NoShardInfo}(
-        data, shape, Sharding.NoShardInfo()
-    )
+    return ConcretePJRTArray{T,N,1}(data, shape, Sharding.NoShardInfo())
 end
 function ConcretePJRTArray{T,N}(
     data::NTuple{D,XLA.PJRT.AsyncBuffer}, shape::NTuple{N,Int}, sharding
 ) where {T,N,D}
-    return ConcretePJRTArray{T,N,D,typeof(sharding)}(data, shape, sharding)
+    return ConcretePJRTArray{T,N,D}(data, shape, sharding)
 end
 
 function ConcretePJRTArray(
@@ -230,7 +224,7 @@ function ConcretePJRTArray(
     sharded_data, shardinfo = sharding(theclient, thedevice, data)
     shape = size(data)
     nsharded = length(sharded_data)
-    return ConcretePJRTArray{T,N,nsharded,typeof(shardinfo)}(sharded_data, shape, shardinfo)
+    return ConcretePJRTArray{T,N,nsharded}(sharded_data, shape, shardinfo)
 end
 
 Base.wait(x::Union{ConcretePJRTArray,ConcretePJRTNumber}) = foreach(wait, x.data)
@@ -241,11 +235,11 @@ function XLA.device(x::Union{ConcretePJRTArray,ConcretePJRTNumber})
 end
 
 const ConcretePJRTScalar{T} = Union{ConcretePJRTArray{T,0},ConcretePJRTNumber{T}}
-const WrappedConcretePJRTArray{T,N,D,S} = WrappedArray{
-    T,N,ConcretePJRTArray,ConcretePJRTArray{T,N,D,S}
+const WrappedConcretePJRTArray{T,N,D} = WrappedArray{
+    T,N,ConcretePJRTArray,ConcretePJRTArray{T,N,D}
 }
-const AnyConcretePJRTArray{T,N,D,S} = Union{
-    ConcretePJRTArray{T,N,D,S},WrappedConcretePJRTArray{T,N,D,S}
+const AnyConcretePJRTArray{T,N,D} = Union{
+    ConcretePJRTArray{T,N,D},WrappedConcretePJRTArray{T,N,D}
 }
 
 function ConcretePJRTArray(x::AnyConcretePJRTArray; kwargs...)
@@ -268,31 +262,27 @@ end
 # While sharding is part of IFRT.Array, we still need to carry it around for compiling the
 # MLIR module.
 ## ConcreteIFRTNumber
-mutable struct ConcreteIFRTNumber{T,S<:Sharding.ShardInfo} <: AbstractConcreteNumber{T}
+mutable struct ConcreteIFRTNumber{T} <: AbstractConcreteNumber{T}
     data::XLA.IFRT.AsyncArray
-    sharding::S
+    sharding::Sharding.ShardInfo
     donated::Bool
 
-    function ConcreteIFRTNumber{T,S}(data::XLA.IFRT.AsyncArray, sharding::S) where {T,S}
-        return new{T,S}(data, sharding, false)
+    function ConcreteIFRTNumber{T}(
+        data::XLA.IFRT.AsyncArray, sharding::Sharding.ShardInfo
+    ) where {T}
+        return new{T}(data, sharding, false)
     end
 end
 
-ConcreteIFRTNumber{T,Sharding.NoShardInfo}(x::Number) where {T} = ConcreteIFRTNumber{T}(x)
-
 function ConcreteIFRTNumber{T}(data::XLA.IFRT.AsyncArray) where {T}
-    return ConcreteIFRTNumber{T,Sharding.NoShardInfo}(data, Sharding.NoShardInfo())
-end
-
-function ConcreteIFRTNumber{T}(data::XLA.IFRT.AsyncArray, sharding) where {T}
-    return ConcreteIFRTNumber{T,typeof(sharding)}(data, sharding)
+    return ConcreteIFRTNumber{T}(data, Sharding.NoShardInfo())
 end
 
 @leaf ConcreteIFRTNumber
 
 function ConcreteIFRTNumber{T}(data::T2; kwargs...) where {T<:Number,T2<:Number}
     carray = ConcreteIFRTArray(fill(convert(T, data)); kwargs...)
-    return ConcreteIFRTNumber{T,typeof(carray.sharding)}(carray.data, carray.sharding)
+    return ConcreteIFRTNumber{T}(carray.data, carray.sharding)
 end
 function ConcreteIFRTNumber(data::T; kwargs...) where {T<:Number}
     return ConcreteIFRTNumber{T}(data; kwargs...)
@@ -309,42 +299,38 @@ function ConcreteIFRTNumber(data::ConcreteIFRTNumber; kwargs...)
 end
 
 ## ConcreteIFRTArray
-mutable struct ConcreteIFRTArray{
-    T,N,S<:Sharding.ShardInfo,P<:Union{Nothing,NTuple{N,Int}}
-} <: AbstractConcreteArray{T,N}
+mutable struct ConcreteIFRTArray{T,N,P<:Union{Nothing,NTuple{N,Int}}} <:
+               AbstractConcreteArray{T,N}
     data::XLA.IFRT.AsyncArray
     shape::NTuple{N,Int}
-    sharding::S
+    sharding::Sharding.ShardInfo
     donated::Bool
     padding::P
 
-    function ConcreteIFRTArray{T,N,S}(
+    function ConcreteIFRTArray{T,N}(
         data::XLA.IFRT.AsyncArray,
         shape::NTuple{N,Int},
-        sharding::S,
+        sharding::Sharding.ShardInfo,
         padding::Union{Nothing,NTuple{N,Int}}=nothing,
-    ) where {T,N,S}
-        return new{T,N,S,typeof(padding)}(data, shape, sharding, false, padding)
+    ) where {T,N}
+        return new{T,N,typeof(padding)}(data, shape, sharding, false, padding)
     end
 end
 
-has_padding(::ConcreteIFRTArray{T,N,S,Nothing}) where {T,N,S} = false
-has_padding(x::ConcreteIFRTArray{T,N,S,P}) where {T,N,S,P} = !all(iszero, x.padding)
+has_padding(::ConcreteIFRTArray{T,N,Nothing}) where {T,N} = false
+has_padding(x::ConcreteIFRTArray{T,N,P}) where {T,N,P} = !all(iszero, x.padding)
 
 @leaf ConcreteIFRTArray
 
 Adapt.parent_type(::Type{<:ConcreteIFRTArray{T,N}}) where {T,N} = ConcreteIFRTArray{T,N}
-function Adapt.parent_type(::Type{<:ConcreteIFRTArray{T,N,S}}) where {T,N,S}
-    return ConcreteIFRTArray{T,N,S}
-end
 
 function ConcreteIFRTArray{T,N}(data::XLA.IFRT.AsyncArray, shape::NTuple{N,Int}) where {T,N}
-    return ConcreteIFRTArray{T,N,Sharding.NoShardInfo}(data, shape, Sharding.NoShardInfo())
+    return ConcreteIFRTArray{T,N}(data, shape, Sharding.NoShardInfo())
 end
 function ConcreteIFRTArray{T,N}(
     data::XLA.IFRT.AsyncArray, shape::NTuple{N,Int}, sharding
 ) where {T,N}
-    return ConcreteIFRTArray{T,N,typeof(sharding)}(data, shape, sharding)
+    return ConcreteIFRTArray{T,N}(data, shape, sharding)
 end
 
 function ConcreteIFRTArray(
@@ -358,7 +344,7 @@ function ConcreteIFRTArray(
     shape = size(data)
     # ToDo: How to use specified device (non-sharded case)?
     sharded_data, shardinfo, padding = sharding(theclient, nothing, data)
-    return ConcreteIFRTArray{T,N,typeof(shardinfo)}(sharded_data, shape, shardinfo, padding)
+    return ConcreteIFRTArray{T,N}(sharded_data, shape, shardinfo, padding)
 end
 
 # Assemble data from multiple arrays. Needed in distributed setting where each process wont
@@ -477,9 +463,6 @@ elseif XLA.REACTANT_XLA_RUNTIME == "IFRT"
     ConcreteIFRTArray
 end
 
-@inline ConcreteRArray{T}(::UndefInitializer, shape::Integer...; kwargs...) where {T} =
-    ConcreteRArray{T}(undef, Dims(shape); kwargs...)
-
 """
     ConcreteRNumber(
         x::Number;
@@ -509,6 +492,12 @@ end
     const AnyConcreteRArray = AnyConcretePJRTArray
 elseif XLA.REACTANT_XLA_RUNTIME == "IFRT"
     const AnyConcreteRArray = AnyConcreteIFRTArray
+end
+
+for aType in (:ConcretePJRTArray, :ConcreteIFRTArray)
+    @eval function $(aType){T}(::UndefInitializer, shape::Integer...; kwargs...) where {T}
+        return $(aType){T}(undef, Dims(shape); kwargs...)
+    end
 end
 
 function ConcretePJRTArray{T}(

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -163,6 +163,17 @@ function ConcretePJRTNumber{T}(data::T2; kwargs...) where {T<:Number,T2<:Number}
                                                             sharded"
     return ConcretePJRTNumber{T,length(carray.data)}(carray.data, carray.sharding)
 end
+function ConcretePJRTNumber{T}(
+    data::ConcretePJRTNumber{T2}; kwargs...
+) where {T<:Number,T2<:Number}
+    return ConcretePJRTNumber{T}(
+        convert(T, data);
+        client=XLA.client(data),
+        device=XLA.device(data),
+        data.sharding,
+        kwargs...,
+    )
+end
 function ConcretePJRTNumber(data::T; kwargs...) where {T<:Number}
     return ConcretePJRTNumber{T}(data; kwargs...)
 end
@@ -285,6 +296,17 @@ end
 function ConcreteIFRTNumber{T}(data::T2; kwargs...) where {T<:Number,T2<:Number}
     carray = ConcreteIFRTArray(fill(convert(T, data)); kwargs...)
     return ConcreteIFRTNumber{T}(carray.data, carray.sharding)
+end
+function ConcreteIFRTNumber{T}(
+    data::ConcreteIFRTNumber{T2}; kwargs...
+) where {T<:Number,T2<:Number}
+    return ConcreteIFRTNumber{T}(
+        convert(T, data);
+        client=XLA.client(data),
+        device=XLA.device(data),
+        data.sharding,
+        kwargs...,
+    )
 end
 function ConcreteIFRTNumber(data::T; kwargs...) where {T<:Number}
     return ConcreteIFRTNumber{T}(data; kwargs...)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -142,6 +142,8 @@ mutable struct ConcretePJRTNumber{T,D} <: AbstractConcreteNumber{T}
     end
 end
 
+ConcretePJRTNumber{T,1}(x::Number) where {T} = ConcretePJRTNumber{T}(x)
+
 function ConcretePJRTNumber{T}(data::Tuple{XLA.PJRT.AsyncBuffer}) where {T}
     return ConcretePJRTNumber{T,1}(data, Sharding.NoShardInfo())
 end
@@ -512,7 +514,7 @@ function ConcretePJRTArray{T}(
     sharded_data, shardinfo = sharding(theclient, thedevice, T, shape)
     N = length(shape)
     nsharded = length(sharded_data)
-    return ConcretePJRTArray{T,N,nsharded,typeof(shardinfo)}(sharded_data, shape, shardinfo)
+    return ConcretePJRTArray{T,N,nsharded}(sharded_data, shape, shardinfo)
 end
 
 function ConcreteIFRTArray{T}(
@@ -529,7 +531,7 @@ function ConcreteIFRTArray{T}(
     dummy_array = Array{T}(undef, shape)
     # ToDo: How to use specified device (non-sharded case)?
     sharded_data, shardinfo, padding = sharding(theclient, nothing, dummy_array)
-    return ConcreteIFRTArray{T,N,typeof(shardinfo)}(sharded_data, shape, shardinfo, padding)
+    return ConcreteIFRTArray{T,N}(sharded_data, shape, shardinfo, padding)
 end
 
 function _select_client_and_device(

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -22,32 +22,17 @@ fwd(Mode, RT, x, y) = Enzyme.autodiff(Mode, square, RT, Duplicated(x, y))
         Enzyme.Reverse,
     ) <: Enzyme.Duplicated
 
-    @test Enzyme.guess_activity(
-        Reactant.ConcretePJRTNumber{
-            Float32,1,Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding,Nothing}
-        },
-        Enzyme.Reverse,
-    ) <: Enzyme.Duplicated
+    @test Enzyme.guess_activity(Reactant.ConcretePJRTNumber{Float32,1}, Enzyme.Reverse) <:
+        Enzyme.Duplicated
 
     @test Enzyme.guess_activity(Reactant.ConcretePJRTNumber{Float32}, Enzyme.Reverse) <:
         Enzyme.Duplicated
 
-    @test Enzyme.guess_activity(
-        Reactant.ConcretePJRTNumber{
-            Float32,1,Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding,Nothing}
-        },
-        Enzyme.Reverse,
-    ) <: Enzyme.Duplicated
+    @test Enzyme.guess_activity(Reactant.ConcretePJRTNumber{Float32,1}, Enzyme.Reverse) <:
+        Enzyme.Duplicated
 
     @test Enzyme.guess_activity(Reactant.ConcretePJRTNumber{Float32}, Enzyme.Reverse) <:
         Enzyme.Duplicated
-
-    @test Enzyme.guess_activity(
-        Reactant.ConcreteIFRTNumber{
-            Float32,Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding,Nothing}
-        },
-        Enzyme.Reverse,
-    ) <: Enzyme.Duplicated
 
     @test Enzyme.guess_activity(Reactant.ConcreteIFRTNumber{Float32}, Enzyme.Reverse) <:
         Enzyme.Duplicated

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -5,22 +5,14 @@ square(x) = x * 2
 fwd(Mode, RT, x, y) = Enzyme.autodiff(Mode, square, RT, Duplicated(x, y))
 
 @testset "Activity" begin
-    @test Enzyme.guess_activity(
-        Reactant.ConcretePJRTArray{
-            Float32,2,1,Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding,Nothing}
-        },
-        Enzyme.Reverse,
-    ) <: Enzyme.Duplicated
+    @test Enzyme.guess_activity(Reactant.ConcretePJRTArray{Float32,2,1}, Enzyme.Reverse) <:
+        Enzyme.Duplicated
 
     @test Enzyme.guess_activity(Reactant.ConcretePJRTArray{Float32}, Enzyme.Reverse) <:
         Enzyme.Duplicated
 
-    @test Enzyme.guess_activity(
-        Reactant.ConcreteIFRTArray{
-            Float32,2,Reactant.Sharding.ShardInfo{Reactant.Sharding.NoSharding,Nothing}
-        },
-        Enzyme.Reverse,
-    ) <: Enzyme.Duplicated
+    @test Enzyme.guess_activity(Reactant.ConcreteIFRTArray{Float32,2}, Enzyme.Reverse) <:
+        Enzyme.Duplicated
 
     @test Enzyme.guess_activity(Reactant.ConcretePJRTNumber{Float32,1}, Enzyme.Reverse) <:
         Enzyme.Duplicated


### PR DESCRIPTION
Traced types don't have a sense of sharding hence when we construct the equivalent Concrete type it is not possible to get the exact sharding type (atleast not without reworking how trace_type_inner works)

(Also this doesn't really affect any kind of performance critical parts of the code)

fixes https://github.com/EnzymeAD/Reactant.jl/issues/1227