### PR TITLE
ProbProg: Fix logpdf

### DIFF
--- a/src/probprog/Distributions.jl
+++ b/src/probprog/Distributions.jl
@@ -49,10 +49,8 @@ function _normal_sampler(rng, μ, σ, shape)
 end
 
 function _normal_logpdf(x, μ, σ, _)
-    n = length(x)
-    log_sigma = sum(log.(σ))
-    diff = x .- μ
-    return -n * log_sigma - n / 2 * log(2π) - sum(diff .* diff ./ (2 .* σ .* σ))
+    z = (x .- μ) ./ σ
+    return sum(.-(abs2.(z) .+ log(2π)) ./ 2 .- log.(σ))
 end
 
 sampler(::Type{<:Normal}) = _normal_sampler
@@ -85,9 +83,7 @@ function _exponential_sampler(rng, λ, shape)
 end
 
 function _exponential_logpdf(x, λ, _)
-    n = length(x)
-    log_lambda = sum(log.(λ))
-    return n * log_lambda - sum(λ .* x)
+    return sum(log.(λ) .- λ .* x)
 end
 
 sampler(::Type{<:Exponential}) = _exponential_sampler
@@ -121,12 +117,9 @@ function _lognormal_sampler(rng, μ, σ, shape)
 end
 
 function _lognormal_logpdf(x, μ, σ, _)
-    n = length(x)
     log_x = log.(x)
-    log_sigma = sum(log.(σ))
-    diff = log_x .- μ
-    return -sum(log_x) - n * log_sigma - n / 2 * log(2π) -
-           sum(diff .* diff ./ (2 .* σ .* σ))
+    z = (log_x .- μ) ./ σ
+    return sum(.-(abs2.(z) .+ log(2π)) ./ 2 .- log.(σ) .- log_x)
 end
 
 sampler(::Type{<:LogNormal}) = _lognormal_sampler

--- a/src/probprog/Distributions.jl
+++ b/src/probprog/Distributions.jl
@@ -48,6 +48,7 @@ function _normal_sampler(rng, μ, σ, shape)
     return μ .+ σ .* randn(rng, shape)
 end
 
+# Reference: https://github.com/probcomp/Gen.jl/blob/027dbc6e71cec3e281b335292c57ad776a8bf9db/src/modeling_library/distributions/normal.jl#L61-L69
 function _normal_logpdf(x, μ, σ, _)
     z = (x .- μ) ./ σ
     return sum(.-(abs2.(z) .+ log(2π)) ./ 2 .- log.(σ))

--- a/test/probprog/distributions.jl
+++ b/test/probprog/distributions.jl
@@ -254,6 +254,71 @@ include(joinpath(@__DIR__, "common.jl"))
         end
     end
 
+    @testset "Normal(0, vector σ) [heteroscedastic]" begin
+        logpdf_fn = ProbProg.logpdf_fn(ProbProg.Normal)
+
+        x = ConcreteRArray([0.5, 1.0, -0.3, 2.1, -1.5])
+        μ = ConcreteRNumber(0.0)
+        σ = ConcreteRArray([0.5, 1.0, 2.0, 0.3, 1.5])
+
+        lp = @jit logpdf_fn(x, μ, σ, nothing)
+        reactant_lp = Reactant.to_number(lp)
+
+        if check_numpyro_available()
+            jnp = pyimport("jax.numpy")
+            dist = pyimport("numpyro.distributions")
+
+            x_jnp = jnp.array(pylist([0.5, 1.0, -0.3, 2.1, -1.5]))
+            σ_jnp = jnp.array(pylist([0.5, 1.0, 2.0, 0.3, 1.5]))
+            d = dist.Normal(0.0, σ_jnp)
+            numpyro_lp = pyconvert(Float64, d.log_prob(x_jnp).sum().item())
+            @test reactant_lp ≈ numpyro_lp atol = 1e-10
+        end
+    end
+
+    @testset "LogNormal(0, vector σ) [heteroscedastic]" begin
+        logpdf_fn = ProbProg.logpdf_fn(ProbProg.LogNormal)
+
+        x = ConcreteRArray([0.5, 1.0, 1.5, 2.0, 3.0])
+        μ = ConcreteRNumber(0.0)
+        σ = ConcreteRArray([0.5, 1.0, 2.0, 0.3, 1.5])
+
+        lp = @jit logpdf_fn(x, μ, σ, nothing)
+        reactant_lp = Reactant.to_number(lp)
+
+        if check_numpyro_available()
+            jnp = pyimport("jax.numpy")
+            dist = pyimport("numpyro.distributions")
+
+            x_jnp = jnp.array(pylist([0.5, 1.0, 1.5, 2.0, 3.0]))
+            σ_jnp = jnp.array(pylist([0.5, 1.0, 2.0, 0.3, 1.5]))
+            d = dist.LogNormal(0.0, σ_jnp)
+            numpyro_lp = pyconvert(Float64, d.log_prob(x_jnp).sum().item())
+            @test reactant_lp ≈ numpyro_lp atol = 1e-10
+        end
+    end
+
+    @testset "Exponential(vector λ) [heteroscedastic]" begin
+        logpdf_fn = ProbProg.logpdf_fn(ProbProg.Exponential)
+
+        x = ConcreteRArray([0.5, 1.0, 2.0, 0.1, 3.0])
+        λ = ConcreteRArray([2.0, 0.5, 1.0, 3.0, 0.25])
+
+        lp = @jit logpdf_fn(x, λ, nothing)
+        reactant_lp = Reactant.to_number(lp)
+
+        if check_numpyro_available()
+            jnp = pyimport("jax.numpy")
+            dist = pyimport("numpyro.distributions")
+
+            x_jnp = jnp.array(pylist([0.5, 1.0, 2.0, 0.1, 3.0]))
+            λ_jnp = jnp.array(pylist([2.0, 0.5, 1.0, 3.0, 0.25]))
+            d = dist.Exponential(; rate=λ_jnp)
+            numpyro_lp = pyconvert(Float64, d.log_prob(x_jnp).sum().item())
+            @test reactant_lp ≈ numpyro_lp atol = 1e-10
+        end
+    end
+
     @testset "Bernoulli(logits=0.5)" begin
         sample_fn = ProbProg.sampler(ProbProg.Bernoulli)
         logpdf_fn = ProbProg.logpdf_fn(ProbProg.Bernoulli)


### PR DESCRIPTION
Fixing wrong use of broadcasting in several logpdf functions that causes wrong result for vector σ