### PR TITLE
Fix wrong link on Introduction page

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -74,7 +74,7 @@ export default defineConfig({
       { text: "Home", link: "/" },
       { text: "Getting Started",
         items: [
-          { text: "Introduction", link: "/introduction" },
+          { text: "Introduction", link: "/introduction/" },
           { text: "Configuration", link: "/introduction/configuration" },
           { text: "FAQs", link: "/introduction/FAQs" },
         ],
@@ -163,7 +163,7 @@ export default defineConfig({
         text: "Getting Started",
         collapsed: false,
         items: [
-          { text: "Introduction", link: "/introduction" },
+          { text: "Introduction", link: "/introduction/" },
           { text: "Configuration", link: "/introduction/configuration" },
           { text: "FAQs", link: "/introduction/FAQs" },
         ],


### PR DESCRIPTION
The introduction page is backed by `docs/src/introduction/index.md`, so its route should be `/introduction/` rather than `/introduction`.
Fixes #2720