### PR TITLE
Fix `create_result` codegen for Dict Symbol keys

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -639,10 +639,13 @@ function create_result(
 
         for (k, v) in pairs(tocopy)
             subexpr = create_result(v, append_path(path, k), args...)
+            # symbol keys must be quoted in generated code; otherwise
+            # they are interpreted as variable references
+            k_expr = k isa Symbol ? QuoteNode(k) : k
             push!(
                 resultgen_code,
                 quote
-                    @inbounds $sym[$k] = $subexpr
+                    @inbounds $sym[$k_expr] = $subexpr
                 end,
             )
         end

--- a/test/core/compile.jl
+++ b/test/core/compile.jl
@@ -581,3 +581,15 @@ end
 
     @test @jit(f(params_ra, points_ra)) ≈ f(params, points)
 end
+
+@testset "Dict with Symbol Keys" begin
+    f(x) = Dict(:Mhalo => x, :x => x .+ 1)
+    x = Reactant.to_rarray([1.0f0, 2.0f0])
+    y = @jit(f(x))
+
+    @test y isa Dict
+    @test haskey(y, :Mhalo)
+    @test haskey(y, :x)
+    @test Array(y[:Mhalo]) ≈ [1.0f0, 2.0f0]
+    @test Array(y[:x]) ≈ [2.0f0, 3.0f0]
+end


### PR DESCRIPTION
Fixes #2382 