### PR TITLE
WIP: decouple `eltype` from `AbstractArray` for `TracedRArray`

### DIFF
--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -205,6 +205,27 @@ for (cT, aT, bT) in (
     end
 end
 
+for (aT, bT) in (
+    (:(LinearAlgebra.StridedMaybeAdjOrTransMat{<:LinearAlgebra.BlasReal}), :(LinearAlgebra.StridedMaybeAdjOrTransMat{<:LinearAlgebra.BlasReal})),
+    (:(LinearAlgebra.StridedMaybeAdjOrTransMat{<:LinearAlgebra.BlasComplex}), :(LinearAlgebra.StridedMaybeAdjOrTransMat{<:LinearAlgebra.BlasComplex})),
+    (:(LinearAlgebra.StridedMatrix{<:LinearAlgebra.BlasComplex}), :(LinearAlgebra.StridedMaybeAdjOrTransMat{<:LinearAlgebra.BlasReal})),
+    (:(LinearAlgebra.AdjOrTransStridedMat{<:LinearAlgebra.BlasComplex}), :(LinearAlgebra.StridedMaybeAdjOrTransMat{<:LinearAlgebra.BlasReal})),
+)
+    @eval begin
+        @reactant_overlay @noinline function Base.:(*)(A::AT, B::BT) where {AT<:$aT,BT<:$bT}
+            A, B = aos_to_soa(A), aos_to_soa(B)
+            if use_overlayed_version((A, B))
+                return call_with_native(TracedLinearAlgebra.overloaded_mul, A, B)
+            else
+                # Inference barrier is required when calling function recursively within
+                # overload. This is required since otherwise type inference will think this
+                # is a recursive edge rather than a call to the base method
+                return call_with_native(*, A, B)
+            end
+        end
+    end
+end
+
 # Base overloads
 @reactant_overlay @noinline function Base._stack(dims::Union{Integer,Colon}, iter)
     if use_overlayed_version(iter)

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -120,6 +120,7 @@ isa_traced_soa(_) = false
 isa_traced_soa(::TracedRArray) = true
 isa_traced_soa(::AbstractRange{<:TracedRNumber}) = true
 
+unwrapped_eltype(::Type) = Any
 unwrapped_eltype(::Type{T}) where {T<:Number} = T
 unwrapped_eltype(::Type{<:RNumber{T}}) where {T} = T
 unwrapped_eltype(::Type{TracedRNumber{T}}) where {T} = T

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -131,6 +131,10 @@ unwrapped_eltype(::TracedRNumber{T}) where {T} = T
 unwrapped_eltype(::Type{<:AbstractArray{T}}) where {T} = unwrapped_eltype(T)
 unwrapped_eltype(::AbstractArray{T}) where {T} = unwrapped_eltype(T)
 
+array_eltype(::T) where {T} = array_eltype(T)
+array_eltype(::Type{<:TracedRArray{T}}) where {T} = T
+array_eltype(T::Type) = eltype(T)
+
 include("Ops.jl")
 Base.push!(no_rewrite_ancestor_modules, Ops)
 

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -131,10 +131,6 @@ unwrapped_eltype(::TracedRNumber{T}) where {T} = T
 unwrapped_eltype(::Type{<:AbstractArray{T}}) where {T} = unwrapped_eltype(T)
 unwrapped_eltype(::AbstractArray{T}) where {T} = unwrapped_eltype(T)
 
-array_eltype(::T) where {T} = array_eltype(T)
-array_eltype(::Type{<:TracedRArray{T}}) where {T} = T
-array_eltype(T::Type) = eltype(T)
-
 include("Ops.jl")
 Base.push!(no_rewrite_ancestor_modules, Ops)
 

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -46,6 +46,8 @@ TracedRArray{T,N}(x::AbstractArray) where {T,N} = convert(TracedRArray{T,N}, x)
 
 Base.Tuple(x::TracedRArray) = ntuple(Base.Fix1(getindex, x), length(x))
 
+Base.eltype(::Type{A}) where {T,A<:TracedRArray{T}} = TracedRNumber{T}
+
 Base.size(x::TracedRArray) = x.shape
 function Base.size(x::TracedRArray, i::Integer)
     if i > ndims(x)

--- a/src/Tracing.jl
+++ b/src/Tracing.jl
@@ -553,7 +553,7 @@ Base.@nospecializeinfer function traced_type_inner(
 ) where {T,N,P,I,L}
     P2 = traced_type_inner(P, seen, mode, track_numbers, ndevices, runtime)
     I2 = traced_type_inner(I, seen, mode, track_numbers, ndevices, runtime)
-    T2 = eltype(P2)
+    T2 = unwrapped_eltype(P2)
     return SubArray{T2,N,P2,I2,L}
 end
 
@@ -1829,7 +1829,7 @@ Base.@nospecializeinfer function make_tracer(
         end
         return nothing
     end
-    TT = traced_type(eltype(RT), Val(mode), track_numbers, sharding, runtime)
+    TT = traced_type(unwrapped_eltype(RT), Val(mode), track_numbers, sharding, runtime)
     newa = Array{TT,ndims(RT)}(undef, size(prev))
     seen[prev] = newa
     same = true

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -91,6 +91,10 @@ end
 @leaf TracedRArray
 Adapt.parent_type(::Type{TracedRArray{T,N}}) where {T,N} = TracedRArray{T,N}
 
+array_eltype(::T) where {T} = array_eltype(T)
+array_eltype(::Type{<:TracedRArray{T}}) where {T} = T
+array_eltype(T::Type) = eltype(T)
+
 ## TracedStepRangeLen
 struct TracedStepRangeLen{T,R,S,L} <: AbstractRange{T}
     ref::R

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -64,7 +64,7 @@ end
 @leaf TracedRNumber
 
 ## TracedRArray
-mutable struct TracedRArray{T,N} <: RArray{TracedRNumber{T},N}
+mutable struct TracedRArray{T,N} <: RArray{T,N}
     paths::Tuple
     mlir_data::Union{Nothing,MLIR.IR.Value}
     shape::NTuple{N,Int}

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -141,7 +141,7 @@ end
 @leaf TracedRational
 Adapt.parent_type(::Type{TracedRational{T}}) where {T} = TracedRational{T}
 
-const AnyTracedRArray{T,N} = AbstractArray{TracedRNumber{T},N}
+const AnyTracedRArray{T,N} = Union{AbstractArray{TracedRNumber{T},N},TracedRArray{T,N}}
 const AnyTracedRVector{T} = AnyTracedRArray{T,1}
 const AnyTracedRMatrix{T} = AnyTracedRArray{T,2}
 const AnyTracedRVecOrMat{T} = Union{AnyTracedRVector{T},AnyTracedRMatrix{T}}

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -91,10 +91,6 @@ end
 @leaf TracedRArray
 Adapt.parent_type(::Type{TracedRArray{T,N}}) where {T,N} = TracedRArray{T,N}
 
-array_eltype(::T) where {T} = array_eltype(T)
-array_eltype(::Type{<:TracedRArray{T}}) where {T} = T
-array_eltype(T::Type) = eltype(T)
-
 ## TracedStepRangeLen
 struct TracedStepRangeLen{T,R,S,L} <: AbstractRange{T}
     ref::R

--- a/test/core/struct.jl
+++ b/test/core/struct.jl
@@ -15,11 +15,6 @@ Adapt.parent_type(::Type{MockTensor{T,N,A}}) where {T,N,A} = A
 Base.cos(x::MockTensor) = MockTensor(cos.(parent(x)), x.inds)
 bcast_cos(x::MockTensor) = cos(x)
 
-mutable struct MutableMockTensor{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
-    data::A
-    inds::Vector{Symbol}
-end
-
 Base.@nospecializeinfer function Reactant.traced_type_inner(
     @nospecialize(A::Type{<:MockTensor}),
     seen,
@@ -31,8 +26,13 @@ Base.@nospecializeinfer function Reactant.traced_type_inner(
     T2 = Reactant.traced_type_inner(
         A.parameters[3], seen, mode, track_numbers, ndevices, runtime
     )
-    MT = MockTensor{eltype(T2),ndims(A),T2}
+    MT = MockTensor{Reactant.unwrapped_eltype(T2),ndims(A),T2}
     return MT
+end
+
+mutable struct MutableMockTensor{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
+    data::A
+    inds::Vector{Symbol}
 end
 
 function MutableMockTensor(data::A, inds) where {T,N,A<:AbstractArray{T,N}}
@@ -48,6 +48,21 @@ Base.cos(x::MutableMockTensor) = MutableMockTensor(cos.(parent(x)), x.inds)
 
 bcast_cos(x) = cos.(x)
 bcast_cos(x::MutableMockTensor) = cos(x)
+
+Base.@nospecializeinfer function Reactant.traced_type_inner(
+    @nospecialize(A::Type{<:MutableMockTensor}),
+    seen,
+    mode::Reactant.TraceMode,
+    @nospecialize(track_numbers::Type),
+    @nospecialize(ndevices),
+    @nospecialize(runtime)
+)
+    T2 = Reactant.traced_type_inner(
+        A.parameters[3], seen, mode, track_numbers, ndevices, runtime
+    )
+    MT = MutableMockTensor{Reactant.unwrapped_eltype(T2),ndims(A),T2}
+    return MT
+end
 
 # modified from JuliaCollections/DataStructures.jl
 # NOTE original uses abstract type instead of union, which is not supported


### PR DESCRIPTION
> [!CAUTION]
> DO NOT MERGE! This is a very delicate change that can have huge negative effects.
> This is an experiment for a potential future design.

this should fix the GNNGraph problem in #2856 without needing to introduce `TracedRInteger`, `TracedRAbstractFloat`, `TracedRComplex`, ... types.