### PR TITLE
Rename `checkpoints` to match Enzyme-JAX

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2398,7 +2398,7 @@ end
             while_op, "enzymexla.enable_checkpointing", MLIR.IR.Attribute(true)
         )
         MLIR.IR.setattr!(
-            while_op, "enzymexla.checkpoints", MLIR.IR.Attribute(checkpointing.n)
+            while_op, "enzymexla.checkpoint_period", MLIR.IR.Attribute(checkpointing.n)
         )
     elseif checkpointing === true
         MLIR.IR.setattr!(

--- a/test/core/control_flow.jl
+++ b/test/core/control_flow.jl
@@ -712,7 +712,7 @@ end
     @test @filecheck begin
         @check_dag "enzyme.disable_mincut"
         @check_dag "enzymexla.enable_checkpointing"
-        @check_dag "enzymexla.checkpoints = 3"
+        @check_dag "enzymexla.checkpoint_period = 3"
         ir
     end
 end
@@ -742,7 +742,7 @@ end
     )
     @test @filecheck begin
         @check_dag "enzymexla.enable_checkpointing"
-        @check_dag "enzymexla.checkpoints = 5"
+        @check_dag "enzymexla.checkpoint_period = 5"
         ir
     end
 end

--- a/test/core/control_flow.jl
+++ b/test/core/control_flow.jl
@@ -768,7 +768,7 @@ end
     ir = sprint(show, @code_hlo while_explicit_checkpoints(x_ra, n_ra))
     @test @filecheck begin
         @check_dag "enzymexla.enable_checkpointing"
-        @check_dag "enzymexla.checkpoints = 5"
+        @check_dag "enzymexla.checkpoint_period = 5"
         ir
     end
 end


### PR DESCRIPTION
Enzyme-JAX reads `checkpoint_period` so `Periodic(n)` falls through without this I believe. See https://github.com/EnzymeAD/Enzyme-JAX/blob/d0b1927095c7ed49598353f880e4ae64d7f808d0/src/enzyme_ad/jax/Implementations/StableHLOAutoDiffOpInterfaceImpl.cpp#L511