### PR TITLE
ProbProg: pass strong_zero through run_chain + diagnostics tensor dim fix

### DIFF
--- a/src/probprog/MCMC.jl
+++ b/src/probprog/MCMC.jl
@@ -72,11 +72,7 @@ function mcmc(
     trace_type = MLIR.IR.TensorType(
         [collection_size, selection_pos_size], MLIR.IR.Type(Float64)
     )
-    diagnostics_type = if collection_size == 1
-        MLIR.IR.TensorType(Int64[], MLIR.IR.Type(Bool))
-    else
-        MLIR.IR.TensorType([Int64(collection_size)], MLIR.IR.Type(Bool))
-    end
+    diagnostics_type = MLIR.IR.TensorType([Int64(collection_size)], MLIR.IR.Type(Bool))
 
     position_type = MLIR.IR.TensorType([1, selection_pos_size], MLIR.IR.Type(Float64))
     scalar_type = MLIR.IR.TensorType(Int64[], MLIR.IR.Type(Float64))
@@ -162,11 +158,7 @@ function mcmc(
     new_trace = TracedRArray{Float64,2}(
         (), MLIR.IR.result(mcmc_op, 1), (collection_size, selection_pos_size)
     )
-    diagnostics = if collection_size == 1
-        TracedRArray{Bool,0}((), MLIR.IR.result(mcmc_op, 2), ())
-    else
-        TracedRArray{Bool,1}((), MLIR.IR.result(mcmc_op, 2), (collection_size,))
-    end
+    diagnostics = TracedRArray{Bool,1}((), MLIR.IR.result(mcmc_op, 2), (collection_size,))
 
     inv_mass_shape =
         isnothing(inverse_mass_matrix) ? (1, selection_pos_size) : size(inverse_mass_matrix)
@@ -273,11 +265,7 @@ function mcmc_logpdf(
 
     collection_size = num_samples ÷ thinning
     trace_type = MLIR.IR.TensorType([collection_size, pos_size], MLIR.IR.Type(Float64))
-    diagnostics_type = if collection_size == 1
-        MLIR.IR.TensorType(Int64[], MLIR.IR.Type(Bool))
-    else
-        MLIR.IR.TensorType([Int64(collection_size)], MLIR.IR.Type(Bool))
-    end
+    diagnostics_type = MLIR.IR.TensorType([Int64(collection_size)], MLIR.IR.Type(Bool))
 
     position_type = MLIR.IR.TensorType([1, pos_size], MLIR.IR.Type(Float64))
     scalar_type = MLIR.IR.TensorType(Int64[], MLIR.IR.Type(Float64))
@@ -332,11 +320,7 @@ function mcmc_logpdf(
     new_trace = TracedRArray{Float64,2}(
         (), MLIR.IR.result(mcmc_op, 1), (collection_size, pos_size)
     )
-    diagnostics = if collection_size == 1
-        TracedRArray{Bool,0}((), MLIR.IR.result(mcmc_op, 2), ())
-    else
-        TracedRArray{Bool,1}((), MLIR.IR.result(mcmc_op, 2), (collection_size,))
-    end
+    diagnostics = TracedRArray{Bool,1}((), MLIR.IR.result(mcmc_op, 2), (collection_size,))
 
     inv_mass_shape =
         isnothing(inverse_mass_matrix) ? (1, pos_size) : size(inverse_mass_matrix)

--- a/src/probprog/MCMC.jl
+++ b/src/probprog/MCMC.jl
@@ -475,9 +475,15 @@ function run_chain(
     adapt_mass_matrix::Bool=true,
     thinning::Int=1,
     trajectory_length::Float64=2π,
+    strong_zero::Bool=false,
 )
     mcmc_kwargs = (;
-        algorithm, max_tree_depth, max_delta_energy, trajectory_length, thinning
+        algorithm,
+        max_tree_depth,
+        max_delta_energy,
+        trajectory_length,
+        thinning,
+        strong_zero,
     )
 
     if !progress_bar
@@ -680,6 +686,7 @@ function run_chain(
     max_delta_energy::Float64=1000.0,
     thinning::Int=1,
     trajectory_length::Float64=2π,
+    strong_zero::Bool=false,
 )
     return run_chain(
         ReactantRNG(state.rng),
@@ -698,5 +705,6 @@ function run_chain(
         adapt_mass_matrix=false,
         thinning,
         trajectory_length,
+        strong_zero,
     )
 end

--- a/test/probprog/mcmc_state.jl
+++ b/test/probprog/mcmc_state.jl
@@ -6,6 +6,10 @@ function standard_normal_logpdf(x)
     return -0.5 * sum(x .^ 2)
 end
 
+function logpdf_divinf(x)
+    return -sum(min.(1.0, 1.0 ./ (x .^ 2)))
+end
+
 function warmup_program(
     rng,
     logpdf_fn,
@@ -643,6 +647,131 @@ end
             @test all(isfinite, more_samples)
         finally
             rm(tmpdir; recursive=true)
+        end
+    end
+
+    @testset "strong_zero" begin
+        initial_position_sz = Reactant.to_rarray([0.0, 0.0])
+        step_size_sz = ConcreteRNumber(0.5)
+        inv_mass_sz = ConcreteRArray([1.0 0.0; 0.0 1.0])
+        fresh_rng_sz() = ReactantRNG(Reactant.to_rarray(UInt64[42, 0]))
+
+        @testset "monolithic strong_zero=true escapes origin" begin
+            samples, _ = ProbProg.run_chain(
+                fresh_rng_sz(),
+                logpdf_divinf,
+                initial_position_sz;
+                algorithm=:NUTS,
+                num_warmup=0,
+                num_samples=3,
+                chunk_size=3,
+                step_size=step_size_sz,
+                inverse_mass_matrix=inv_mass_sz,
+                progress_bar=false,
+                max_tree_depth=5,
+                adapt_step_size=false,
+                adapt_mass_matrix=false,
+                strong_zero=true,
+            )
+            @test size(samples) == (3, pos_size)
+            @test all(isfinite, samples)
+            @test !all(samples .== 0.0)
+        end
+
+        @testset "monolithic strong_zero=false stays at origin" begin
+            samples, _ = ProbProg.run_chain(
+                fresh_rng_sz(),
+                logpdf_divinf,
+                initial_position_sz;
+                algorithm=:NUTS,
+                num_warmup=0,
+                num_samples=3,
+                chunk_size=3,
+                step_size=step_size_sz,
+                inverse_mass_matrix=inv_mass_sz,
+                progress_bar=false,
+                max_tree_depth=5,
+                adapt_step_size=false,
+                adapt_mass_matrix=false,
+                strong_zero=false,
+            )
+            @test size(samples) == (3, pos_size)
+            @test all(samples .== 0.0)
+        end
+
+        @testset "chunked strong_zero=true escapes origin" begin
+            samples, _ = ProbProg.run_chain(
+                fresh_rng_sz(),
+                logpdf_divinf,
+                initial_position_sz;
+                algorithm=:NUTS,
+                num_warmup=0,
+                num_samples=5,
+                chunk_size=2,
+                step_size=step_size_sz,
+                inverse_mass_matrix=inv_mass_sz,
+                progress_bar=true,
+                max_tree_depth=5,
+                adapt_step_size=false,
+                adapt_mass_matrix=false,
+                strong_zero=true,
+            )
+            @test size(samples) == (5, pos_size)
+            @test all(isfinite, samples)
+            @test !all(samples .== 0.0)
+        end
+
+        @testset "chunked strong_zero=false stays at origin" begin
+            samples, _ = ProbProg.run_chain(
+                fresh_rng_sz(),
+                logpdf_divinf,
+                initial_position_sz;
+                algorithm=:NUTS,
+                num_warmup=0,
+                num_samples=5,
+                chunk_size=2,
+                step_size=step_size_sz,
+                inverse_mass_matrix=inv_mass_sz,
+                progress_bar=true,
+                max_tree_depth=5,
+                adapt_step_size=false,
+                adapt_mass_matrix=false,
+                strong_zero=false,
+            )
+            @test size(samples) == (5, pos_size)
+            @test all(samples .== 0.0)
+        end
+
+        @testset "MCMCState overload forwards strong_zero=true" begin
+            _, state = ProbProg.run_chain(
+                fresh_rng_sz(),
+                logpdf_divinf,
+                initial_position_sz;
+                algorithm=:NUTS,
+                num_warmup=0,
+                num_samples=2,
+                chunk_size=2,
+                step_size=step_size_sz,
+                inverse_mass_matrix=inv_mass_sz,
+                progress_bar=false,
+                max_tree_depth=5,
+                adapt_step_size=false,
+                adapt_mass_matrix=false,
+                strong_zero=true,
+            )
+
+            samples2, _ = ProbProg.run_chain(
+                state,
+                logpdf_divinf;
+                algorithm=:NUTS,
+                num_samples=3,
+                chunk_size=3,
+                progress_bar=false,
+                max_tree_depth=5,
+                strong_zero=true,
+            )
+            @test size(samples2) == (3, pos_size)
+            @test all(isfinite, samples2)
         end
     end
 end


### PR DESCRIPTION
Also fixes the bug exposed by `progress_bar=true` due to wrong dimention handling of `diagnostics` tensor (which contains sample acceptance info atm) to follow the convention   https://github.com/EnzymeAD/Enzyme/blob/e0b27c20d397ce08a58ab28b09c1e2e772b37488/enzyme/Enzyme/MLIR/Passes/ExpandImpulsePass.cpp#L1207-L1208 in Enzyme proper