### PR TITLE
feat(JLL): wrappers for xprof apis

### DIFF
--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -1,6 +1,6 @@
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("@xla//tools/toolchains/cross_compile/cc:cc_toolchain_config.bzl", "cc_toolchain_config")
 
 # load("//toolchain:yggdrasil.bzl", "ygg_cc_toolchain")
@@ -1060,6 +1060,9 @@ cc_library(
             "-Wl,-exported_symbol,_RunAnalysisOnHloModule",
             "-Wl,-exported_symbol,_EstimateRunTimeForInstruction",
             "-Wl,-exported_symbol,_registerReactantXLAFFI",
+            "-Wl,-exported_symbol,_InitializeXProfStubs",
+            "-Wl,-exported_symbol,_StartGrpcServer",
+            "-Wl,-exported_symbol,_XSpaceToToolsData",
         ],
     }),
     linkstatic = True,
@@ -1163,6 +1166,9 @@ cc_library(
         "@xla//xla/backends/profiler/cpu:metadata_utils",
         "@xla//xla/backends/profiler/tpu:tpu_tracer",
         "@xla//xla/python:profiler_utils",
+        "@org_xprof//xprof/pywrap:profiler_plugin_impl",
+        "@org_xprof//plugin/xprof/worker:stub_factory",
+        "@org_xprof//xprof/convert:tool_options",
         "@tsl//tsl/platform:env_impl",
         "@xla//xla/stream_executor:stream_executor_impl",
         "@xla//xla/mlir/utils:type_util",

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -15,6 +15,17 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
+XPROF_COMMIT = "xprof-v2.21.1"
+
+XPROF_SHA256 = ""
+
+http_archive(
+    name = "org_xprof",
+    sha256 = XPROF_SHA256,
+    strip_prefix = "xprof-" + XPROF_COMMIT,
+    urls = ["https://github.com/openxla/xprof/archive/refs/tags/{commit}.tar.gz".format(commit = XPROF_COMMIT)],
+)
+
 http_archive(
     name = "enzyme_ad",
     patch_cmds = [
@@ -226,11 +237,6 @@ load(
 
 cuda_json_init_repository()
 
-load(
-    "@cuda_redist_json//:distributions.bzl",
-    "CUDA_REDISTRIBUTIONS",
-    "CUDNN_REDISTRIBUTIONS",
-)
 load(
     "@cuda_redist_json//:distributions.bzl",
     "CUDA_REDISTRIBUTIONS",


### PR DESCRIPTION
Will let us implement versions of `@profile`, `@time`, etc which return the actual execution time. Will have a follow up PR removing the python nonsense from XProfUtils and will move that module into reactant itself.