### PR TITLE
allow unanalyzable `Reactant.InterpolationType` in QA tests

### DIFF
--- a/test/core/qa.jl
+++ b/test/core/qa.jl
@@ -111,6 +111,7 @@ end
                 Reactant.Accelerators.TPU.TPUVersion,
                 Reactant.PrecisionConfig,
                 ReactantMPIExt.Ops,
+                Reactant.InterpolationType,
             ),
             ignore=(
                 Reactant.Proto,


### PR DESCRIPTION
seems like #2801 broke QA tests