### PR TITLE
Remove `__init__` of `ProbProg`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Reactant"
 uuid = "3c362404-f566-11ee-1572-e11a4b42c853"
-version = "0.2.217"
+version = "0.2.218"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>", "Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>", "Paul Berg <paul@plutojl.org>", "Avik Pal <avikpal@mit.edu>", "Mosè Giordano <mose@gnu.org>"]
 
 [workspace]

--- a/src/probprog/FFI.jl
+++ b/src/probprog/FFI.jl
@@ -115,16 +115,3 @@ function show_dumps()
         end
     end
 end
-
-function __init__()
-    dump_ptr = @cfunction(
-        dump,
-        Cvoid,
-        (Ptr{Any}, Ptr{UInt8}, Ptr{UInt64}, Ptr{UInt64}, Ptr{UInt64}, Ptr{UInt64})
-    )
-    @ccall MLIR.API.mlir_c.EnzymeJaXMapSymbol(
-        :enzyme_probprog_dump::Cstring, dump_ptr::Ptr{Cvoid}
-    )::Cvoid
-
-    return nothing
-end


### PR DESCRIPTION
This is

1. [actively breaking testing in downstream packages](https://github.com/EnzymeAD/Reactant.jl/pull/2063#discussion_r2796194849)
2. [not required nor effective](https://github.com/EnzymeAD/Reactant.jl/pull/2063#discussion_r2796207954)

I'm also bumping the version number because I need this fix in a registered version.