### PR TITLE
Improve error message for unbound type parameters

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -752,15 +752,17 @@ function call_llvm_generator(
     end
 
     for svar in mi.sparam_vals
-	if svar isa TypeVar
-		errstr = sprint() do io
-		    println(io, "Calling method with unbound type parameters is unsupported by GPUCompiler and thus Reactant")
-		    Enzyme.Compiler.pretty_print_mi(mi, io)
-		end
-	method_error =
-            :(throw(AssertionError($errstr)))
-        return stub(world, source, method_error)
-	end
+        if svar isa TypeVar
+            errstr = sprint() do io
+                println(
+                    io,
+                    "Calling method with unbound type parameters is unsupported by GPUCompiler and thus Reactant",
+                )
+                Enzyme.Compiler.pretty_print_mi(mi, io)
+            end
+            method_error = :(throw(AssertionError($errstr)))
+            return stub(world, source, method_error)
+        end
     end
     slotnames = Any[:call_llvm_generator, REDUB_ARGUMENTS_NAME]
     overdubbed_code = Any[]


### PR DESCRIPTION
Fixes https://github.com/EnzymeAD/Reactant.jl/issues/2494

```
ERROR: AssertionError: Calling method with unbound type parameters is unsupported by GPUCompiler and thus Reactant
test(::Float64)
     @ Main REPL[2]:1
Stacktrace:
  [1] macro expansion
    @ /mnt3/wmoses/git/Reactant.jl/src/utils.jl:0 [inlined]
  [2] call_with_reactant(::typeof(test), ::Float64)
    @ Reactant /mnt3/wmoses/git/Reactant.jl/src/utils.jl:1188
```