### PR TITLE
Add script to regenerate mlir bindings manually

### DIFF
--- a/deps/ReactantExtra/regenerate-mlir-bindings.sh
+++ b/deps/ReactantExtra/regenerate-mlir-bindings.sh
@@ -1,0 +1,27 @@
+# Launch from deps/ReactantExtra
+
+# 1. Install JuliaFormatter
+julia --color=yes -e 'import Pkg; Pkg.add(; name="JuliaFormatter", version="1")'
+
+# 2. Set up a temporary depot path
+export JULIA_DEPOT_PATH="$HOME/.julia"
+
+# 3. Instantiate dependencies
+julia --project=. --color=yes -e 'using Pkg; Pkg.instantiate(); Pkg.precompile(); using Clang; Clang.JLLEnvs.get_system_includes()'
+
+# 4. Generate MLIR Bindings
+julia --project=. --color=yes make-bindings.jl
+
+# 5. Make files writable
+chmod -R u+rw ../../src/mlir/Dialects/
+chmod u+rw ../../src/mlir/libMLIR_h.jl
+
+# 6. Format the generated code
+julia --color=yes -e '
+  using JuliaFormatter
+  format("../../src/mlir/Dialects/")
+  format("../../src/mlir/libMLIR_h.jl")
+  # Format twice to work around formatter issue
+  format("../../src/mlir/Dialects/")
+  format("../../src/mlir/libMLIR_h.jl")
+'


### PR DESCRIPTION
I use this script to manually do the actions that `.github/workflows/regenerate-mlir-bindings.yml` does. I find this useful when actively developing Enzyme-JAX and Reactant simultaneously, and thought it might be worth considering checking it in. 