### PR TITLE
Extending the oceananigans benchmark

### DIFF
--- a/benchmark/oceananigans/abernathey_channel.jl
+++ b/benchmark/oceananigans/abernathey_channel.jl
@@ -381,18 +381,18 @@ function run_abernathey_channel_benchmark!(
         model, Tᵢ, Sᵢ, u_wind_stress, v_wind_stress, T_flux
     )
 
-    restimate_tracer_error = @compile raise_first=true raise=true sync=true estimate_tracer_error(
-        model, Tᵢ, Sᵢ, u_wind_stress, v_wind_stress, T_flux, Δz
-    )
+    #restimate_tracer_error = @compile raise_first=true raise=true sync=true estimate_tracer_error(
+    #    model, Tᵢ, Sᵢ, u_wind_stress, v_wind_stress, T_flux, Δz
+    #)
 
     rspinup_reentrant_channel_model!(model, Tᵢ, Sᵢ, u_wind_stress, v_wind_stress, T_flux)
     @allowscalar set!(Tᵢ, model.tracers.T)
     @allowscalar set!(Sᵢ, model.tracers.S)
 
     # Profile and time the spinup_reentrant_channel_model!
-    Reactant.Profiler.@profile restimate_tracer_error(model, Tᵢ, Sᵢ, u_wind_stress, v_wind_stress, T_flux, Δz)
+    #Reactant.Profiler.@profile restimate_tracer_error(model, Tᵢ, Sᵢ, u_wind_stress, v_wind_stress, T_flux, Δz)
 
-    #=
+    
     # Now AD test, make the grid again:
     grid = make_grid(architecture, Nx, Ny, Nz, z_faces)
     model = build_model(grid, Δt₀, parameters)
@@ -421,7 +421,7 @@ function run_abernathey_channel_benchmark!(
 
     # Profile and time the differentiate_tracer_error
     Reactant.Profiler.@profile rdifferentiate_tracer_error(model, Tᵢ, Sᵢ, u_wind_stress, v_wind_stress, T_flux, Δz_ra, dmodel, dTᵢ, dSᵢ, du_wind_stress, dv_wind_stress, dT_flux, dΔz_ra)
-    =#
+    
     return nothing
 end
 


### PR DESCRIPTION
This expands the Oceananigans benchmark from 9 steps to 25, and profiles the primal as well as reverse-mode derivative.