### PR TITLE
Add fft inverse complex tests

### DIFF
--- a/test/ops.jl
+++ b/test/ops.jl
@@ -332,7 +332,9 @@ end
     @test ComplexF32[1.0, -1.0, 1.0, -1.0] ≈ @jit(gifft(x))
 
     # Test FFT followed by IFFT recovers original (round-trip)
-    original = Reactant.to_rarray(ComplexF32[1.0 + 2.0im, 3.0 - 1.0im, -2.0 + 0.5im, 0.0 - 3.0im])
+    original = Reactant.to_rarray(
+        ComplexF32[1.0 + 2.0im, 3.0 - 1.0im, -2.0 + 0.5im, 0.0 - 3.0im]
+    )
     fft_result = @jit(gfft(original))
     @test Array(original) ≈ @jit(gifft(Reactant.to_rarray(fft_result)))
 


### PR DESCRIPTION
- Add tests for inverse FFT (IFFT) with complex inputs
- Add tests for inverse real FFT (IRFFT) with complex inputs  
- Add round-trip tests verifying FFT→IFFT and RFFT→IRFFT recover original

Closes part of #311 (fft inverse and complex numbers)