### PR TITLE
fix: missing tf_stats proto

### DIFF
--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -46,6 +46,7 @@ genrule(
         # Xprof protos - main files
         "@org_xprof//plugin/xprof/protobuf:op_metrics.proto",
         "@org_xprof//plugin/xprof/protobuf:op_stats.proto",
+        "@org_xprof//plugin/xprof/protobuf:tf_stats.proto",
         "@org_xprof//plugin/xprof/protobuf:op_profile.proto",
         "@org_xprof//plugin/xprof/protobuf:hlo_stats.proto",
         "@org_xprof//plugin/xprof/protobuf:kernel_stats.proto",


### PR DESCRIPTION
Needed for https://github.com/EnzymeAD/Reactant.jl/pull/2596