### PR TITLE
[CI] Pass `parsed_args` instead of `ARGS` to `runtests`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,28 +29,28 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          # - "1.10"
-          # - "1.11"
+          - "1.10"
+          - "1.11"
           - "1.12"
           # - 'nightly'
         os:
-          # - ubuntu-24.04
-          # # `ubuntu-22.04-arm` is considered more stable than `ubuntu-24.04-arm`:
-          # # <https://github.com/orgs/community/discussions/148648#discussioncomment-12099554>.
-          # - ubuntu-22.04-arm
-          # # Disable `macOS-13` until
-          # # <https://github.com/EnzymeAD/Reactant.jl/issues/867> is resolved.
-          # # - macOS-13
-          # - macOS-latest
-          # - windows-latest
+          - ubuntu-24.04
+          # `ubuntu-22.04-arm` is considered more stable than `ubuntu-24.04-arm`:
+          # <https://github.com/orgs/community/discussions/148648#discussioncomment-12099554>.
+          - ubuntu-22.04-arm
+          # Disable `macOS-13` until
+          # <https://github.com/EnzymeAD/Reactant.jl/issues/867> is resolved.
+          # - macOS-13
+          - macOS-latest
+          - windows-latest
           - linux-x86-ct6e-180-4tpu
         test_group:
           - core
-          # - nn
-          # - integration
-          # - probprog
+          - nn
+          - integration
+          - probprog
         runtime:
-          # - "pjrt"
+          - "pjrt"
           - "ifrt"
         exclude:
           - os: linux-x86-ct6e-180-4tpu


### PR DESCRIPTION
Fix #2518