### PR TITLE
Fix `Base.reduce_empty` call to `BottomRF`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,7 +88,7 @@ for F in (:MappingRF, :FilteringRF)
 end
 
 function Base.reduce_empty(f::Base.BottomRF{<:CallWithReactant}, T::Type)
-    return Base.reduce_empty(BottomRF(f.rf.f), T)
+    return Base.reduce_empty(Base.BottomRF(f.rf.f), T)
 end
 
 function Base.reduce_empty(f::Base.FlipArgs{<:CallWithReactant}, T::Type)


### PR DESCRIPTION
To be honest, I am not even sure what exactly this does, but this just seems like a straight bug, `BottomRF` isn't in scope. I just got a  ```ERROR: UndefVarError: `BottomRF` not defined in `Reactant```  while working on our model