### PR TITLE
fix: set_dimension_size bugs and add tests

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -587,7 +587,7 @@ end
 
 @noinline function set_dimension_size(
     x::TracedRArray{T,N},
-    size::TracedRNumber{Int},
+    dim_size::TracedRNumber{Int32},
     dim::Int;
     location=mlir_stacktrace("set_dimension_size", @__FILE__, @__LINE__),
 ) where {T,N}
@@ -595,8 +595,8 @@ end
     res = MLIR.IR.result(
         stablehlo.set_dimension_size(
             x.mlir_data,
-            size.mlir_data;
-            result=mlir_type(TracedRArray{T,N}, size(x)),
+            dim_size.mlir_data;
+            result_0=mlir_type(TracedRArray{T,N}, size(x)),
             dimension,
             location,
         ),

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -661,7 +661,38 @@ end
 
 @testset "send" begin end
 
-@testset "set_dimension_size" begin end
+@testset "set_dimension_size" begin
+    # Test with 1D array
+    x = Reactant.to_rarray(Float32[1.0, 2.0, 3.0, 4.0])
+    dim_size = ConcreteRNumber(Int32(4))
+    g1(x, s) = Ops.set_dimension_size(x, s, 1)
+    result = @jit(g1(x, dim_size))
+    @test size(result) == (4,)
+    @test Array(result) ≈ Float32[1.0, 2.0, 3.0, 4.0]
+
+    # Test with 2D array, setting dimension 1
+    x2d = Reactant.to_rarray(Float32[1.0 2.0; 3.0 4.0; 5.0 6.0])
+    dim_size = ConcreteRNumber(Int32(3))
+    g2(x, s) = Ops.set_dimension_size(x, s, 1)
+    result = @jit(g2(x2d, dim_size))
+    @test size(result) == (3, 2)
+    @test Array(result) ≈ Float32[1.0 2.0; 3.0 4.0; 5.0 6.0]
+
+    # Test with 2D array, setting dimension 2
+    dim_size = ConcreteRNumber(Int32(2))
+    g3(x, s) = Ops.set_dimension_size(x, s, 2)
+    result = @jit(g3(x2d, dim_size))
+    @test size(result) == (3, 2)
+    @test Array(result) ≈ Float32[1.0 2.0; 3.0 4.0; 5.0 6.0]
+
+    # Test with different element types (Int32 array)
+    x_int = Reactant.to_rarray(Int32[1, 2, 3])
+    dim_size = ConcreteRNumber(Int32(3))
+    g4(x, s) = Ops.set_dimension_size(x, s, 1)
+    result = @jit(g4(x_int, dim_size))
+    @test size(result) == (3,)
+    @test Array(result) == Int32[1, 2, 3]
+end
 
 @testset "shift_left" begin
     a = Reactant.to_rarray([-1, 0, 1])


### PR DESCRIPTION
- Rename parameter 'size' to 'dim_size' to avoid shadowing Base.size
- Change parameter type to Int32 (required by StableHLO spec)
- Fix keyword argument 'result' to 'result_0'
- Add comprehensive tests for 1D, 2D arrays and different dtypes

Closes part of #311 (set_dimension_size)