### PR TITLE
fix: broadcast error when type inference did not produce concrete eltype

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -285,11 +285,8 @@ function Base.copy(bc::Broadcasted{<:AbstractReactantArrayStyle})
     end
     ElType = Broadcast.combine_eltypes(fn, bc.args)
     # Special case a union{} return so we can see the better error message
-    if ElType === Union{}
-        fn(map(first_scalar, bc.args)...)
-    elseif ElType == Any
-        res = fn(map(first_scalar, bc.args)...)
-        ElType = Core.Typeof(res)
+    if ElType === Union{} || ElType == Any || ElType == TracedRNumber
+        ElType = Core.Typeof(fn(map(first_scalar, bc.args)...))
     end
     if ElType == Any || ElType == Union{}
         throw(AssertionError("Failed to deduce eltype of broadcast of $fn, found $ElType"))

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -40,6 +40,9 @@ function Base.typemax(::Type{TracedRNumber{T}}) where {T}
 end
 Base.typemax(x::TracedRNumber{T}) where {T} = typemax(typeof(x))
 
+Base.floatmin(::Type{Reactant.TracedRNumber{T}}) where {T} = floatmin(T)
+Base.floatmax(::Type{Reactant.TracedRNumber{T}}) where {T} = floatmax(T)
+
 function Base.nextfloat(x::TracedRNumber{T}) where {T<:AbstractFloat}
     return @opcall next_after(x, typemax(x))
 end


### PR DESCRIPTION
fixes https://github.com/EnzymeAD/Reactant.jl/issues/2467

This probably warrants a deeper investigation, but atleast unblocks @dominic-chang's issue. The inferred type in base probably doesn't use the overloads in our interpreter.