### PR TITLE
despecialize generic `create_result` method

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -218,9 +218,9 @@ function traced_setfield_buffer!(
     return traced_setfield!(obj, field, cval, path)
 end
 
-function create_result(
-    tocopy::T,
-    path,
+Base.@nospecializeinfer function create_result(
+    @nospecialize(tocopy),
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -230,10 +230,12 @@ function create_result(
     result_cache,
     var_idx,
     resultgen_code,
-) where {T}
+)
     if !isstructtype(typeof(tocopy))
         error("cannot copy $tocopy of type $(Core.Typeof(tocopy))")
     end
+
+    T = typeof(tocopy)
 
     args = (
         result_stores,
@@ -277,7 +279,7 @@ end
 
 function create_result(
     tocopy::ConcretePJRTNumber{T,D},
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -319,7 +321,7 @@ end
 
 function create_result(
     tocopy::ConcreteIFRTNumber{T},
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -361,7 +363,7 @@ end
 
 function create_result(
     tocopy::ConcretePJRTArray{T,N,D},
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -404,7 +406,7 @@ end
 
 function create_result(
     tocopy::ConcreteIFRTArray{T,N},
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -490,7 +492,7 @@ end
 
 function create_result(
     tocopy::Array{T,N},
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -542,7 +544,7 @@ end
 
 function create_result(
     tocopy::Tuple,
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -573,7 +575,7 @@ end
 
 function create_result(
     tocopy::NamedTuple{K,T},
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -604,7 +606,7 @@ end
 
 function create_result(
     tocopy::D,
-    path,
+    @nospecialize(path::Tuple),
     result_stores,
     path_to_shard_info,
     to_unreshard_results,
@@ -661,7 +663,7 @@ end
 
 function create_result(
     tocopy::Reactant.XLA.AbstractDevice,
-    _path,
+    @nospecialize(_path::Tuple),
     _result_stores,
     _path_to_shard_info,
     _to_unreshard_results,
@@ -677,7 +679,7 @@ end
 
 function create_result(
     tocopy::Union{Integer,AbstractFloat,AbstractString,Nothing,Type,Symbol,Char},
-    _path,
+    @nospecialize(_path::Tuple),
     _result_stores,
     _path_to_shard_info,
     _to_unreshard_results,

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -235,7 +235,7 @@ Base.@nospecializeinfer function create_result(
         error("cannot copy $tocopy of type $(Core.Typeof(tocopy))")
     end
 
-    T = typeof(tocopy)
+    T = Core.Typeof(tocopy)
 
     args = (
         result_stores,

--- a/test/core/compile.jl
+++ b/test/core/compile.jl
@@ -195,7 +195,7 @@ end
 
     function Reactant.Compiler.create_result(
         tocopy::MockTestCustomPath,
-        path,
+        path::Tuple,
         result_stores,
         path_to_shard_info,
         to_unreshard_results,


### PR DESCRIPTION
this pr reduces time taken by `create_result` on first call to `@compile identity(model)` by a x4 factor: from 20% to 5% of total.

since most functions in GB-25 do not return the model, I don't expect to see a huge improvement on it but it's still nice and general.