### PR TITLE
refactor `hloSharding(To/From)TensorShardingAttr` to use MLIR-C types on the interface

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -2728,8 +2728,10 @@ REACTANT_ABI void distributed_runtime_service_shutdown(
 #pragma region Shardy
 
 REACTANT_ABI xla::HloSharding *
-hloShardingFromTensorShardingAttr(mlir::sdy::TensorShardingAttr attr,
-                                  mlir::sdy::MeshAttr meshAttr) {
+hloShardingFromTensorShardingAttr(MlirAttribute cattr,
+                                  MlirAttribute cmeshAttr) {
+  auto attr = mlir::cast<mlir::sdy::TensorShardingAttr>(unwrap(cattr));
+  auto meshAttr = mlir::cast<mlir::sdy::MeshAttr>(unwrap(cmeshAttr));
   mlir::ArrayRef<mlir::StringAttr> manual_axes = {};
   std::function<mlir::sdy::MeshAttr(mlir::sdy::TensorShardingAttr)>
       get_mesh_attr = [meshAttr](mlir::sdy::TensorShardingAttr local_attr) {


### PR DESCRIPTION
while debugging for other PR, i noticed that `hloShardingToTensorShardingAttr` and `hloShardingFromTensorShardingAttr` functions in ReactantExtra use MLIR C++ types on an C-interface.

although no problems have appeared, this is risky.

this PR addresses that by correctly using MLIR-C types `MlirContext` and `MlirAttribute`.