### PR TITLE
Change CondaPkg.toml

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,4 +4,4 @@ python = "<=3.12,>=3.9,<4"
 [pip.deps]
 jax = ">= 0.5"
 tensorflow = ">= 2.17"
-numpy = ">= 1, >= 2"
+numpy = ">= 1"


### PR DESCRIPTION
Python is a weird language and when you do ">=1, >=2" this is the same as "2" in Julia so the version 1 is ignored. If you relax CondaPkg.toml to ">=1" it means all versions past and equal to one will be included such as "2", "3", "4", etc.

I need this for some of my code where we have a upper bound on numpy.

I think Python's sematics are explained here https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers-compatible-release