### PR TITLE
chore: bump xprof version

### DIFF
--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -15,7 +15,7 @@ http_archive(
     urls = ["https://github.com/wsmoses/nsync/archive/{commit}.tar.gz".format(commit = NSYNC_COMMIT)],
 )
 
-XPROF_COMMIT = "xprof-v2.21.1"
+XPROF_COMMIT = "e2f03b3f236c581ec2ce70a548b753546f587c3d"
 
 XPROF_SHA256 = ""
 
@@ -23,7 +23,7 @@ http_archive(
     name = "org_xprof",
     sha256 = XPROF_SHA256,
     strip_prefix = "xprof-" + XPROF_COMMIT,
-    urls = ["https://github.com/openxla/xprof/archive/refs/tags/{commit}.tar.gz".format(commit = XPROF_COMMIT)],
+    urls = ["https://github.com/openxla/xprof/archive/{commit}.tar.gz".format(commit = XPROF_COMMIT)],
 )
 
 http_archive(


### PR DESCRIPTION
needed for tpu info