### PR TITLE
Update `cubinFeatures` to support CUDA 12.9 and 13.0-13.2 

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -1732,7 +1732,7 @@ const cuOptLevel = Ref{Int}(2)
 #                                      12.2 -> 82
 #                                      11.8 -> 78
 function cubinFeatures()
-    fallback = "+ptx86"
+    fallback = "+ptx80"
     ver = MLIR.API.ReactantCudaDriverGetVersion()
     # No cuda available
     if ver == 0


### PR DESCRIPTION
* added the mapping for CUDA version -> PTX ISA for CUDA 12.9 and 13.0 - 13.2
* changed the fallback value from the non-existing feature `86` (should probably have been `+ptx86`?  But also, the PTX ISA 8.6 doesn't even exist, they jumped from 8.5 to 8.7) to `+ptx80`, the oldest supported ISA for CUDA 12

In Breeze.jl tests with Reactant, where we use a machine with CUDA 13.0, we're currently spammed by literally thousands of
```
'86' is not a recognized feature for this target (ignoring feature)
```
I confirmed in [this job](https://github.com/NumericalEarth/Breeze.jl/actions/runs/23385062535/job/68030614634#step:10:499) that they go away with this PR.  CC @dkytezab you might like this one 🙂 