### PR TITLE
add `traced_type_inner` rule for `AbstractArray{T,N} where {T}`

### DIFF
--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -431,6 +431,17 @@ Base.@nospecializeinfer function traced_type_inner(
 end
 
 Base.@nospecializeinfer function traced_type_inner(
+    A::Type{AbstractArray{T,N} where {T}},
+    seen,
+    mode::TraceMode,
+    @nospecialize(track_numbers::Type),
+    @nospecialize(ndevices),
+    @nospecialize(runtime)
+) where {N}
+    return A
+end
+
+Base.@nospecializeinfer function traced_type_inner(
     A::Type{AbstractArray{T,N}},
     seen,
     mode::TraceMode,

--- a/test/core/tracing.jl
+++ b/test/core/tracing.jl
@@ -107,6 +107,21 @@ end
                     Array{TracedRArray{Float64,2},1},
                 ),
 
+                # AbstractArray types
+                (
+                    AbstractArray{Float64,1},
+                    AbstractArray{Float64,1},
+                    AbstractArray{TracedRNumber{Float64},1},
+                ),
+                (AbstractArray, AbstractArray, AbstractArray),
+                (
+                    AbstractArray{Float64},
+                    AbstractArray{Float64},
+                    AbstractArray{TracedRNumber{Float64}},
+                ),
+                (AbstractVector, AbstractVector, AbstractVector),
+                (AbstractMatrix, AbstractMatrix, AbstractMatrix),
+
                 # Union types
                 (Union{Nothing,Int}, Union{Nothing,Int}, Union{Nothing,TracedRNumber{Int}}),
                 (


### PR DESCRIPTION
fixes #2317

`DataFrames.DataFrame` has a field `Vector{AbstractVector}`, and we lacked a rule for `AbstractArray{T,N} where {T}`. thus going through the default rule and wrongfully returning `AbstractVector{Any}` instead of `AbstractVector`.

this now works.

```julia
julia> cat = build_df(4)
4×2 DataFrame
 Row │ a        b       
     │ Float64  Float64 
─────┼──────────────────
   1 │     1.0     10.0
   2 │     2.0     20.0
   3 │     3.0     30.0
   4 │     4.0     40.0

julia> @jit sum_cols(cat)
4-element Vector{Float64}:
 11.0
 22.0
 33.0
 44.0

julia> cat_ra = DataFrame(
           a = Reactant.ConcreteRArray(cat.a),
           b = Reactant.ConcreteRArray(cat.b),
       )
4×2 DataFrame
 Row │ a        b       
     │ Float64  Float64 
─────┼──────────────────
   1 │     1.0     10.0
   2 │     2.0     20.0
   3 │     3.0     30.0
   4 │     4.0     40.0

julia> @code_hlo sum_cols(cat_ra)
module @reactant_sum_cols attributes {mhlo.num_partitions = 1 : i64, mhlo.num_replicas = 1 : i64} {
  func.func @main(%arg0: tensor<4xf64> {enzymexla.memory_effects = []}, %arg1: tensor<4xf64> {enzymexla.memory_effects = []}) -> tensor<4xf64> attributes {enzymexla.memory_effects = []} {
    %0 = stablehlo.add %arg0, %arg1 : tensor<4xf64>
    return %0 : tensor<4xf64>
  }
}

julia> @jit sum_cols(cat_ra)
4-element ConcretePJRTArray{Float64,1}:
 11.0
 22.0
 33.0
 44.0
```

cc @vimarsh6739