### PR TITLE
[MLIR] replace `with_block`, `with_module`, `with_context` for macro-version

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1182,7 +1182,7 @@ Reactant.@reactant_overlay function (func::LLVMFunc{F,tt})(
     wrapftype = MLIR.IR.Type(
         MLIR.API.mlirLLVMFunctionTypeGet(voidty, length(wrapper_tys), wrapper_tys, false)
     )
-    wrapfunc = MLIR.IR.with_block(MLIR.IR.body(mod)) do
+    wrapfunc = MLIR.IR.@with_block MLIR.IR.body(mod) begin
         return MLIR.Dialects.llvm.func(;
             sym_name,
             sym_visibility=MLIR.IR.Attribute("private"),
@@ -1241,7 +1241,7 @@ Reactant.@reactant_overlay function (func::LLVMFunc{F,tt})(
         end
 
         # TODO(#2240): check for only integer and explicitly non cutraced types
-        MLIR.IR.with_block(wrapbody) do
+        MLIR.IR.@with_block wrapbody begin
             argty = MLIR.IR.Type(
                 MLIR.API.mlirLLVMFunctionTypeGetInput(gpu_function_type, trueidx - 1)
             )
@@ -1374,7 +1374,7 @@ Reactant.@reactant_overlay function (func::LLVMFunc{F,tt})(
             else
                 get_field_offset(typeof(julia_arg), p[3:end])
             end
-            MLIR.IR.with_block(wrapbody) do
+            MLIR.IR.@with_block wrapbody begin
                 ptr = MLIR.IR.result(
                     MLIR.Dialects.llvm.getelementptr(
                         alloc,
@@ -1391,7 +1391,7 @@ Reactant.@reactant_overlay function (func::LLVMFunc{F,tt})(
         argidx += 1
     end
 
-    MLIR.IR.with_block(wrapbody) do
+    MLIR.IR.@with_block wrapbody begin
         for arg in allocs
             if arg === nothing
                 continue

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1183,7 +1183,7 @@ Reactant.@reactant_overlay function (func::LLVMFunc{F,tt})(
         MLIR.API.mlirLLVMFunctionTypeGet(voidty, length(wrapper_tys), wrapper_tys, false)
     )
     wrapfunc = MLIR.IR.@with_block MLIR.IR.body(mod) begin
-        return MLIR.Dialects.llvm.func(;
+        MLIR.Dialects.llvm.func(;
             sym_name,
             sym_visibility=MLIR.IR.Attribute("private"),
             function_type=wrapftype,

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -3390,7 +3390,7 @@ end
 
     sym_name = Reactant.TracedUtils.__lookup_unique_name_in_module(mod, sym_name)
 
-    mesh_op = MLIR.IR.with_module(mod) do
+    mesh_op = MLIR.IR.@with_module mod begin
         return MLIR.Dialects.sdy.mesh(; sym_name, mesh=mesh_attr, location)
     end
 

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -3336,6 +3336,7 @@ We return a NamedTuple with the following fields:
     sym_name::String="mesh",
     location=mlir_stacktrace("mesh", @__FILE__, @__LINE__),
 )
+    @info "1"
     cache = Reactant.Compiler.sdycache(; throw_error=ReactantCore.within_compile())
     key = (m.logical_device_ids, m.axis_names, size(m))
     cache !== nothing && haskey(cache, key) && return cache[key]
@@ -3357,6 +3358,7 @@ end
     sym_name::String="mesh",
     location=mlir_stacktrace("mesh", @__FILE__, @__LINE__),
 )
+    @info "2"
     # See https://github.com/openxla/shardy/blob/f9d83e779a58b811b848c4edfaf68e88b636787d/shardy/dialect/sdy/ir/verifiers.cc#L647-L699 for the checks
     ndevices = prod(last, mesh_axes)
 
@@ -3391,7 +3393,7 @@ end
     sym_name = Reactant.TracedUtils.__lookup_unique_name_in_module(mod, sym_name)
 
     mesh_op = MLIR.IR.@with_module mod begin
-        return MLIR.Dialects.sdy.mesh(; sym_name, mesh=mesh_attr, location)
+        MLIR.Dialects.sdy.mesh(; sym_name, mesh=mesh_attr, location)
     end
 
     # mesh_op needs to be moved to the beginning of the module

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2467,7 +2467,7 @@ end
 
     # compile the true branch without any returns first
     true_fn_mod = MLIR.IR.current_module()
-    true_func_tmp = MLIR.IR.with_block(MLIR.IR.body(true_fn_mod)) do
+    true_func_tmp = MLIR.IR.@with_block MLIR.IR.body(true_fn_mod) begin
         return MLIR.Dialects.func.func_(;
             sym_name=string(true_fn) * "_tb_tmp",
             function_type=MLIR.IR.FunctionType(input_types, []),
@@ -2533,7 +2533,7 @@ end
 
     # compile the false branch without any returns similar to the true branch
     false_fn_mod = MLIR.IR.current_module()
-    false_func_tmp = MLIR.IR.with_block(MLIR.IR.body(false_fn_mod)) do
+    false_func_tmp = MLIR.IR.@with_block MLIR.IR.body(false_fn_mod) begin
         return MLIR.Dialects.func.func_(;
             sym_name=string(false_fn) * "_fb_tmp",
             function_type=MLIR.IR.FunctionType(input_types, []),
@@ -2761,7 +2761,7 @@ end
     # With the corrected results, we can compile the true and false branches
     tb_out_types = [mlir_type(tr) for tr in tb_corrected_linear_results]
 
-    true_fn_compiled = MLIR.IR.with_block(MLIR.IR.body(true_fn_mod)) do
+    true_fn_compiled = MLIR.IR.@with_block MLIR.IR.body(true_fn_mod) begin
         return MLIR.Dialects.func.func_(;
             sym_name=Reactant.TracedUtils.__lookup_unique_name_in_module(
                 true_fn_mod, string(true_fn) * "_tb"
@@ -2778,7 +2778,7 @@ end
 
     fb_out_types = [mlir_type(fr) for fr in fb_corrected_linear_results]
 
-    false_fn_compiled = MLIR.IR.with_block(MLIR.IR.body(false_fn_mod)) do
+    false_fn_compiled = MLIR.IR.@with_block MLIR.IR.body(false_fn_mod) begin
         return MLIR.Dialects.func.func_(;
             sym_name=Reactant.TracedUtils.__lookup_unique_name_in_module(
                 false_fn_mod, string(false_fn) * "_fb"
@@ -2939,7 +2939,7 @@ result = Ops.case(
     branch_results = Vector{Any}(undef, n_branches)
 
     for b in 1:n_branches
-        branch_func_tmps[b] = MLIR.IR.with_block(MLIR.IR.body(branch_mods[b])) do
+        branch_func_tmps[b] = MLIR.IR.@with_block MLIR.IR.body(branch_mods[b]) begin
             return MLIR.Dialects.func.func_(;
                 sym_name=string(branch_fns[b]) * "_branch$(b)_tmp",
                 function_type=MLIR.IR.FunctionType(input_types, []),
@@ -3140,7 +3140,7 @@ result = Ops.case(
     for b in 1:n_branches
         branch_out_types = [mlir_type(tr) for tr in branch_corrected_linear_results[b]]
 
-        branch_fn_compiled = MLIR.IR.with_block(MLIR.IR.body(branch_mods[b])) do
+        branch_fn_compiled = MLIR.IR.@with_block MLIR.IR.body(branch_mods[b]) begin
             return MLIR.Dialects.func.func_(;
                 sym_name=Reactant.TracedUtils.__lookup_unique_name_in_module(
                     branch_mods[b], string(branch_fns[b]) * "_branch$(b)"

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2468,7 +2468,7 @@ end
     # compile the true branch without any returns first
     true_fn_mod = MLIR.IR.current_module()
     true_func_tmp = MLIR.IR.@with_block MLIR.IR.body(true_fn_mod) begin
-        return MLIR.Dialects.func.func_(;
+        MLIR.Dialects.func.func_(;
             sym_name=string(true_fn) * "_tb_tmp",
             function_type=MLIR.IR.FunctionType(input_types, []),
             body=MLIR.IR.Region(),
@@ -2534,7 +2534,7 @@ end
     # compile the false branch without any returns similar to the true branch
     false_fn_mod = MLIR.IR.current_module()
     false_func_tmp = MLIR.IR.@with_block MLIR.IR.body(false_fn_mod) begin
-        return MLIR.Dialects.func.func_(;
+        MLIR.Dialects.func.func_(;
             sym_name=string(false_fn) * "_fb_tmp",
             function_type=MLIR.IR.FunctionType(input_types, []),
             body=MLIR.IR.Region(),
@@ -2762,7 +2762,7 @@ end
     tb_out_types = [mlir_type(tr) for tr in tb_corrected_linear_results]
 
     true_fn_compiled = MLIR.IR.@with_block MLIR.IR.body(true_fn_mod) begin
-        return MLIR.Dialects.func.func_(;
+        MLIR.Dialects.func.func_(;
             sym_name=Reactant.TracedUtils.__lookup_unique_name_in_module(
                 true_fn_mod, string(true_fn) * "_tb"
             ),
@@ -2779,7 +2779,7 @@ end
     fb_out_types = [mlir_type(fr) for fr in fb_corrected_linear_results]
 
     false_fn_compiled = MLIR.IR.@with_block MLIR.IR.body(false_fn_mod) begin
-        return MLIR.Dialects.func.func_(;
+        MLIR.Dialects.func.func_(;
             sym_name=Reactant.TracedUtils.__lookup_unique_name_in_module(
                 false_fn_mod, string(false_fn) * "_fb"
             ),
@@ -2940,7 +2940,7 @@ result = Ops.case(
 
     for b in 1:n_branches
         branch_func_tmps[b] = MLIR.IR.@with_block MLIR.IR.body(branch_mods[b]) begin
-            return MLIR.Dialects.func.func_(;
+            MLIR.Dialects.func.func_(;
                 sym_name=string(branch_fns[b]) * "_branch$(b)_tmp",
                 function_type=MLIR.IR.FunctionType(input_types, []),
                 body=MLIR.IR.Region(),
@@ -3141,7 +3141,7 @@ result = Ops.case(
         branch_out_types = [mlir_type(tr) for tr in branch_corrected_linear_results[b]]
 
         branch_fn_compiled = MLIR.IR.@with_block MLIR.IR.body(branch_mods[b]) begin
-            return MLIR.Dialects.func.func_(;
+            MLIR.Dialects.func.func_(;
                 sym_name=Reactant.TracedUtils.__lookup_unique_name_in_module(
                     branch_mods[b], string(branch_fns[b]) * "_branch$(b)"
                 ),

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -3336,7 +3336,6 @@ We return a NamedTuple with the following fields:
     sym_name::String="mesh",
     location=mlir_stacktrace("mesh", @__FILE__, @__LINE__),
 )
-    @info "1"
     cache = Reactant.Compiler.sdycache(; throw_error=ReactantCore.within_compile())
     key = (m.logical_device_ids, m.axis_names, size(m))
     cache !== nothing && haskey(cache, key) && return cache[key]
@@ -3358,7 +3357,6 @@ end
     sym_name::String="mesh",
     location=mlir_stacktrace("mesh", @__FILE__, @__LINE__),
 )
-    @info "2"
     # See https://github.com/openxla/shardy/blob/f9d83e779a58b811b848c4edfaf68e88b636787d/shardy/dialect/sdy/ir/verifiers.cc#L647-L699 for the checks
     ndevices = prod(last, mesh_axes)
 

--- a/src/Sharding.jl
+++ b/src/Sharding.jl
@@ -836,7 +836,8 @@ function HloSharding(sharding::DimsSharding, size_x)
 end
 
 function Base.convert(::Type{HloSharding}, sharding::NamedSharding)
-    MLIR.IR.with_context(; allow_use_existing=true) do ctx
+    ctx = MLIR.IR.has_context() ? MLIR.IR.current_context() : Reactant.ReactantContext()
+    MLIR.IR.@with_context ctx begin
         mesh_op = Reactant.Ops.mesh(
             sharding.mesh; mod=MLIR.IR.Module(MLIR.IR.Location(; context=ctx))
         )

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -538,7 +538,7 @@ function prepare_mlir_fn_args(
         end
     end
 
-    func = MLIR.IR.with_block(MLIR.IR.body(mod)) do
+    func = MLIR.IR.@with_block MLIR.IR.body(mod) begin
         return MLIR.Dialects.func.func_(;
             sym_name=name * "_tmp",
             function_type=MLIR.IR.FunctionType(in_tys, Vector{MLIR.IR.Type}(undef, 0)),

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -877,8 +877,8 @@ function finalize_mlir_fn(
         MLIR.IR.deactivate(fnbody)
     end
 
-    func2 = MLIR.IR.with_block(MLIR.IR.body(mod)) do
-        return MLIR.Dialects.func.func_(;
+    func2 = MLIR.IR.@with_block MLIR.IR.body(mod) begin
+        MLIR.Dialects.func.func_(;
             sym_name=__lookup_unique_name_in_module(mod, name),
             function_type=MLIR.IR.FunctionType(in_tys, out_tys),
             body=MLIR.IR.Region(),

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -539,7 +539,7 @@ function prepare_mlir_fn_args(
     end
 
     func = MLIR.IR.@with_block MLIR.IR.body(mod) begin
-        return MLIR.Dialects.func.func_(;
+        MLIR.Dialects.func.func_(;
             sym_name=name * "_tmp",
             function_type=MLIR.IR.FunctionType(in_tys, Vector{MLIR.IR.Type}(undef, 0)),
             body=MLIR.IR.Region(),

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -1099,7 +1099,7 @@ function compile_mlir!(
     MLIR.IR.dispose(ret)
 
     MLIR.IR.@with_block fnbody begin
-        return MLIR.Dialects.func.return_(nresults)
+        MLIR.Dialects.func.return_(nresults)
     end
 
     out_tys2 = [MLIR.IR.type(a) for a in nresults]

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -1098,7 +1098,7 @@ function compile_mlir!(
 
     MLIR.IR.dispose(ret)
 
-    MLIR.IR.with_block(fnbody) do
+    MLIR.IR.@with_block fnbody begin
         return MLIR.Dialects.func.return_(nresults)
     end
 

--- a/src/compiler/OptimizationPasses.jl
+++ b/src/compiler/OptimizationPasses.jl
@@ -212,7 +212,7 @@ end
 
 # helper for debug purposes: String -> Text
 function run_pass_pipeline_on_source(source, pass_pipeline; enable_verifier=true)
-    return MLIR.IR.with_context() do _
+    return MLIR.IR.@with_context Reactant.ReactantContext() begin
         mod = parse(MLIR.IR.Module, source)
         run_pass_pipeline!(mod, pass_pipeline; enable_verifier)
         MLIR.IR.verifyall(MLIR.IR.Operation(mod); debug=true)

--- a/src/mlir/IR/Block.jl
+++ b/src/mlir/IR/Block.jl
@@ -235,11 +235,14 @@ function current_block(; throw_error::Core.Bool=true)
     return last(task_local_storage(:mlir_block)::Vector{Block})
 end
 
-function with_block(f, blk::Block)
-    activate(blk)
-    try
-        f()
-    finally
-        deactivate(blk)
+macro with_block(blk, body)
+    quote
+        blk = $(esc(blk))
+        $activate(blk)
+        try
+            $(esc(body))
+        finally
+            $deactivate(blk)
+        end
     end
 end

--- a/src/mlir/IR/Context.jl
+++ b/src/mlir/IR/Context.jl
@@ -73,23 +73,3 @@ macro with_context(ctx, body)
         end
     end
 end
-
-# TODO replace this method on all call sites for the one accepting a context argument
-function with_context(f; allow_use_existing=false)
-    do_dispose = false
-    if allow_use_existing && has_context()
-        ctx = current_context()
-    else
-        ctx = Context(Reactant.registry[])
-        do_dispose = true
-        API.RegisterDialects(ctx)
-    end
-
-    activate(ctx)
-    try
-        return f(ctx)
-    finally
-        deactivate(ctx)
-        do_dispose && dispose(ctx)
-    end
-end

--- a/src/mlir/IR/Context.jl
+++ b/src/mlir/IR/Context.jl
@@ -62,12 +62,15 @@ function current_context(; throw_error::Core.Bool=true)
     return last(task_local_storage(:mlir_context_stack)::Vector{Context})
 end
 
-function with_context(f, ctx::Context)
-    activate(ctx)
-    try
-        f()
-    finally
-        deactivate(ctx)
+macro with_context(ctx, body)
+    quote
+        ctx = $(esc(ctx))
+        $activate(ctx)
+        try
+            $(esc(body))
+        finally
+            $deactivate(ctx)
+        end
     end
 end
 

--- a/src/mlir/IR/IR.jl
+++ b/src/mlir/IR/IR.jl
@@ -45,7 +45,7 @@ end
 # MLIR `Type` and `Module`
 export Attribute, Block, Context, Dialect, Location, Operation, Region, Value
 export activate, deactivate, dispose, enable_multithreading!
-export context, current_context, has_context, with_context
+export context, current_context, has_context, @with_context
 export block, current_block, has_block, @with_block
 export current_module, has_module, @with_module
 export type, settype!, location, typeid, dialect

--- a/src/mlir/IR/IR.jl
+++ b/src/mlir/IR/IR.jl
@@ -46,7 +46,7 @@ end
 export Attribute, Block, Context, Dialect, Location, Operation, Region, Value
 export activate, deactivate, dispose, enable_multithreading!
 export context, current_context, has_context, with_context
-export block, current_block, has_block, with_block
+export block, current_block, has_block, @with_block
 export current_module, has_module, with_module
 export type, settype!, location, typeid, dialect
 export nattrs, getattr, setattr!, rmattr!

--- a/src/mlir/IR/IR.jl
+++ b/src/mlir/IR/IR.jl
@@ -47,7 +47,7 @@ export Attribute, Block, Context, Dialect, Location, Operation, Region, Value
 export activate, deactivate, dispose, enable_multithreading!
 export context, current_context, has_context, with_context
 export block, current_block, has_block, @with_block
-export current_module, has_module, with_module
+export current_module, has_module, @with_module
 export type, settype!, location, typeid, dialect
 export nattrs, getattr, setattr!, rmattr!
 export nregions, region

--- a/src/mlir/IR/Module.jl
+++ b/src/mlir/IR/Module.jl
@@ -93,11 +93,14 @@ function current_module(; throw_error::Core.Bool=true)
     return last(task_local_storage(:mlir_module)::Vector{Module})
 end
 
-function with_module(f, blk::Module)
-    activate(blk)
-    try
-        f()
-    finally
-        deactivate(blk)
+macro with_module(_mod, body)
+    quote
+        _mod = $(esc(_mod))
+        $activate(_mod)
+        try
+            $(esc(body))
+        finally
+            $deactivate(_mod)
+        end
     end
 end

--- a/test/core/bcast.jl
+++ b/test/core/bcast.jl
@@ -32,7 +32,7 @@ function test()
         push!(MLIR.IR.region(func, 1), fnbody)
 
         GC.@preserve mod func fnbody begin
-            MLIR.IR.with_block(fnbody) do
+            MLIR.IR.@with_block fnbody begin
                 a = ones(4)
                 b = ones(4)
                 d = Data(

--- a/test/core/bcast.jl
+++ b/test/core/bcast.jl
@@ -39,7 +39,7 @@ function test()
                     Reactant.TracedRArray{Float64,1}((), MLIR.IR.argument(fnbody, 1), (4,))
                 )
 
-                return tmp(a, b, d)
+                tmp(a, b, d)
             end
         end
 

--- a/test/core/bcast.jl
+++ b/test/core/bcast.jl
@@ -16,7 +16,7 @@ end
 end
 
 function test()
-    MLIR.IR.with_context() do ctx
+    MLIR.IR.@with_context Reactant.ReactantContext() begin
         mod = MLIR.IR.Module(MLIR.IR.Location())
         modbody = MLIR.IR.body(mod)
 

--- a/test/core/ir.jl
+++ b/test/core/ir.jl
@@ -4,7 +4,7 @@ using Reactant: MLIR
     MLIR.IR.with_context() do ctx
         mod = MLIR.IR.Module()
 
-        MLIR.IR.with_module(mod) do
+        MLIR.IR.@with_module mod begin
             MLIR.IR.inject!(
                 "MPI_COMM_WORLD", "llvm.mlir.global constant @MPI_COMM_WORLD() : !llvm.ptr"
             )

--- a/test/core/ir.jl
+++ b/test/core/ir.jl
@@ -1,7 +1,7 @@
 using Reactant: MLIR
 
 @testset "inject" begin
-    MLIR.IR.with_context() do ctx
+    MLIR.IR.@with_context Reactant.ReactantContext() begin
         mod = MLIR.IR.Module()
 
         MLIR.IR.@with_module mod begin


### PR DESCRIPTION
i.e. avoid closures