### PR TITLE
change `@error` for `@warn` on backend initialization error

### DIFF
--- a/src/accelerators/Registration.jl
+++ b/src/accelerators/Registration.jl
@@ -108,7 +108,8 @@ function initialize_backends(
             state.clients[backend.platform_name] = client
             successful_initializations[i] = true
         catch err
-            @error "Failed to initialize client: $(backend.platform_name)" exception = (
+            @warn "Failed to initialize client: $(backend.platform_name)"
+            @debug "Failed to initialize client (with backtrace): $(backend.platform_name)" exception = (
                 err, catch_backtrace()
             )
         end


### PR DESCRIPTION
As discussed in #2774, it's a lil confusing for users to see an error with backtrace when a backend fails to init. Specially when CPU backend is chosen but a GPU backend fails.

cc @tpapp