### PR TITLE
refactor type of trace paths to persistent stack

### DIFF
--- a/ext/ReactantAbstractFFTsExt.jl
+++ b/ext/ReactantAbstractFFTsExt.jl
@@ -15,7 +15,7 @@ const AnyStridedTracedRArray{T,N} = StridedArray{TracedRNumber{T},N}
 function Reactant.make_tracer(
     seen,
     @nospecialize(prev::AbstractFFTs.Plan{T}),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Reactant.Sharding.NoSharding()),

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1710,7 +1710,7 @@ function Reactant.make_tracer(
             nv = Reactant.make_tracer(
                 seen,
                 pv,
-                append_path(path, I),
+                push(path, I),
                 mode;
                 track_numbers,
                 sharding=Base.getproperty(sharding, I),

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1017,7 +1017,7 @@ function to_bytes(x)
 end
 
 function Reactant.make_tracer(
-    seen, @nospecialize(prev::CuTracedArray), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::CuTracedArray), path, mode; kwargs...
 )
     x = Base.unsafe_pointer_to_objref(Base.reinterpret(Ptr{Cvoid}, prev.ptr))
     x = x::TracedRArray
@@ -1026,7 +1026,7 @@ function Reactant.make_tracer(
 end
 
 function Reactant.make_tracer(
-    seen, @nospecialize(prev::CuTracedRNumber), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::CuTracedRNumber), path, mode; kwargs...
 )
     x = Base.unsafe_pointer_to_objref(Base.reinterpret(Ptr{Cvoid}, prev.ptr))
     x = x::TracedRNumber
@@ -1676,7 +1676,7 @@ end
 function Reactant.make_tracer(
     seen,
     @nospecialize(prev::CUDA.CuArray),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Reactant.Sharding.NoSharding()),

--- a/ext/ReactantDatesExt/reactant_bindings.jl
+++ b/ext/ReactantDatesExt/reactant_bindings.jl
@@ -25,7 +25,7 @@ for T in (
     @eval function Reactant.make_tracer(
         seen,
         @nospecialize(prev::Dates.$T),
-        @nospecialize(path),
+        path,
         mode;
         @nospecialize(track_numbers::Type = Union{}),
         @nospecialize(sharding = Reactant.Sharding.NoSharding()),

--- a/ext/ReactantFillArraysExt.jl
+++ b/ext/ReactantFillArraysExt.jl
@@ -30,7 +30,7 @@ Base.@nospecializeinfer function Reactant.make_tracer(
 ) where {T,N,Axes}
     return Fill(
         Reactant.make_tracer(
-            seen, prev.value, (path..., 1), mode; kwargs..., track_numbers=Number
+            seen, prev.value, push(path, 1), mode; kwargs..., track_numbers=Number
         ),
         prev.axes,
     )
@@ -79,7 +79,7 @@ Base.@nospecializeinfer function Reactant.make_tracer(
 ) where {T,N,I,A}
     return OneElement(
         Reactant.make_tracer(
-            seen, prev.val, (path..., 1), mode; kwargs..., track_numbers=Number
+            seen, prev.val, push(path, 1), mode; kwargs..., track_numbers=Number
         ),
         prev.ind,
         prev.axes,

--- a/ext/ReactantFillArraysExt.jl
+++ b/ext/ReactantFillArraysExt.jl
@@ -26,7 +26,7 @@ for AT in (Fill, Ones, Zeros)
 end
 
 Base.@nospecializeinfer function Reactant.make_tracer(
-    seen, @nospecialize(prev::Fill{T,N,Axes}), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::Fill{T,N,Axes}), path, mode; kwargs...
 ) where {T,N,Axes}
     return Fill(
         Reactant.make_tracer(
@@ -39,7 +39,7 @@ end
 Base.@nospecializeinfer function Reactant.make_tracer(
     seen,
     @nospecialize(prev::Ones{T,N,Axes}),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     @nospecialize(runtime = nothing),
@@ -51,7 +51,7 @@ end
 Base.@nospecializeinfer function Reactant.make_tracer(
     seen,
     @nospecialize(prev::Zeros{T,N,Axes}),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     @nospecialize(runtime = nothing),
@@ -75,7 +75,7 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
 end
 
 Base.@nospecializeinfer function Reactant.make_tracer(
-    seen, @nospecialize(prev::OneElement{T,N,I,A}), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::OneElement{T,N,I,A}), path, mode; kwargs...
 ) where {T,N,I,A}
     return OneElement(
         Reactant.make_tracer(

--- a/ext/ReactantMPIExt/ReactantMPIExt.jl
+++ b/ext/ReactantMPIExt/ReactantMPIExt.jl
@@ -250,7 +250,7 @@ end
 # Base.@nospecializeinfer function Reactant.make_tracer(
 #     seen,
 #     @nospecialize(prev::TracedRequest),
-#     @nospecialize(path),
+#     path,
 #     mode;
 #     tobatch=nothing,
 #     toscalar=false,

--- a/ext/ReactantStructArraysExt.jl
+++ b/ext/ReactantStructArraysExt.jl
@@ -16,7 +16,6 @@ import Reactant:
     TraceMode,
     TracedToTypes,
     traced_type_inner,
-    append_path,
     make_tracer,
     traced_type,
     ReactantPrimitive,

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -21,7 +21,7 @@ import ..Reactant:
     OrderedIdDict,
     make_tracer,
     TracedToConcrete,
-    append_path,
+    push,
     ancestor,
     TracedType
 import Reactant: OptimizeCommunicationOptions, ShardyPropagationOptions, CompileOptions
@@ -257,7 +257,7 @@ function create_result(
             # If the field is undefined we don't set it. A common example for this is `du2`
             # for Tridiagonal
             isdefined(tocopy, i) || continue
-            ev = create_result(getfield(tocopy, i), append_path(path, i), args...)
+            ev = create_result(getfield(tocopy, i), push(path, i), args...)
             push!(elems, ev)
         end
 
@@ -527,7 +527,7 @@ function create_result(
         result_cache[tocopy] = sym
 
         for (i, v) in enumerate(tocopy)
-            subexpr = create_result(v, append_path(path, i), args...)
+            subexpr = create_result(v, push(path, i), args...)
             push!(
                 resultgen_code,
                 quote
@@ -566,7 +566,7 @@ function create_result(
     )
     elems = Union{Symbol,Expr}[]
     for (k, v) in pairs(tocopy)
-        push!(elems, create_result(v, append_path(path, k), args...))
+        push!(elems, create_result(v, push(path, k), args...))
     end
     return :(($(elems...),))
 end
@@ -597,7 +597,7 @@ function create_result(
     )
     elems = Union{Symbol,Expr}[]
     for (i, (_, v)) in enumerate(pairs(tocopy))
-        push!(elems, create_result(v, append_path(path, i), args...))
+        push!(elems, create_result(v, push(path, i), args...))
     end
     return :(NamedTuple{$K}(($(elems...),)))
 end
@@ -641,7 +641,7 @@ function create_result(
         result_cache[tocopy] = sym
 
         for (k, v) in pairs(tocopy)
-            subexpr = create_result(v, append_path(path, k), args...)
+            subexpr = create_result(v, push(path, k), args...)
             # symbol keys must be quoted in generated code; otherwise
             # they are interpreted as variable references
             k_expr = k isa Symbol ? QuoteNode(k) : k

--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -21,6 +21,7 @@ import ..Reactant:
     OrderedIdDict,
     make_tracer,
     TracedToConcrete,
+    PersistentStack,
     push,
     ancestor,
     TracedType
@@ -2169,7 +2170,7 @@ function compile_mlir!(
     end
 
     concrete_result = make_tracer(
-        OrderedIdDict(), traced_result, ("result",), TracedToConcrete; runtime
+        OrderedIdDict(), traced_result, PersistentStack{Any}("result"), TracedToConcrete; runtime
     )
 
     return Reactant.TracedUtils.CompiledMlirFnResult(
@@ -3108,7 +3109,7 @@ function codegen_unflatten!(
 
     result_code = create_result(
         concrete_result,
-        (),
+        PersistentStack{Any}(nothing, nothing, 0),
         result_stores,
         path_to_shard_info,
         to_unreshard_results,
@@ -3562,8 +3563,8 @@ function compile(ctx, f, args; kwargs...)
     (; linear_args, seen_args, linear_results, preserved_args, concrete_result) =
         mlir_fn_res
 
-    result_stores = Dict{Tuple,Symbol}()
-    path_to_shard_info = mlir_fn_res.is_sharded ? Dict{Tuple,Symbol}() : nothing
+    result_stores = Dict{PersistentStack{Any},Symbol}()
+    path_to_shard_info = mlir_fn_res.is_sharded ? Dict{PersistentStack{Any},Symbol}() : nothing
 
     global_mesh_expr = if mlir_fn_res.unique_meshes === nothing
         :()

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -42,12 +42,12 @@ Base.firstindex(::PersistentStack) = 1
 Base.lastindex(stack::PersistentStack) = length(stack)
 
 function Base.collect(stack::PersistentStack{T}) where {T}
-    res = T[pop(stack)]
-    state = Base.front(stack)
-    while !isnothing(state)
-        push!(res, pop(state))
-        state = Base.front(state)
+    n = length(stack)
+    res = Vector{T}(undef, n)
+    state = stack
+    for i in 1:n
+        res[n-i+1] = pop(state)
+        state = Base.front(state) 
     end
-    reverse!(res)
     return res
 end

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -7,6 +7,9 @@ end
 PersistentStack(x) = PersistentStack(x, nothing, 1)
 PersistentStack{T}(x) where {T} = PersistentStack{T}(x, nothing, 1)
 
+PersistentStack(stack::PersistentStack) = stack
+PersistentStack{T}(stack::PersistentStack{T}) where {T} = stack
+
 push(stack::PersistentStack, x) = PersistentStack(x, stack, length(stack) + 1)
 pop(stack::PersistentStack) = stack.data
 

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -1,14 +1,45 @@
 struct PersistentStack{T}
     data::T
     prev::Union{Nothing, PersistentStack{T}}
+    length::Int
 end
 
-PersistentStack(x) = PersistentStack(x, nothing)
-PersistentStack{T}(x) where {T} = PersistentStack{T}(x, nothing)
+PersistentStack(x) = PersistentStack(x, nothing, 1)
+PersistentStack{T}(x) where {T} = PersistentStack{T}(x, nothing, 1)
 
-push(stack::PersistentStack, x) = PersistentStack(x, stack)
+push(stack::PersistentStack, x) = PersistentStack(x, stack, length(stack) + 1)
 pop(stack::PersistentStack) = stack.data
 Base.front(stack::PersistentStack) = stack.prev
+
+Base.IteratorEltype(::Type{<:PersistentStack{T}}) where {T} = Base.HasEltype()
+Base.eltype(::Type{<:PersistentStack{T}}) where {T} = T
+Base.IteratorSize(::Type{<:PersistentStack}) = Base.HasLength()
+Base.length(stack::PersistentStack) = stack.length
+
+function Base.iterate(stack::PersistentStack, state = 1)
+    state > length(stack) && return nothing
+    return stack[state], state + 1
+end
+
+# fast shortcut for Base.Iterators.reverse
+function Base.iterate(stack::Base.Iterators.Reverse{<:PersistentStack}, state = stack.itr)
+    isempty(stack.itr) && return nothing
+    return pop(state), front(state)
+end
+
+function Base.getindex(stack::PersistentStack, i)
+    if i < 1 || i > length(stack)
+        throw(BoundsError(stack, i))
+    end
+    count = length(stack)
+    while count > i
+        stack = front(stack)
+        count -= 1
+    end
+    return pop(stack)
+end
+Base.firstindex(::PersistentStack) = 1
+Base.lastindex(stack::PersistentStack) = length(stack)
 
 function Base.collect(stack::PersistentStack{T}) where {T}
     res = T[pop(stack)]

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -78,7 +78,7 @@ function Base.collect(stack::PersistentStack{T}) where {T}
     state = stack
     for i in 1:n
         res[n-i+1] = pop(state)
-        state = Base.front(state) 
+        state = state.prev
     end
     return res
 end

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -9,7 +9,10 @@ PersistentStack{T}(x) where {T} = PersistentStack{T}(x, nothing, 1)
 
 push(stack::PersistentStack, x) = PersistentStack(x, stack, length(stack) + 1)
 pop(stack::PersistentStack) = stack.data
-Base.front(stack::PersistentStack) = stack.prev
+
+function Base.front(stack::PersistentStack{T}) where {T}
+    !isnothing(stack.prev) ? stack.prev : PersistentStack{T}(pop(stack), nothing, 0)
+end
 
 Base.IteratorEltype(::Type{<:PersistentStack{T}}) where {T} = Base.HasEltype()
 Base.eltype(::Type{<:PersistentStack{T}}) where {T} = T

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -54,3 +54,5 @@ end
 
 # calling (stack...,) is bad [median=617.612 ns]. use this instead [median=382.267 ns].
 Base.Tuple(stack::PersistentStack) = Tuple(collect(stack))
+
+Base.show(io::IO, stack::PersistentStack) = print(io, Tuple(stack))

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -43,7 +43,7 @@ function Base.getindex(stack::PersistentStack, i::Int)
 end
 
 function Base.getindex(stack::PersistentStack{T}, r::UnitRange{Int}) where {T}
-    isempty(r) && throw(ErrorException("Empty range is not supported."))
+    isempty(r) && return PersistentStack{T}(pop(stack), nothing, 0)
     if first(r) < 1 || last(r) > length(stack)
         throw(BoundsError(stack, r))
     end

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -27,7 +27,10 @@ function Base.iterate(stack::Base.Iterators.Reverse{<:PersistentStack}, state = 
     return pop(state), Base.front(state)
 end
 
-function Base.getindex(stack::PersistentStack, i)
+Base.firstindex(::PersistentStack) = 1
+Base.lastindex(stack::PersistentStack) = length(stack)
+
+function Base.getindex(stack::PersistentStack, i::Int)
     if i < 1 || i > length(stack)
         throw(BoundsError(stack, i))
     end
@@ -38,8 +41,19 @@ function Base.getindex(stack::PersistentStack, i)
     end
     return pop(stack)
 end
-Base.firstindex(::PersistentStack) = 1
-Base.lastindex(stack::PersistentStack) = length(stack)
+
+function Base.getindex(stack::PersistentStack{T}, r::UnitRange{Int}) where {T}
+    isempty(r) && throw(ErrorException("Empty range is not supported."))
+    if first(r) < 1 || last(r) > length(stack)
+        throw(BoundsError(stack, r))
+    end
+
+    res = PersistentStack{T}(stack[first(r)])
+    for i in r[2:end]
+        res = push(res, stack[i])
+    end
+    return res
+end
 
 function Base.collect(stack::PersistentStack{T}) where {T}
     n = length(stack)

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -1,0 +1,22 @@
+struct PersistentStack{T}
+    data::T
+    prev::Union{Nothing, PersistentStack{T}}
+end
+
+PersistentStack(x) = PersistentStack(x, nothing)
+PersistentStack{T}(x) where {T} = PersistentStack{T}(x, nothing)
+
+push(stack::PersistentStack, x) = PersistentStack(x, stack)
+pop(stack::PersistentStack) = stack.data
+Base.front(stack::PersistentStack) = stack.prev
+
+function Base.collect(stack::PersistentStack{T}) where {T}
+    res = T[pop(stack)]
+    state = front(stack)
+    while !isnothing(state)
+        push!(res, pop(state))
+        state = front(state)
+    end
+    reverse!(res)
+    return res
+end

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -51,3 +51,6 @@ function Base.collect(stack::PersistentStack{T}) where {T}
     end
     return res
 end
+
+# calling (stack...,) is bad [median=617.612 ns]. use this instead [median=382.267 ns].
+Base.Tuple(stack::PersistentStack) = Tuple(collect(stack))

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -55,6 +55,17 @@ function Base.getindex(stack::PersistentStack{T}, r::UnitRange{Int}) where {T}
     return res
 end
 
+function Base.hash(x::PersistentStack, h::UInt)
+    isempty(x) && return hash((), h ⊻ 0x12345678)
+    return hash((pop(x), Base.front(x)), h)
+end
+
+function Base.:(==)(x::PersistentStack, y::PersistentStack)
+    length(x) != length(y) && return false
+    isempty(x) && isempty(y) && return true
+    pop(x) == pop(y) && Base.front(x) == Base.front(y)
+end
+
 function Base.collect(stack::PersistentStack{T}) where {T}
     n = length(stack)
     res = Vector{T}(undef, n)

--- a/src/PersistentStack.jl
+++ b/src/PersistentStack.jl
@@ -24,7 +24,7 @@ end
 # fast shortcut for Base.Iterators.reverse
 function Base.iterate(stack::Base.Iterators.Reverse{<:PersistentStack}, state = stack.itr)
     isempty(stack.itr) && return nothing
-    return pop(state), front(state)
+    return pop(state), Base.front(state)
 end
 
 function Base.getindex(stack::PersistentStack, i)
@@ -33,7 +33,7 @@ function Base.getindex(stack::PersistentStack, i)
     end
     count = length(stack)
     while count > i
-        stack = front(stack)
+        stack = Base.front(stack)
         count -= 1
     end
     return pop(stack)
@@ -43,10 +43,10 @@ Base.lastindex(stack::PersistentStack) = length(stack)
 
 function Base.collect(stack::PersistentStack{T}) where {T}
     res = T[pop(stack)]
-    state = front(stack)
+    state = Base.front(stack)
     while !isnothing(state)
         push!(res, pop(state))
-        state = front(state)
+        state = Base.front(state)
     end
     reverse!(res)
     return res

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -49,6 +49,7 @@ include("ProtoUtils.jl")
 
 # auxiliary types and functions
 include("OrderedIdDict.jl")
+include("PersistentStack.jl")
 
 function precompiling()
     return (@ccall jl_generating_output()::Cint) == 1

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -12,6 +12,8 @@ using ..Reactant:
     MissingTracedValue,
     OrderedIdDict,
     Ops,
+    PersistentStack,
+    push,
     promote_to, # keep this to avoid breaking external code
     broadcast_to_size # keep this to avoid breaking external code
 using ..Ops: @opcall
@@ -471,9 +473,10 @@ function prepare_mlir_fn_args(
     Ops.activate_constant_context!(fnbody)
     seen_args0 = OrderedIdDict()
     try
+        path = PersistentStack{Any}(argprefix)
         for i in 1:N
             @inbounds traced_args[i] = Reactant.make_tracer(
-                seen_args0, args[i], (argprefix, i), inmode; toscalar, runtime
+                seen_args0, args[i], push(path, i), inmode; toscalar, runtime
             )
         end
     finally
@@ -665,15 +668,16 @@ function finalize_mlir_fn(
     MLIR.IR.activate(fnbody)
     traced_result = try
         traced_result = Reactant.make_tracer(
-            seen_results, result, (resprefix,), outmode; runtime
+            seen_results, result, PersistentStack{Any}(resprefix), outmode; runtime
         )
 
         # marks buffers to be donated
+        path = PersistentStack{Any}(resargprefix)
         for i in 1:N
             Reactant.make_tracer(
                 seen_results,
                 traced_args[i],
-                (resargprefix, i),
+                push(path, i),
                 Reactant.NoStopTracedTrack;
                 runtime,
             )

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -1380,7 +1380,7 @@ Base.@nospecializeinfer function make_tracer(
     mode == ArrayToConcrete && return ConcretePJRTArray(prev; sharding, device, client)
     mode != ConcreteToTraced && throw("Cannot trace concrete")
     haskey(seen, prev) && return seen[prev]::TracedRArray{T,N}
-    res = TracedRArray{T,N}((path,), nothing, size(prev))
+    res = TracedRArray{T,N}(PersistentStack{Any}(path), nothing, size(prev))
     seen[prev] = res
     return res
 end
@@ -1401,7 +1401,7 @@ Base.@nospecializeinfer function make_tracer(
     mode == ArrayToConcrete && return ConcreteIFRTArray(prev; sharding, device, client)
     mode != ConcreteToTraced && throw("Cannot trace concrete")
     haskey(seen, prev) && return seen[prev]::TracedRArray{T,N}
-    res = TracedRArray{T,N}((path,), nothing, size(prev))
+    res = TracedRArray{T,N}(PersistentStack{Any}(path), nothing, size(prev))
     seen[prev] = res
     return res
 end
@@ -1422,7 +1422,7 @@ Base.@nospecializeinfer function make_tracer(
     mode == ArrayToConcrete && return ConcretePJRTNumber(prev; sharding, device, client)
     mode != ConcreteToTraced && throw("Cannot trace existing trace type")
     haskey(seen, prev) && return seen[prev]::TracedRNumber{T}
-    res = TracedRNumber{T}((path,), nothing)
+    res = TracedRNumber{T}(PersistentStack{Any}(path), nothing)
     seen[prev] = res
     return res
 end
@@ -1443,7 +1443,7 @@ Base.@nospecializeinfer function make_tracer(
     mode == ArrayToConcrete && return ConcreteIFRTNumber(prev; sharding, device, client)
     mode != ConcreteToTraced && throw("Cannot trace existing trace type")
     haskey(seen, prev) && return seen[prev]::TracedRNumber{T}
-    res = TracedRNumber{T}((path,), nothing)
+    res = TracedRNumber{T}(PersistentStack{Any}(path), nothing)
     seen[prev] = res
     return res
 end
@@ -1486,11 +1486,11 @@ Base.@nospecializeinfer function make_tracer(
             return seen[prev]
         end
         res = if toscalar
-            TracedRNumber{T}((path,), nothing)
+            TracedRNumber{T}(PersistentStack{Any}(path), nothing)
         elseif tobatch !== nothing
             error("This should not happen...")
         else
-            TracedRArray{T,N}((path,), prev.mlir_data, size(prev))
+            TracedRArray{T,N}(PersistentStack{Any}(path), prev.mlir_data, size(prev))
         end
         seen[prev] = res
         return res
@@ -1575,11 +1575,11 @@ Base.@nospecializeinfer function make_tracer(
             return seen[prev]
         end
         res = if toscalar
-            TracedRNumber{T}((path,), nothing)
+            TracedRNumber{T}(PersistentStack{Any}(path), nothing)
         elseif tobatch !== nothing
-            TracedRArray{T,length(tobatch)}((path,), prev.mlir_data, tobatch)
+            TracedRArray{T,length(tobatch)}(PersistentStack{Any}(path), prev.mlir_data, tobatch)
         else
-            TracedRNumber{T}((path,), prev.mlir_data)
+            TracedRNumber{T}(PersistentStack{Any}(path), prev.mlir_data)
         end
         seen[prev] = res
         return res
@@ -1689,7 +1689,7 @@ Base.@nospecializeinfer function make_tracer(
             error("Unsupported runtime $runtime")
         else
             if mode == TracedTrack || mode == NoStopTracedTrack
-                res = TracedRNumber{RT}((path,), broadcast_to_size(prev, ()).mlir_data)
+                res = TracedRNumber{RT}(PersistentStack{Any}(path), broadcast_to_size(prev, ()).mlir_data)
                 if Base.ismutable(prev) && !haskey(seen, prev)
                     return seen[prev] = res
                 end
@@ -1697,7 +1697,7 @@ Base.@nospecializeinfer function make_tracer(
                 return res
             elseif mode == TracedSetPath
                 haskey(seen, prev) && return seen[prev]
-                res = TracedRNumber{RT}((path,), broadcast_to_size(prev, ()).mlir_data)
+                res = TracedRNumber{RT}(PersistentStack{Any}(path), broadcast_to_size(prev, ()).mlir_data)
                 seen[prev] = res
                 return res
             elseif mode == TracedToConcrete

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -1078,7 +1078,6 @@ function make_tracer(
 )
     return prev
 end
-append_path(@nospecialize(path), i) = (path..., i)
 
 Base.@nospecializeinfer function make_tracer_via_immutable_constructor(
     seen,
@@ -1122,7 +1121,7 @@ Base.@nospecializeinfer function make_tracer_via_immutable_constructor(
     changed = false
     for i in 1:nf
         if isdefined(prev, i)
-            newpath = mode == TracedToTypes ? path : append_path(path, i)
+            newpath = mode == TracedToTypes ? path : push(path, i)
             xi = Base.getfield(prev, i)
             xi2 = make_tracer(
                 seen,
@@ -1206,7 +1205,7 @@ Base.@nospecializeinfer function make_tracer_unknown(
         changed = false
         for i in 1:nf
             if isdefined(prev, i)
-                newpath = mode == TracedToTypes ? path : append_path(path, i)
+                newpath = mode == TracedToTypes ? path : push(path, i)
                 xi = Base.getfield(prev, i)
                 xi2 = make_tracer(
                     seen,
@@ -1243,7 +1242,7 @@ Base.@nospecializeinfer function make_tracer_unknown(
     changed = false
     for i in 1:nf
         if isdefined(prev, i)
-            newpath = mode == TracedToTypes ? path : append_path(path, i)
+            newpath = mode == TracedToTypes ? path : push(path, i)
             xi = Base.getfield(prev, i)
             xi2 = make_tracer(
                 seen,
@@ -1280,7 +1279,7 @@ Base.@nospecializeinfer function make_tracer_unknown(
                         elseif is_traced_number(ft_j) && val_j isa unwrapped_eltype(ft_j)
                             val_wrapped = ft_j(val_j)
                             # Correct the path for the wrapped scalar
-                            sub_path = append_path(newpath, j)
+                            sub_path = push(newpath, j)
                             val_wrapped = Core.Typeof(val_wrapped)(
                                 (sub_path,), val_wrapped.mlir_data
                             )
@@ -1359,7 +1358,7 @@ function make_tracer(
     kwargs...,
 )
     if toscalar && mode == TracedSetPath
-        return make_tracer(seen, prev[], append_path(path, :x), mode; toscalar=false)
+        return make_tracer(seen, prev[], push(path, :x), mode; toscalar=false)
     end
     @assert !toscalar
     return make_tracer_unknown(seen, prev, path, mode; toscalar, kwargs...)
@@ -1752,8 +1751,8 @@ Base.@nospecializeinfer function make_tracer(
         return nothing
     end
     return Complex(
-        make_tracer(seen, prev.re, append_path(path, :re), mode; kwargs...),
-        make_tracer(seen, prev.im, append_path(path, :im), mode; kwargs...),
+        make_tracer(seen, prev.re, push(path, :re), mode; kwargs...),
+        make_tracer(seen, prev.im, push(path, :im), mode; kwargs...),
     )
 end
 
@@ -1824,7 +1823,7 @@ Base.@nospecializeinfer function make_tracer(
             nv = make_tracer(
                 seen,
                 pv,
-                append_path(path, I),
+                push(path, I),
                 mode;
                 track_numbers,
                 sharding=Base.getproperty(sharding, I),
@@ -1928,7 +1927,7 @@ Base.@nospecializeinfer function make_tracer(
         nv = make_tracer(
             seen,
             v,
-            append_path(path, k),
+            push(path, k),
             mode;
             track_numbers,
             sharding=Base.getproperty(sharding, k),
@@ -1970,7 +1969,7 @@ Base.@nospecializeinfer function make_tracer(
             make_tracer(
                 seen,
                 v,
-                append_path(path, i),
+                push(path, i),
                 mode;
                 sharding=Base.getproperty(sharding, i),
                 kwargs...,
@@ -2007,7 +2006,7 @@ Base.@nospecializeinfer function make_tracer(
             make_tracer(
                 seen,
                 Base.getfield(prev, i),
-                append_path(path, i),
+                push(path, i),
                 mode;
                 sharding=Base.getproperty(sharding, i),
                 track_numbers,
@@ -2050,7 +2049,7 @@ Base.@nospecializeinfer function make_tracer(
     tr = make_tracer(
         seen,
         prev2,
-        append_path(path, :contents),
+        push(path, :contents),
         mode;
         sharding=Base.getproperty(sharding, :contents),
         kwargs...,
@@ -2334,8 +2333,8 @@ function make_tracer(
         make_tracer(seen, prev.stop, path, mode; kwargs...)
         return nothing
     end
-    newstart = make_tracer(seen, prev.start, append_path(path, :start), mode; kwargs...)
-    newstop = make_tracer(seen, prev.stop, append_path(path, :stop), mode; kwargs...)
+    newstart = make_tracer(seen, prev.start, push(path, :start), mode; kwargs...)
+    newstop = make_tracer(seen, prev.stop, push(path, :stop), mode; kwargs...)
     if typeof(newstart) == typeof(prev.start) && typeof(newstop) == typeof(prev.stop)
         return prev
     else
@@ -2381,21 +2380,21 @@ function make_tracer(
         make_tracer(seen, prev.offset, path, mode; sharding, kwargs...)
         return nothing
     end
-    newref = make_tracer(seen, prev.ref, append_path(path, :ref), mode; sharding, kwargs...)
+    newref = make_tracer(seen, prev.ref, push(path, :ref), mode; sharding, kwargs...)
     newstep = make_tracer(
-        seen, prev.step, append_path(path, :step), mode; sharding, kwargs...
+        seen, prev.step, push(path, :step), mode; sharding, kwargs...
     )
     newlen = make_tracer(
         seen,
         prev.len,
-        append_path(path, :len),
+        push(path, :len),
         mode;
         sharding,
         kwargs...,
         track_numbers=Union{},
     )
     newoffset = make_tracer(
-        seen, prev.offset, append_path(path, :offset), mode; sharding, kwargs...
+        seen, prev.offset, push(path, :offset), mode; sharding, kwargs...
     )
     if (
         typeof(newref) == typeof(prev.ref) &&
@@ -2441,8 +2440,8 @@ function make_tracer(
         make_tracer(seen, prev.den, path, mode; kwargs...)
         return nothing
     end
-    newnum = make_tracer(seen, prev.num, append_path(path, :num), mode; kwargs...)
-    newden = make_tracer(seen, prev.den, append_path(path, :den), mode; kwargs...)
+    newnum = make_tracer(seen, prev.num, push(path, :num), mode; kwargs...)
+    newden = make_tracer(seen, prev.den, push(path, :den), mode; kwargs...)
     if typeof(newnum) == typeof(prev.num) && typeof(newden) == typeof(prev.den)
         return prev
     else

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -1652,7 +1652,7 @@ Base.@nospecializeinfer function make_tracer(
     if mode == TracedSetPath
         TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         haskey(seen, prev) && return seen[prev]
-        res = MissingTracedValue((path,))
+        res = MissingTracedValue(Tuple(path))
         seen[res] = res
         return res
     end

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -1467,21 +1467,21 @@ Base.@nospecializeinfer function make_tracer(
         return nothing
     end
     if mode == TracedTrack
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if !haskey(seen, prev)
             return seen[prev] = prev
         end
         return prev
     end
     if mode == NoStopTracedTrack
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if !haskey(seen, prev)
             seen[prev] = prev # don't return!
         end
         return prev
     end
     if mode == TracedSetPath
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if haskey(seen, prev)
             return seen[prev]
         end
@@ -1556,21 +1556,21 @@ Base.@nospecializeinfer function make_tracer(
         return nothing
     end
     if mode == TracedTrack
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if !haskey(seen, prev)
             return seen[prev] = prev
         end
         return prev
     end
     if mode == NoStopTracedTrack
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if !haskey(seen, prev)
             seen[prev] = prev # don't return!
         end
         return prev
     end
     if mode == TracedSetPath
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if haskey(seen, prev)
             return seen[prev]
         end
@@ -1636,21 +1636,21 @@ Base.@nospecializeinfer function make_tracer(
         throw("Cannot have MissingTracedValue as function call argument.")
     end
     if mode == TracedTrack
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if !haskey(seen, prev)
             return seen[prev] = prev
         end
         return prev
     end
     if mode == NoStopTracedTrack
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         if !haskey(seen, prev)
             seen[prev] = prev # don't return!
         end
         return prev
     end
     if mode == TracedSetPath
-        TracedUtils.set_paths!(prev, (TracedUtils.get_paths(prev)..., path))
+        TracedUtils.set_paths!(prev, push(TracedUtils.get_paths(prev), path))
         haskey(seen, prev) && return seen[prev]
         res = MissingTracedValue((path,))
         seen[res] = res
@@ -2083,7 +2083,7 @@ Base.@nospecializeinfer function make_tracer(
         return make_tracer(seen, prev.seed, path, mode; kwargs...)
     end
     return ReactantRNG(
-        make_tracer(seen, prev.seed, (path..., 1), mode; kwargs...), prev.algorithm
+        make_tracer(seen, prev.seed, push(path, 1), mode; kwargs...), prev.algorithm
     )
 end
 
@@ -2093,7 +2093,7 @@ Base.@nospecializeinfer function make_tracer(
     if mode == ArrayToConcrete
         TracedRandom.should_warn_if_not_natively_supported(prev)
         return ReactantRNG(
-            make_tracer(seen, TracedRandom.make_seed(prev), (path..., 1), mode; kwargs...),
+            make_tracer(seen, TracedRandom.make_seed(prev), push(path, 1), mode; kwargs...),
             TracedRandom.rng_algorithm(prev),
         )
     end

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -1072,7 +1072,7 @@ end
 function make_tracer(
     seen,
     @nospecialize(prev::Union{Base.ExceptionStack,Core.MethodInstance}),
-    @nospecialize(path),
+    path,
     mode;
     kwargs...,
 )
@@ -1082,7 +1082,7 @@ end
 Base.@nospecializeinfer function make_tracer_via_immutable_constructor(
     seen,
     @nospecialize(prev),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -1166,7 +1166,7 @@ end
 Base.@nospecializeinfer function make_tracer_unknown(
     seen,
     @nospecialize(prev),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -1337,7 +1337,7 @@ end
 function make_tracer(
     seen,
     @nospecialize(prev),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -1352,7 +1352,7 @@ end
 function make_tracer(
     seen,
     @nospecialize(prev::Base.RefValue),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(toscalar = false),
     kwargs...,
@@ -1367,7 +1367,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::ConcretePJRTArray{T,N}),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     @nospecialize(device = nothing),
@@ -1388,7 +1388,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::ConcreteIFRTArray{T,N}),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     @nospecialize(device = nothing),
@@ -1409,7 +1409,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     prev::ConcretePJRTNumber{T},
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     @nospecialize(device = nothing),
@@ -1430,7 +1430,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::ConcreteIFRTNumber{T}),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     @nospecialize(device = nothing),
@@ -1451,7 +1451,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::TracedRArray{T,N}),
-    @nospecialize(path),
+    path,
     mode;
     toscalar=false,
     tobatch=nothing,
@@ -1540,7 +1540,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::TracedRNumber{T}),
-    @nospecialize(path),
+    path,
     mode;
     tobatch=nothing,
     toscalar=false,
@@ -1627,7 +1627,7 @@ Base.@nospecializeinfer function make_tracer(
 end
 
 Base.@nospecializeinfer function make_tracer(
-    seen, @nospecialize(prev::MissingTracedValue), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::MissingTracedValue), path, mode; kwargs...
 )
     if mode == ConcreteToTraced
         throw("Cannot trace existing trace type")
@@ -1666,7 +1666,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::Number),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -1710,13 +1710,13 @@ end
 
 # avoid the real fallback
 Base.@nospecializeinfer function make_tracer(
-    seen, @nospecialize(prev::TracedRational), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::TracedRational), path, mode; kwargs...
 )
     return make_tracer_via_immutable_constructor(seen, prev, path, mode; kwargs...)
 end
 
 Base.@nospecializeinfer function make_tracer(
-    seen, @nospecialize(prev::Type), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::Type), path, mode; kwargs...
 )
     if mode == TracedToTypes
         push!(path, prev)
@@ -1726,7 +1726,7 @@ Base.@nospecializeinfer function make_tracer(
 end
 
 Base.@nospecializeinfer function make_tracer(
-    seen, @nospecialize(prev::Symbol), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::Symbol), path, mode; kwargs...
 )
     if mode == TracedToTypes
         push!(path, prev)
@@ -1738,7 +1738,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::Complex),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     kwargs...,
@@ -1759,7 +1759,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::Array),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -1846,7 +1846,7 @@ Base.@nospecializeinfer function make_tracer(
 end
 
 Base.@nospecializeinfer function make_tracer(
-    seen, @nospecialize(prev::BitArray), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::BitArray), path, mode; kwargs...
 )
     if mode == ArrayToConcrete
         return make_tracer(seen, Array(prev), path, mode; kwargs...)
@@ -1858,7 +1858,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::Dict{Key,Value}),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -1949,7 +1949,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::Tuple),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     kwargs...,
@@ -1981,7 +1981,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::NamedTuple),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -2022,7 +2022,7 @@ struct UndefinedBox end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::Core.Box),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     kwargs...,
@@ -2065,7 +2065,7 @@ end
 Base.@nospecializeinfer function make_tracer(
     seen,
     @nospecialize(prev::Sharding.Mesh),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(track_numbers::Type = Union{}),
     @nospecialize(sharding = Sharding.NoSharding()),
@@ -2076,7 +2076,7 @@ Base.@nospecializeinfer function make_tracer(
 end
 
 Base.@nospecializeinfer function make_tracer(
-    seen, @nospecialize(prev::ReactantRNG), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::ReactantRNG), path, mode; kwargs...
 )
     if mode == TracedToTypes
         push!(path, Core.Typeof(prev))
@@ -2088,7 +2088,7 @@ Base.@nospecializeinfer function make_tracer(
 end
 
 Base.@nospecializeinfer function make_tracer(
-    seen, @nospecialize(prev::Random.AbstractRNG), @nospecialize(path), mode; kwargs...
+    seen, @nospecialize(prev::Random.AbstractRNG), path, mode; kwargs...
 )
     if mode == ArrayToConcrete
         TracedRandom.should_warn_if_not_natively_supported(prev)
@@ -2321,7 +2321,7 @@ end
 function make_tracer(
     seen,
     @nospecialize(prev::UnitRange),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     kwargs...,
@@ -2366,7 +2366,7 @@ end
 function make_tracer(
     seen,
     @nospecialize(prev::StepRangeLen),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     kwargs...,
@@ -2428,7 +2428,7 @@ end
 function make_tracer(
     seen,
     @nospecialize(prev::Rational),
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     kwargs...,
@@ -2452,7 +2452,7 @@ end
 function make_tracer(
     seen,
     prev::IOStream,
-    @nospecialize(path),
+    path,
     mode;
     @nospecialize(sharding = Sharding.NoSharding()),
     kwargs...,

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -39,11 +39,11 @@ end
 
 ## TracedRNumber
 mutable struct TracedRNumber{T} <: RNumber{T}
-    paths::Tuple
+    paths::PersistentStack{Any}
     mlir_data::Union{Nothing,MLIR.IR.Value}
 
     function TracedRNumber{T}(
-        paths::Tuple, mlir_data::Union{Nothing,MLIR.IR.Value}
+        paths::PersistentStack{Any}, mlir_data::Union{Nothing,MLIR.IR.Value}
     ) where {T}
         if !isnothing(mlir_data)
             @assert size(MLIR.IR.type(mlir_data)) == ()
@@ -65,12 +65,12 @@ end
 
 ## TracedRArray
 mutable struct TracedRArray{T,N} <: RArray{TracedRNumber{T},N}
-    paths::Tuple
+    paths::PersistentStack{Any}
     mlir_data::Union{Nothing,MLIR.IR.Value}
     shape::NTuple{N,Int}
 
     function TracedRArray{T,N}(
-        paths::Tuple, mlir_data::Union{Nothing,MLIR.IR.Value}, shape
+        paths::PersistentStack{Any}, mlir_data::Union{Nothing,MLIR.IR.Value}, shape
     ) where {T,N}
         shape = Tuple(shape)
         if !isnothing(mlir_data)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -52,6 +52,11 @@ mutable struct TracedRNumber{T} <: RNumber{T}
     end
 end
 
+TracedRNumber{T}(mlir_data::Union{Nothing,MLIR.IR.Value}) where {T} = TracedRNumber{T}((), mlir_data)
+function TracedRNumber{T}(::Tuple{}, mlir_data) where {T}
+    return TracedRNumber{T}(PersistentStack{Any}(nothing, nothing, 0), mlir_data)
+end
+
 Base.elsize(::Type{TracedRNumber{T}}) where {T} = sizeof(T)
 Base.elsize(::Type{RNumber{T}}) where {T} = sizeof(T)
 Base.elsize(::Type{<:AbstractConcreteNumber{T}}) where {T} = sizeof(T)
@@ -82,6 +87,11 @@ mutable struct TracedRArray{T,N} <: RArray{TracedRNumber{T},N}
     function TracedRArray{T,N}(::UndefInitializer, shape::Integer...) where {T,N}
         return similar(TracedRArray{T,N}, shape...)
     end
+end
+
+TracedRArray{T,N}(mlir_data::Union{Nothing,MLIR.IR.Value}) where {T} = TracedRArray{T,N}((), mlir_data)
+function TracedRArray{T,N}(::Tuple{}, mlir_data) where {T}
+    return TracedRArray{T,N}(PersistentStack{Any}(nothing, nothing, 0), mlir_data)
 end
 
 function repath(x::TracedRArray{T,N}, paths) where {T,N}

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -89,9 +89,9 @@ mutable struct TracedRArray{T,N} <: RArray{TracedRNumber{T},N}
     end
 end
 
-TracedRArray{T,N}(mlir_data::Union{Nothing,MLIR.IR.Value}) where {T} = TracedRArray{T,N}((), mlir_data)
-function TracedRArray{T,N}(::Tuple{}, mlir_data) where {T}
-    return TracedRArray{T,N}(PersistentStack{Any}(nothing, nothing, 0), mlir_data)
+TracedRArray{T,N}(mlir_data::Union{Nothing,MLIR.IR.Value}, shape) where {T,N} = TracedRArray{T,N}((), mlir_data, shape)
+function TracedRArray{T,N}(::Tuple{}, mlir_data, shape) where {T,N}
+    return TracedRArray{T,N}(PersistentStack{Any}(nothing, nothing, 0), mlir_data, shape)
 end
 
 function repath(x::TracedRArray{T,N}, paths) where {T,N}

--- a/test/core/compile.jl
+++ b/test/core/compile.jl
@@ -178,7 +178,7 @@ end
     function Reactant.Compiler.make_tracer(
         seen, prev::MockTestCustomPath, path, mode; kwargs...
     )
-        custom_path = Reactant.append_path(path, (; custom_id=1))
+        custom_path = Reactant.push(path, (; custom_id=1))
         traced_x = Reactant.make_tracer(seen, prev.x, custom_path, mode; kwargs...)
         return MockTestCustomPath(traced_x)
     end
@@ -206,7 +206,7 @@ end
         var_idx,
         resultgen_code,
     )
-        custom_path = Reactant.append_path(path, (; custom_id=1))
+        custom_path = Reactant.push(path, (; custom_id=1))
 
         args = (
             result_stores,


### PR DESCRIPTION
cc @gbaraldi

microbenchmarks look good: `push` is x50-100 faster and although indexing is _O(n)_ instead of _O(1)_, i'm not seeing a huge slowdown for the tipical ranges.

it is more type-stable but since we are using `Any`, there is probably no much improvement on this front. i'm experimenting with just using `Symbol` (currently, paths should just contain `Symbol`, `Int` and some `String`), so it can slightly improve type-stability overall.

there are more allocs on `@compile`, so I don't think this is yet ready to merge.

## benchmarks

### push element to the back (T=Int64)

```julia
julia> y = (collect(x)...,)
(1, 2, 3, 4, 5)

julia> f(y) = (y..., 6)
f (generic function with 1 method)

julia> Base.@nospecializeinfer ff(@nospecialize(y::Tuple)) = (y..., 6)
ff (generic function with 1 method)

julia> @benchmark f($y)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  3.077 ns … 264.270 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.382 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.784 ns ±   4.307 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▇▃█▆▂▁▂▁▂▂▂▂▂▂▂▂▁▁▁ ▁▂▂▂▁▁                                 ▂
  ██████████████████████████████▇█▄▅▄▄▄▃▅▄▃▄▅▄▄▄▅▃▁▄▁▃▁▃▅▁▁▃▄ █
  3.08 ns      Histogram: log(frequency) by time       8.4 ns <

julia> @benchmark ff($y)
BenchmarkTools.Trial: 10000 samples with 236 evaluations per sample.
 Range (min … max):  314.737 ns …  56.670 μs  ┊ GC (min … max): 0.00% … 98.83%
 Time  (median):     322.746 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   400.441 ns ± 734.065 ns  ┊ GC (mean ± σ):  4.86% ±  3.19%

  █▄▅▃▂▂▂▂▂▁▁▁       ▁     ▁                                    ▁
  ██████████████████████████████▇██▇▆▇▅▆▅▆▅▆▆▄▄▅▅▅▅▅▅▄▄▆▅▄▄▃▃▃▄ █
  315 ns        Histogram: log(frequency) by time        940 ns <

 Memory estimate: 160 bytes, allocs estimate: 3.

julia> @benchmark push($x, 6)
BenchmarkTools.Trial: 10000 samples with 999 evaluations per sample.
 Range (min … max):   7.381 ns …  17.526 μs  ┊ GC (min … max):  0.00% … 99.75%
 Time  (median):      8.814 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   14.097 ns ± 211.200 ns  ┊ GC (mean ± σ):  26.70% ±  1.99%

  ▁▆▅█  ▁                                                       
  ████▅▄█▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂ ▃
  7.38 ns         Histogram: frequency by time         33.1 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.
```

### push element to the back (T=Any)

```julia
julia> @benchmark push($x, 6)
BenchmarkTools.Trial: 10000 samples with 999 evaluations per sample.
 Range (min … max):   7.549 ns …  13.689 μs  ┊ GC (min … max):  0.00% … 99.69%
 Time  (median):      9.040 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   12.769 ns ± 163.231 ns  ┊ GC (mean ± σ):  20.42% ±  1.72%

   █▂▄▆                                                         
  ▆████▅▃█▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂ ▃
  7.55 ns         Histogram: frequency by time         30.3 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.

julia> @benchmark ff($y)
BenchmarkTools.Trial: 10000 samples with 238 evaluations per sample.
 Range (min … max):  312.966 ns …  60.079 μs  ┊ GC (min … max): 0.00% … 99.15%
 Time  (median):     323.092 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   399.641 ns ± 746.153 ns  ┊ GC (mean ± σ):  3.95% ±  2.57%

  █▄▅▃▃▂▂▂▂▁▁▁▁     ▁  ▁        ▁                               ▁
  ████████████████████████████▇████▆▇▆▇▆▅▆▆▆▆▄▄▄▆▅▄▅▄▄▄▅▅▃▄▃▅▄▄ █
  313 ns        Histogram: log(frequency) by time        954 ns <

 Memory estimate: 160 bytes, allocs estimate: 3.
```

### random access

```julia
julia> Base.@nospecializeinfer gi(@nospecialize(y::Tuple), i) = y[i]
gi (generic function with 1 method)

julia> @benchmark $x[1]
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  6.060 ns … 241.103 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.468 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.397 ns ±   6.089 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ██▇▄▂       ▁▁▁▁▁▁▁▁▁▁                                      ▂
  ███████▆▇██████████████▇▇▇█▆▆▅▄▅▅▄▃▅▃▄▃▅▄▄▆▃▁▅▅▅▆▆▅▄▄▆▄▄▅▄▆ █
  6.06 ns      Histogram: log(frequency) by time      22.4 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark $x[5]
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  4.902 ns … 433.212 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.225 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.998 ns ±   6.046 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆█▆▃   ▁▁▂▃▃▃▃▁▁▁                                           ▂
  █████▇███████████▇▇▅▅▅▃▁▇▄▃▁▁▃▁▁▁▁▄▃▃▁▄▄▃▅▄▃▅▄▄▄▄▄▄▃▅▄▄▃▄▅▄ █
  4.9 ns       Histogram: log(frequency) by time      18.7 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark gi($y, 1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  2.641 ns … 63.914 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.801 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.020 ns ±  1.857 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

     █▂▇▁▄      ▁▁▁▁▁                                        ▂
  ▃▁▁████████▇██████████▇▇▆▆▅▅▅▆▅▄▄▄▄▅▄▄▅▁▄▃▁▁▁▁▁▁▁▃▁▄▁▁▃▁▄▆ █
  2.64 ns      Histogram: log(frequency) by time     5.14 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark gi($y, 5)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  2.623 ns … 128.522 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.790 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.071 ns ±   2.127 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▂ █▁▆▁                                                     ▁
  ▂█▄█████▇▇▆▅▆▅▄▅▅▆▆▇▆▆▇▇▇▇▇▇▇▇▇▇█▇▇▇▆▆▆▆▆▅▅▅▆▆▇▇▇▆▇▅▆▅▅▅▅▄▅ █
  2.62 ns      Histogram: log(frequency) by time      5.31 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

### collect to vector

```julia
julia> Base.@nospecializeinfer collect_tuple(@nospecialize(y::Tuple)) = collect(y)
collect_tuple (generic function with 1 method)

julia> @benchmark collect($x)
BenchmarkTools.Trial: 10000 samples with 994 evaluations per sample.
 Range (min … max):  29.900 ns …  16.999 μs  ┊ GC (min … max):  0.00% … 99.50%
 Time  (median):     32.264 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   54.525 ns ± 267.812 ns  ┊ GC (mean ± σ):  26.18% ±  6.17%

  ██▅▃▃▃▂▂▂▂▂▃▃▃▃▃▃▂▁▁▁                                        ▂
  █████████████████████████████▇▇▇▇▇▇▇▅▆▇▇▆▅▅▅▁▅▅▃▄▅▄▅▅▄▅▄▆▅▄▄ █
  29.9 ns       Histogram: log(frequency) by time       141 ns <

 Memory estimate: 96 bytes, allocs estimate: 2.

julia> @benchmark collect_tuple($y)
BenchmarkTools.Trial: 10000 samples with 990 evaluations per sample.
 Range (min … max):  41.091 ns …  17.819 μs  ┊ GC (min … max):  0.00% … 99.38%
 Time  (median):     43.520 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):   70.873 ns ± 340.947 ns  ┊ GC (mean ± σ):  27.26% ±  6.12%

  █▇▄▄▃▂▂▂▂▂▂▂▂▂▁▁▁                                            ▂
  ████████████████████▇███▇▇▇▆▇▆▆▆▆▅▆▅▄▅▅▄▆▅▄▄▅▅▄▄▄▄▅▃▅▄▁▃▁▁▃▄ █
  41.1 ns       Histogram: log(frequency) by time       184 ns <

 Memory estimate: 144 bytes, allocs estimate: 3.
```

## type stability check

WIP

## first compilation

WIP