### PR TITLE
Add MakeClientFromApi to C++ PJRT bridge

### DIFF
--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -1125,6 +1125,7 @@ cc_library(
             "-Wl,-exported_symbol,_LoadPjrtPlugin",
             "-Wl,-exported_symbol,_InitializePjrtPlugin",
             "-Wl,-exported_symbol,_MakeClientUsingPluginAPI",
+            "-Wl,-exported_symbol,_MakeClientFromApi",
             "-Wl,-exported_symbol,_GetCApiClient",
             "-Wl,-exported_symbol,_ClientNumDevices",
             "-Wl,-exported_symbol,_ClientNumAddressableDevices",


### PR DESCRIPTION
## Summary

Adds a new C++ function `MakeClientFromApi` that allows Julia-allocated `PJRT_Api` structs to be registered with XLA's PJRT infrastructure without needing `dlopen` on a shared library.

This is the C++/Bazel portion of the Metal PJRT backend work, split out per @avik-pal's request from #2489 so a new JLL can be built independently.

## Changes

- **`deps/ReactantExtra/API.cpp`** (+21 lines): New `MakeClientFromApi(api, device_type, client_name, error)` function that:
  1. Calls `pjrt::SetPjrtApi()` to register the API struct
  2. Calls `InitializePjrtPlugin()` to initialize the plugin
  3. Calls `RegisterProfiler()` and returns the client via `GetCApiClient()`
- **`deps/ReactantExtra/BUILD`** (+1 line): Exports `_MakeClientFromApi` symbol

## Context

The Metal PJRT backend (PR #2489) implements PJRT callbacks as Julia `@cfunction` pointers packed into a `PJRT_Api` struct. Unlike GPU/TPU plugins which are loaded via `dlopen` on a `.so/.dylib`, the Metal backend lives in Julia and needs a way to register its `PJRT_Api` struct directly with XLA. This function provides that bridge.

## Test plan

- [ ] JLL builds successfully with the new symbol exported
- [ ] `nm libReactantExtra.so | grep MakeClientFromApi` shows the symbol
- [ ] Full Metal backend integration tested in #2489

🤖 Generated with [Claude Code](https://claude.com/claude-code)