### PR TITLE
Add stablehlo fixup pass 

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -2685,6 +2685,8 @@ function compile_mlir!(
                 ),
                 "to_mhlo_shardings",
             )
+
+            run_stablehlo_fixup!(mod)
         end
     end
 


### PR DESCRIPTION
workaround for https://github.com/openxla/stablehlo/pull/2924 used in https://github.com/PRONTOLab/GB-25/pull/258. 

not sure we want to merge :warning: 