### PR TITLE
Fix executable destructor

### DIFF
--- a/src/xla/IFRT/LoadedExecutable.jl
+++ b/src/xla/IFRT/LoadedExecutable.jl
@@ -1,4 +1,4 @@
-struct LoadedExecutable <: XLA.AbstractLoadedExecutable
+mutable struct LoadedExecutable <: XLA.AbstractLoadedExecutable
     exec::Ptr{Cvoid}
     num_outputs::Int64
     num_parameters::Int64

--- a/src/xla/PJRT/LoadedExecutable.jl
+++ b/src/xla/PJRT/LoadedExecutable.jl
@@ -1,4 +1,4 @@
-struct LoadedExecutable <: XLA.AbstractLoadedExecutable
+mutable struct LoadedExecutable <: XLA.AbstractLoadedExecutable
     exec::Ptr{Cvoid}
     num_outputs::Int64
     num_parameters::Int64


### PR DESCRIPTION
Similar "we destroyed the client but not the executable" issue to the one I mentioned on wednesday with the buffers.

Observed in https://github.com/EnzymeAD/Reactant.jl/actions/runs/21932567400/job/63339718046?pr=2425

```
[ Info: Saved 1 benchmark results to /__w/Reactant.jl/Reactant.jl/benchmark/oceananigans/results/oceananigans_TPUbenchmarks.json and /__w/Reactant.jl/Reactant.jl/benchmark/oceananigans/results/oceananigans_TPUbenchmarks_tflops.json

[38667] signal 11 (1): Segmentation fault
in expression starting at none:0
_ZN3tpu13ProgramHandleD2Ev at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZN3tsl8internal18ConcreteAsyncValueIN3tpu13ProgramHandleEED2Ev at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZZN3tsl10AsyncValue12MakeTypeInfoINS_8internal18ConcreteAsyncValueIN3tpu13ProgramHandleEEEEENS0_8TypeInfoEvENUlPS0_E_8__invokeES8_ at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZN3tsl10AsyncValue7DestroyEv at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZNSt3__u20__shared_ptr_emplaceIN3xla19TpuLoadedExecutable18LoadedProgramStateENS_9allocatorIS3_EEE16__on_zero_sharedEv at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZN3xla19TpuLoadedExecutable19EvictLoadedProgramsEv at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZN3xla19TpuLoadedExecutable6DeleteEv at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZN3xla19TpuLoadedExecutableD1Ev at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZN3xla19TpuLoadedExecutableD0Ev at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZN4pjrt29PJRT_LoadedExecutable_DestroyEP34PJRT_LoadedExecutable_Destroy_Args at /root/.julia/scratchspaces/3c362404-f566-11ee-1572-e11a4b42c853/libtpu/libtpu-0_0_35_dev20260129.so (unknown line)
_ZNSt17_Function_handlerIFvP21PJRT_LoadedExecutableEZN4pjrt27MakeLoadedExecutableDeleterEPK8PJRT_ApiE3$_0E9_M_invokeERKSt9_Any_dataOS1_ at /root/.julia/artifacts/a6475f5704704b033c8187081d1d7d7dfd3650bb/lib/libReactantExtra.so (unknown line)
_ZN3xla24PjRtCApiLoadedExecutableD2Ev at /root/.julia/artifacts/a6475f5704704b033c8187081d1d7d7dfd3650bb/lib/libReactantExtra.so (unknown line)
_ZN3xla24PjRtCApiLoadedExecutableD0Ev at /root/.julia/artifacts/a6475f5704704b033c8187081d1d7d7dfd3650bb/lib/libReactantExtra.so (unknown line)
free_exec at /__w/Reactant.jl/Reactant.jl/src/xla/PJRT/LoadedExecutable.jl:16
jfptr_free_exec_44358 at /root/.julia/compiled/v1.11/Reactant/p9PzF_3tOMV.so (unknown line)
run_finalizer at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/gc.c:303
jl_gc_run_finalizers_in_list at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/gc.c:393
run_finalizers at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/gc.c:439
run_finalizers at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/gc.c:420 [inlined]
ijl_gc_collect at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/gc.c:3915
gc at ./gcutils.jl:133 [inlined]
temp_cleanup_purge_all at ./file.jl:596
jfptr_temp_cleanup_purge_all_51603.1 at /__w/_tool/julia/1.11.9/x64/lib/julia/sys.so (unknown line)
_atexit at ./initdefs.jl:451
jfptr__atexit_69611.1 at /__w/_tool/julia/1.11.9/x64/lib/julia/sys.so (unknown line)
jl_apply at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/julia.h:2157 [inlined]
ijl_atexit_hook at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/init.c:271
jl_repl_entrypoint at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/src/jlapi.c:1060
main at /cache/build/builder-amdci4-7/julialang/julia-release-1-dot-11/cli/loader_exe.c:58
unknown function (ip: 0x7cd367b171c9)
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x4010b8)
```