### PR TITLE
fix: convert AbstractRange to concrete types (#2276)

### DIFF
--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -2119,6 +2119,28 @@ end
 end
 
 @inline function to_rarray_internal(
+    @nospecialize(x::AbstractRange{<:ReactantPrimitive}),
+    @nospecialize(track_numbers::Type),
+    @nospecialize(sharding),
+    @nospecialize(runtime),
+    @nospecialize(device),
+    @nospecialize(client)
+)
+    return to_rarray_internal(collect(x), track_numbers, sharding, runtime, device, client)
+end
+
+@inline function to_rarray_internal(
+    @nospecialize(x::Base.ReshapedArray{<:ReactantPrimitive,N,<:AbstractRange}),
+    @nospecialize(track_numbers::Type),
+    @nospecialize(sharding),
+    @nospecialize(runtime),
+    @nospecialize(device),
+    @nospecialize(client)
+) where {N}
+    return to_rarray_internal(collect(x), track_numbers, sharding, runtime, device, client)
+end
+
+@inline function to_rarray_internal(
     @nospecialize(x::Array{T}),
     @nospecialize(track_numbers::Type),
     @nospecialize(sharding),

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -240,6 +240,16 @@ function ConcretePJRTArray(
     return ConcretePJRTArray{T,N,nsharded}(sharded_data, shape, shardinfo)
 end
 
+function ConcretePJRTArray(
+    data::AbstractRange{T};
+    client::Union{Nothing,XLA.PJRT.Client}=nothing,
+    idx::Union{Int,Nothing}=nothing,
+    device::Union{Nothing,XLA.PJRT.Device}=nothing,
+    sharding::Sharding.AbstractSharding=Sharding.NoSharding(),
+) where {T}
+    return ConcretePJRTArray(collect(data); client, idx, device, sharding)
+end
+
 Base.wait(x::Union{ConcretePJRTArray,ConcretePJRTNumber}) = foreach(wait, x.data)
 XLA.client(x::Union{ConcretePJRTArray,ConcretePJRTNumber}) = XLA.client(x.data)
 function XLA.device(x::Union{ConcretePJRTArray,ConcretePJRTNumber})
@@ -369,6 +379,16 @@ function ConcreteIFRTArray(
     # ToDo: How to use specified device (non-sharded case)?
     sharded_data, shardinfo, padding = sharding(theclient, nothing, data)
     return ConcreteIFRTArray{T,N}(sharded_data, shape, shardinfo, padding)
+end
+
+function ConcreteIFRTArray(
+    data::AbstractRange{T};
+    client::Union{Nothing,XLA.IFRT.Client}=nothing,
+    idx::Union{Int,Nothing}=nothing,
+    device::Union{Nothing,XLA.IFRT.Device}=nothing,
+    sharding::Sharding.AbstractSharding=Sharding.NoSharding(),
+) where {T}
+    return ConcreteIFRTArray(collect(data); client, idx, device, sharding)
 end
 
 # Assemble data from multiple arrays. Needed in distributed setting where each process wont


### PR DESCRIPTION
Fixes #2276.

- Adds support for converting `AbstractRange` types (e.g., `range()`, `reshape(range(...))`) to `ConcreteRArray` when using `to_rarray` or `Adapt.adapt`
- Added `AbstractArray` constructors for `ConcretePJRTArray` and `ConcreteIFRTArray`
- Added `to_rarray_internal` methods for `AbstractArray` types
- Added `Adapt.adapt_structure` overrides for range types
- Added tests for AbstractRange conversion