### PR TITLE
Support unified memory

### DIFF
--- a/src/xla/XLA.jl
+++ b/src/xla/XLA.jl
@@ -134,8 +134,13 @@ function __init__()
             )
             @debug "XLA_REACTANT_GPU_MEM_FRACTION: " XLA_REACTANT_GPU_MEM_FRACTION[] maxlog =
                 1
-            if XLA_REACTANT_GPU_MEM_FRACTION[] > 1 || XLA_REACTANT_GPU_MEM_FRACTION[] < 0
-                error("XLA_REACTANT_GPU_MEM_FRACTION must be between 0 and 1")
+            if XLA_REACTANT_GPU_MEM_FRACTION[] < 0
+                error("XLA_REACTANT_GPU_MEM_FRACTION must be not be negative")
+            elseif XLA_REACTANT_GPU_MEM_FRACTION[] > 1
+                if get(ENV, "TF_FORCE_UNIFIED_MEMORY", "0") != "1"
+                    error("XLA_REACTANT_GPU_MEM_FRACTION must be not greater than 1 without \
+                        TF_FORCE_UNIFIED_MEMORY=1")
+                end
             end
         end
 


### PR DESCRIPTION
Doesn't fully work yet. Allocation of unified memory works after relaxing the limits of `XLA_REACTANT_GPU_MEM_FRACTION` in `__init__()` in XLA.jl. With

```shell
export TF_FORCE_UNIFIED_MEMORY=1
export XLA_REACTANT_GPU_MEM_FRACTION=4
```

we can run

```julia
using Reactant

Reactant.set_default_backend("cuda")

Reactant.XLA.default_device()
Reactant.XLA.XLA_REACTANT_GPU_MEM_FRACTION[]

A = ConcreteRArray{Float32}(undef, 6*10^10)
sizeof(eltype(A)) * length(A) / 1024^3
```

and successfully allocate 224 GiB on an NVIDIA GH200 system with 96GB GPU RAM and 480GB CPU RAM.

`nvtop` actually shows the GPU ram being filled up and then flattening out when full, and `free` shows that the rest of the array has been allocated on CPU RAM. (Note, `nvidia-smi` is not helpful, it only shows 578MiB allocated by the Julia process in unified memory mode, but from what I read that's expected.)

But when I try to fill and sum the array

```julia
fill_sum = @compile sum(fill!(A, one(eltype(A))))
fill_sum(A)
```

compilation fails with

```
E0000 00:00:1761906288.544836 1566209 gpu_hlo_schedule.cc:817] The byte size of input/output arguments (240000000000) exceeds the base limit (81604378624). This indicates an error in the calculation!
```

so the compiler still tries to limit sizes to GPU ram instead of unified RAM.

@wsmoses I think I need some help, here.