### PR TITLE
fix Module leak in macros

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1558,7 +1558,9 @@ function compile_mlir(f, args; kwargs...)
     end
 end
 
-function compile_mlir(ctx, f, args; client=nothing, drop_unsupported_attributes=false, kwargs...)
+function compile_mlir(
+    ctx, f, args; client=nothing, drop_unsupported_attributes=false, kwargs...
+)
     client = client !== nothing ? client : XLA.default_backend()
     backend = XLA.platform_name(client)
 


### PR DESCRIPTION
required for #2365 tests to pass, but didn't want to make that PR bigger so i'm splitting that here.

the main change is that now `compile`, `compile_mlir` and `compile_xla` require a MLIR Context as its first argument (but i keep the methods without explicit context passing for backward compat). this is required for the cases in which they return a MLIR object and the Context lifetime must match the one of the MLIR operation / module.

such is the case of the `@code_hlo` and `@code_mhlo` macros, but i had to change the code of `compile_call_expr` to make all compatible.