### PR TITLE
Remove ProbProg wrappers from JLL

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -381,33 +381,6 @@ enzymeActivityAttrGet(MlirContext ctx, int32_t val) {
                                               (mlir::enzyme::Activity)val));
 }
 
-REACTANT_ABI MLIR_CAPI_EXPORTED MlirType enzymeTraceTypeGet(MlirContext ctx) {
-  return wrap(mlir::enzyme::TraceType::get(unwrap(ctx)));
-}
-
-REACTANT_ABI MLIR_CAPI_EXPORTED MlirType
-enzymeConstraintTypeGet(MlirContext ctx) {
-  return wrap(mlir::enzyme::ConstraintType::get(unwrap(ctx)));
-}
-
-REACTANT_ABI MLIR_CAPI_EXPORTED MlirAttribute
-enzymeSymbolAttrGet(MlirContext ctx, uint64_t symbol) {
-  mlir::Attribute attr = mlir::enzyme::SymbolAttr::get(unwrap(ctx), symbol);
-  return wrap(attr);
-}
-
-REACTANT_ABI MLIR_CAPI_EXPORTED MlirAttribute
-enzymeRngDistributionAttrGet(MlirContext ctx, int32_t val) {
-  return wrap(mlir::enzyme::RngDistributionAttr::get(
-      unwrap(ctx), (mlir::enzyme::RngDistribution)val));
-}
-
-REACTANT_ABI MLIR_CAPI_EXPORTED MlirAttribute
-enzymeMCMCAlgorithmAttrGet(MlirContext ctx, int32_t val) {
-  return wrap(mlir::enzyme::MCMCAlgorithmAttr::get(
-      unwrap(ctx), (mlir::enzyme::MCMCAlgorithm)val));
-}
-
 // Create profiler session and start profiling
 REACTANT_ABI tsl::ProfilerSession *
 CreateProfilerSession(uint32_t device_tracer_level,


### PR DESCRIPTION
I removed a few Enzyme attributes in https://github.com/EnzymeAD/Enzyme/pull/2646 which causes Reactant_jll CI to fail. I think it would be good to remove them from API.cpp (luckily none of them are actually used in Reactant yet) and create a separate Enzyme PR to auto wrap them like in https://github.com/EnzymeAD/Enzyme-JAX/blob/main/src/enzyme_ad/jax/Integrations/c/EnzymeXLA.h