### PR TITLE
add `make_tracer` case for `IOStream`

### DIFF
--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -2449,3 +2449,14 @@ function make_tracer(
         return TracedRational(newnum, newden)
     end
 end
+
+function make_tracer(
+    seen,
+    prev::IOStream,
+    @nospecialize(path),
+    mode;
+    @nospecialize(sharding = Sharding.NoSharding()),
+    kwargs...,
+)
+    return prev
+end

--- a/test/core/tracing.jl
+++ b/test/core/tracing.jl
@@ -213,6 +213,8 @@ end
             Dict{Int,TracedRArray{Float64,0}},
             Dict{Int,TracedRArray{Float64,0}},
         ),
+
+        # others
         (Dict{Int}, Dict{Int}, Dict{Int}),
         (Dict, Dict, Dict),
         (
@@ -252,6 +254,7 @@ end
             Base.RefValue{A} where {A},
             Base.RefValue{A} where {A},
         ),
+        (IOStream, IOStream, IOStream),
         (Wrapper{Symbol,Symbol}, Wrapper{Symbol,Symbol}, Wrapper{Symbol,Symbol}),
         (
             Wrapper{Float64,Vector{Float64}},


### PR DESCRIPTION
fixes #2636

should we generalize this for all `IO`?

cc @maximilian-gelbrecht