### PR TITLE
fix: remove usage of looped_any

### DIFF
--- a/ext/ReactantPythonCallExt/overlays.jl
+++ b/ext/ReactantPythonCallExt/overlays.jl
@@ -1,5 +1,5 @@
 @reactant_overlay function PythonCall.pycall(f::Py, args...)
-    if Reactant.looped_any(Reactant.use_overlayed_version, args)
+    if Reactant.use_overlayed_version(args)
         return pycall_with_jax_tracing(f, args...)
     else
         return Reactant.call_with_native(PythonCall.pycall, f, args...)

--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -211,11 +211,7 @@ end
 end
 
 @reactant_overlay @noinline function Base.map(f, x::AbstractArray, ys::AbstractArray...)
-    if (
-        use_overlayed_version(x) ||
-        use_overlayed_version(f) ||
-        looped_any(use_overlayed_version, ys)
-    )
+    if use_overlayed_version((f, x, ys...))
         return call_with_native(TracedRArrayOverrides.overloaded_map, f, x, ys...)
     else
         return call_with_native(Base.map, CallWithReactant(f), x, ys...)
@@ -225,12 +221,7 @@ end
 @reactant_overlay @noinline function Base.map!(
     f, y::AbstractArray, x::AbstractArray, xs::AbstractArray...
 )
-    if (
-        use_overlayed_version(y) ||
-        use_overlayed_version(x) ||
-        use_overlayed_version(f) ||
-        looped_any(use_overlayed_version, xs)
-    )
+    if use_overlayed_version((f, y, x, xs...))
         return call_with_native(TracedRArrayOverrides.overloaded_map!, f, y, x, xs...)
     else
         return call_with_native(Base.map!, CallWithReactant(f), y, x, xs...)

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -212,9 +212,9 @@ end
 use_overlayed_version(x::Base.Generator) = use_overlayed_version((x.f, x.iter))
 use_overlayed_version(x::Base.Iterators.Zip) = use_overlayed_version(x.is)
 use_overlayed_version(x::Base.Iterators.Enumerate) = use_overlayed_version(x.itr)
-use_overlayed_version(x::Vector) = looped_any(use_overlayed_version, x)
-use_overlayed_version(iter::Tuple) = looped_any(use_overlayed_version, iter)
-use_overlayed_version(iter::NamedTuple) = looped_any(use_overlayed_version, values(iter))
+function use_overlayed_version(x::Union{Vector,Tuple,NamedTuple})
+    return call_with_native(any, use_overlayed_version, values(x))
+end
 use_overlayed_version(::Number) = false
 use_overlayed_version(::MissingTracedValue) = true
 use_overlayed_version(rng::ReactantRNG) = use_overlayed_version(rng.seed)
@@ -227,14 +227,6 @@ function use_overlayed_version(x::AbstractArray)
     a = ancestor(x)
     a === x && return false
     return use_overlayed_version(a)
-end
-
-## We avoid calling into `any` to avoid triggering the `any` overlay
-function looped_any(f::F, itr) where {F}
-    @inbounds for x in itr
-        f(x) && return true
-    end
-    return false
 end
 
 # StdLib Overloads

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -672,7 +672,7 @@ function finalize_mlir_fn(
     skipped_results = Reactant.TracedType[]
     for (k, v) in seen_results
         v isa Reactant.TracedType || continue
-        if Reactant.looped_any(Base.Fix1(===, k), skipped_args)
+        if Reactant.call_with_native(any, Base.Fix1(===, k), skipped_args)
             push!(skipped_results, v)
 
             _, argpath = get_argidx(v, argprefix)


### PR DESCRIPTION
Checking if we can safely remove this. Previously we had issues with OC, so had to add this.