### PR TITLE
implement destructuring for `BatchedSVD`

### DIFF
--- a/src/stdlibs/factorization/SVD.jl
+++ b/src/stdlibs/factorization/SVD.jl
@@ -19,6 +19,21 @@ function BatchedSVD(U::M, S::C, Vt::M) where {M,C}
     return BatchedSVD{eltype(U),eltype(S),M,C}(U, S, Vt)
 end
 
+function Base.getproperty(F::BatchedSVD, d::Symbol)
+    if d === :V
+        return adjoint(getfield(F, :Vt))
+    else
+        return getfield(F, d)
+    end
+end
+
+Base.propertynames(::BatchedSVD) = (:U, :S, :V, :Vt)
+
+Base.iterate(F::BatchedSVD) = (F.U, Val(:S))
+Base.iterate(F::BatchedSVD, ::Val{:S}) = (F.S, Val(:Vt))
+Base.iterate(F::BatchedSVD, ::Val{:V}) = (F.V, Val(:done))
+Base.iterate(::BatchedSVD, ::Val{:done}) = nothing
+
 struct DefaultEnzymeXLASVDAlgorithm <: LinearAlgebra.Algorithm end
 struct JacobiAlgorithm <: LinearAlgebra.Algorithm end
 


### PR DESCRIPTION
it returns `V` instead of `Vt` to keep in synch with the semantics of `LinearAlgebra.SVD`

```julia
F = @jit svd(A)
U, S, V = F
```