### PR TITLE
fix `create_result` on `Enum`

### DIFF
--- a/src/Compiler.jl
+++ b/src/Compiler.jl
@@ -277,6 +277,37 @@ Base.@nospecializeinfer function create_result(
     return result_cache[tocopy]
 end
 
+Base.@nospecializeinfer function create_result(
+    @nospecialize(tocopy::Enum),
+    @nospecialize(path::Tuple),
+    result_stores,
+    path_to_shard_info,
+    to_unreshard_results,
+    _unresharded_code::Vector{Expr},
+    _unresharded_arrays_cache,
+    used_shardinfo,
+    result_cache,
+    var_idx,
+    resultgen_code,
+)
+    if !haskey(result_cache, tocopy)
+        sym = Symbol("result", var_idx[])
+        var_idx[] += 1
+
+        result = Meta.quot(tocopy)
+
+        push!(
+            resultgen_code,
+            quote
+                $sym = $result
+            end,
+        )
+        result_cache[tocopy] = sym
+    end
+
+    return result_cache[tocopy]
+end
+
 function create_result(
     tocopy::ConcretePJRTNumber{T,D},
     @nospecialize(path::Tuple),

--- a/test/core/compile.jl
+++ b/test/core/compile.jl
@@ -13,75 +13,73 @@ intout_caller(vis) = @noinline intout(vis)
     @test_throws MethodError @compile intout_caller(visr)
 end
 
-@testset "compile" begin
-    @testset "create_result" begin
-        @testset "NamedTuple" begin
-            x = (; a=Reactant.TestUtils.construct_test_array(Float64, 4, 3))
-            x2 = Reactant.to_rarray(x)
+@testset "create_result" begin
+    @testset "NamedTuple" begin
+        x = (; a=Reactant.TestUtils.construct_test_array(Float64, 4, 3))
+        x2 = Reactant.to_rarray(x)
 
-            res = @jit sum(x2)
-            @test res isa NamedTuple
-            @test res.a isa ConcreteRNumber{Float64}
-            @test isapprox(res.a, sum(x.a))
-        end
-
-        @testset "Array" begin
-            x = [1 2; 3 4; 5 6]
-            f = Reactant.compile(() -> x, ())
-            @test f() ≈ x
-        end
+        res = @jit sum(x2)
+        @test res isa NamedTuple
+        @test res.a isa ConcreteRNumber{Float64}
+        @test isapprox(res.a, sum(x.a))
     end
 
-    @testset "world-age" begin
-        a = ones(2, 10)
-        b = ones(10, 2)
-        a_ra = Reactant.to_rarray(a)
-        b_ra = Reactant.to_rarray(b)
-
-        fworld(x, y) = @jit(x * y)
-
-        @test fworld(a_ra, b_ra) ≈ ones(2, 2) * 10
+    @testset "Array" begin
+        x = [1 2; 3 4; 5 6]
+        f = Reactant.compile(() -> x, ())
+        @test f() ≈ x
     end
-
-    @testset "type casting & optimized out returns" begin
-        a = ones(2, 10)
-        a_ra = Reactant.to_rarray(a)
-
-        ftype1(x) = Float64.(x)
-        ftype2(x) = Float32.(x)
-
-        y1 = @jit ftype1(a_ra)
-        y2 = @jit ftype2(a_ra)
-
-        @test y1 isa Reactant.ConcreteRArray{Float64,2}
-        @test y2 isa Reactant.ConcreteRArray{Float32,2}
-
-        @test y1 ≈ Float64.(a)
-        @test y2 ≈ Float32.(a)
-    end
-
-    @testset "no variable name collisions in compile macros (#237)" begin
-        f(x) = x
-        g(x) = f(x)
-        x = Reactant.TestUtils.construct_test_array(Float64, 2, 2)
-        y = Reactant.to_rarray(x)
-        @test (@jit g(y); true)
-    end
-
-    # disabled due to long test time (core tests go from 2m to 7m just with this test)
-    # @testset "resource exhaustation bug (#190)" begin
-    #     x = rand(2, 2)
-    #     y = Reactant.to_rarray(x)
-    #     @test try
-    #         for _ in 1:10_000
-    #             f = @compile sum(y)
-    #         end
-    #         true
-    #     catch e
-    #         false
-    #     end
-    # end
 end
+
+@testset "world-age" begin
+    a = ones(2, 10)
+    b = ones(10, 2)
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+
+    fworld(x, y) = @jit(x * y)
+
+    @test fworld(a_ra, b_ra) ≈ ones(2, 2) * 10
+end
+
+@testset "type casting & optimized out returns" begin
+    a = ones(2, 10)
+    a_ra = Reactant.to_rarray(a)
+
+    ftype1(x) = Float64.(x)
+    ftype2(x) = Float32.(x)
+
+    y1 = @jit ftype1(a_ra)
+    y2 = @jit ftype2(a_ra)
+
+    @test y1 isa Reactant.ConcreteRArray{Float64,2}
+    @test y2 isa Reactant.ConcreteRArray{Float32,2}
+
+    @test y1 ≈ Float64.(a)
+    @test y2 ≈ Float32.(a)
+end
+
+@testset "no variable name collisions in compile macros (#237)" begin
+    f(x) = x
+    g(x) = f(x)
+    x = Reactant.TestUtils.construct_test_array(Float64, 2, 2)
+    y = Reactant.to_rarray(x)
+    @test (@jit g(y); true)
+end
+
+# disabled due to long test time (core tests go from 2m to 7m just with this test)
+# @testset "resource exhaustation bug (#190)" begin
+#     x = rand(2, 2)
+#     y = Reactant.to_rarray(x)
+#     @test try
+#         for _ in 1:10_000
+#             f = @compile sum(y)
+#         end
+#         true
+#     catch e
+#         false
+#     end
+# end
 
 @testset "Module export" begin
     f(x) = sin.(cos.(x))

--- a/test/core/compile.jl
+++ b/test/core/compile.jl
@@ -29,6 +29,17 @@ end
         f = Reactant.compile(() -> x, ())
         @test f() ≈ x
     end
+
+    @testset "Enum" begin
+        @enum MyEnum begin
+            MyEnumA = 1
+            MyEnumB = 2
+        end
+
+        x = MyEnumA
+        f = @compile identity(x)
+        @test f(x) == x
+    end
 end
 
 @testset "world-age" begin


### PR DESCRIPTION
```julia
@enum MyEnum begin
    MyEnumA = 1
    MyEnumB = 2
end

x = MyEnumA
f = @compile identity(x)
@test f(x) == x
```

```julia
ERROR: cannot copy MyEnumA of type MyEnum
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] create_result(tocopy::Any, path::Tuple, result_stores::Dict{…}, path_to_shard_info::Nothing, to_unreshard_results::Dict{…}, unresharded_code::Vector{…}, unresharded_arrays_cache::Dict{…}, used_shardinfo::Set{…}, result_cache::IdDict{…}, var_idx::Base.RefValue{…}, resultgen_code::Vector{…})
   @ Reactant.Compiler ~/.julia/packages/Reactant/rqe8E/src/Compiler.jl:235
 [3] codegen_unflatten!(linear_args::Vector{…}, preserved_args::Vector{…}, concretized_res_names::Vector{…}, linear_results::Vector{…}, concrete_result::MyEnum, result_stores::Dict{…}, path_to_shard_info::Nothing, linear_result_shard_info::Vector{…}, client::Reactant.XLA.PJRT.Client, resharded_inputs::Dict{…})
   @ Reactant.Compiler ~/.julia/packages/Reactant/rqe8E/src/Compiler.jl:3118
 [4] compile(ctx::Reactant.MLIR.IR.Context, f::Function, args::Tuple{…}; kwargs::@Kwargs{…})
   @ Reactant.Compiler ~/.julia/packages/Reactant/rqe8E/src/Compiler.jl:3625
```