### PR TITLE
[WIP] PyTorch Import

### DIFF
--- a/docs/src/tutorials/pytorch.md
+++ b/docs/src/tutorials/pytorch.md
@@ -10,7 +10,9 @@ This feature lives in the `ReactantPythonCallExt` extension and is enabled when
 traced with [`torch.export`](https://pytorch.org/docs/stable/export.html), lowered
 to StableHLO with [`torchax`](https://github.com/pytorch/xla/tree/master/torchax),
 and inlined into the current trace. The module's parameters and buffers are carried
-across as inlined constants, mirroring how JAX closure parameters are captured.
+across as inlined constants, mirroring how JAX closure parameters are captured. As
+with closure-captured values in the JAX path, this embeds the weights directly in
+the compiled module, so very large models produce correspondingly large modules.
 
 ## Usage
 
@@ -31,6 +33,12 @@ y = @jit model(x)                              # traced, compiled, executed
 
 You provide only the model object and the Reactant input arrays; the weights are
 read from the module automatically.
+
+!!! note "The module is mutated in place"
+    Importing a module switches it into eval mode (`model.eval()`), and for
+    TorchScript inputs it also rewraps leaf parameters as `torch.nn.Parameter` on
+    the module object you pass in. If you need the original module untouched, pass a
+    copy.
 
 !!! note "Array layout"
     The Reactant array's shape is the PyTorch tensor shape directly, with the batch

--- a/docs/src/tutorials/pytorch.md
+++ b/docs/src/tutorials/pytorch.md
@@ -1,0 +1,65 @@
+# Importing PyTorch models
+
+Reactant can trace an existing PyTorch model and splice it into a Reactant
+computation, in the same way it traces JAX functions invoked through
+[PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl). This lets you reuse a
+`torch.nn.Module` (including its trained weights) from Julia without rewriting it.
+
+This feature lives in the `ReactantPythonCallExt` extension and is enabled when
+`PythonCall`, `torch`, and `torchax` are all available. Under the hood the model is
+traced with [`torch.export`](https://pytorch.org/docs/stable/export.html), lowered
+to StableHLO with [`torchax`](https://github.com/pytorch/xla/tree/master/torchax),
+and inlined into the current trace. The module's parameters and buffers are carried
+across as inlined constants, mirroring how JAX closure parameters are captured.
+
+## Usage
+
+Construct (or load) the PyTorch module, then call it inside `@compile`/`@jit` with
+Reactant arrays:
+
+```julia
+using Reactant, PythonCall
+
+torch = pyimport("torch")
+nn = pyimport("torch.nn")
+
+model = nn.Sequential(nn.Linear(8, 16), nn.ReLU(), nn.Linear(16, 4))
+
+x = Reactant.to_rarray(rand(Float32, 4, 8))   # (batch, features)
+y = @jit model(x)                              # traced, compiled, executed
+```
+
+You provide only the model object and the Reactant input arrays; the weights are
+read from the module automatically.
+
+!!! note "Array layout"
+    The Reactant array's shape is the PyTorch tensor shape directly, with the batch
+    dimension first (for example `(batch, channels, height, width)` for a 2D
+    convolution). There is no axis reversal. Provide inputs in the layout the model
+    expects, exactly as you would when calling the model in Python.
+
+## TorchScript models
+
+TorchScript artifacts produced by `torch.jit.script` or `torch.jit.trace` are
+supported as well. Load the module and call it the same way:
+
+```julia
+scripted = torch.jit.load("model.pt")
+y = @jit scripted(x)
+```
+
+## Limitations
+
+- The model must be exportable with `torch.export`. Data-dependent control flow or
+  shapes that `torch.export` cannot capture are not supported.
+- Inputs and outputs must be tensors. Nested or non-tensor arguments are not
+  supported.
+- Element types are limited to those Reactant maps to StableHLO (the floating point,
+  integer, and boolean types in `Reactant.Serialization.NUMPY_SIMPLE_TYPES`).
+- `torchax` depends on JAX, so a JAX installation compatible with your `torchax`
+  version is required.
+- Use a CPU build of PyTorch (`torch==...+cpu`). A CUDA PyTorch wheel ships a
+  `libtorch_cuda.so` that clashes with Reactant's runtime when imported after
+  Reactant, and the import fails. The extension already prevents the related
+  Triton/LLVM clash by blocking Triton during export, so no special import order is
+  needed.

--- a/docs/src/tutorials/pytorch.md
+++ b/docs/src/tutorials/pytorch.md
@@ -56,6 +56,53 @@ scripted = torch.jit.load("model.pt")
 y = @jit scripted(x)
 ```
 
+## Matmul precision
+
+The float32 matmul precision of an imported model is fixed by jax when it lowers the
+model to StableHLO, and it is baked into the exported program. jax chooses it from
+the platform it detects in the current process at trace time, not from the backend
+Reactant ultimately runs on, so the two can disagree:
+
+- With a GPU visible to jax (the default when `CUDA_VISIBLE_DEVICES` is unset, or any
+  non-empty value), jax lowers float32 matmuls at reduced, TF32-style precision. That
+  reduced precision is frozen in, so it applies even if Reactant then executes on CPU.
+  On a CPU-only host this shows up as a roughly `5e-4` relative difference from eager
+  PyTorch rather than the roughly `1e-7` of full float32.
+- With only CPU detected (`CUDA_VISIBLE_DEVICES=""` hides all GPUs), jax lowers at
+  full float32, and that too is frozen in, so you will not get the TF32 speedup even
+  if you later run the compiled module on a GPU. TF32 also requires an Ampere or newer
+  GPU in the first place.
+
+The import path deliberately follows jax's default so callers can trade accuracy for
+speed, and it emits a one-time warning reporting the precision in effect. For a
+deterministic, platform-independent result, set the precision explicitly before
+tracing:
+
+```julia
+pyimport("jax").config.update("jax_default_matmul_precision", "highest")
+```
+
+`"highest"` gives full float32 on any platform; the integration tests use it so their
+comparisons against eager PyTorch are exact.
+
+## Float64 (double precision)
+
+Double precision models work directly. Build the module and the Reactant input in
+`Float64` and call it as usual:
+
+```julia
+model = nn.Sequential(nn.Linear(8, 16), nn.ReLU(), nn.Linear(16, 4))
+model.double()
+
+x = Reactant.to_rarray(rand(Float64, 4, 8))
+y = @jit model(x)            # y is a Float64 Reactant array
+```
+
+jax disables 64-bit support by default and would otherwise canonicalize float64 to
+float32 during lowering. The import path enables jax's x64 mode only for the duration
+of the export, so float64 models keep double precision without changing jax's global
+configuration.
+
 ## Limitations
 
 - The model must be exportable with `torch.export`. Data-dependent control flow or

--- a/ext/ReactantPythonCallExt/ReactantPythonCallExt.jl
+++ b/ext/ReactantPythonCallExt/ReactantPythonCallExt.jl
@@ -1,6 +1,17 @@
 module ReactantPythonCallExt
 
-using PythonCall: PythonCall, Py, pyconvert, pydict, pyfunc, pyimport, pylist
+using PythonCall:
+    PythonCall,
+    Py,
+    pybuiltins,
+    pyconvert,
+    pydict,
+    pyeval,
+    pyexec,
+    pyfunc,
+    pyimport,
+    pylist,
+    pytuple
 using Reactant: Reactant, TracedRArray, TracedRNumber, @reactant_overlay
 using Reactant.Ops: @opcall
 using Reactant.Serialization: NUMPY_SIMPLE_TYPES
@@ -15,6 +26,14 @@ const tf2xlaptr = Ref{Py}()
 const npptr = Ref{Py}()
 
 const SAVED_MODEL_EXPORT_SUPPORTED = Ref{Bool}(false)
+
+const torchptr = Ref{Py}()
+# torchax lowers a torch.export'd program to StableHLO whose entry signature is
+# `(weights..., inputs...)`; this helper re-exports it through jax so the signature
+# becomes `(inputs..., weights...)`, which is the order pytorch.jl feeds to hlo_call.
+const torch_to_stablehlo_inputs_first = Ref{Py}()
+
+const TORCH_EXPORT_SUPPORTED = Ref{Bool}(false)
 
 function __init__()
     try
@@ -37,11 +56,26 @@ function __init__()
                tensorflow SavedModel will not be \
                supported." exception = (err, catch_backtrace())
     end
+
+    try
+        torchptr[] = pyimport("torch")
+        pyimport("torchax")  # registers torchax; the export helper imports its submodules
+        npptr[] = pyimport("numpy")
+        pyexec(TORCH_TO_STABLEHLO_INPUTS_FIRST_PY, @__MODULE__)
+        torch_to_stablehlo_inputs_first[] = pyeval(
+            "_torch_to_stablehlo_inputs_first", @__MODULE__
+        )
+        TORCH_EXPORT_SUPPORTED[] = true
+    catch err
+        @warn "Failed to import torch/torchax. Importing PyTorch modules invoked with \
+               pycall won't be supported." exception = (err, catch_backtrace())
+    end
     return nothing
 end
 
 include("overlays.jl")
 include("pycall.jl")
+include("pytorch.jl")
 include("saved_model.jl")
 
 end

--- a/ext/ReactantPythonCallExt/ReactantPythonCallExt.jl
+++ b/ext/ReactantPythonCallExt/ReactantPythonCallExt.jl
@@ -3,13 +3,13 @@ module ReactantPythonCallExt
 using PythonCall:
     PythonCall,
     Py,
-    pybuiltins,
     pyconvert,
     pydict,
     pyeval,
     pyexec,
     pyfunc,
     pyimport,
+    pyisinstance,
     pylist,
     pytuple
 using Reactant: Reactant, TracedRArray, TracedRNumber, @reactant_overlay

--- a/ext/ReactantPythonCallExt/overlays.jl
+++ b/ext/ReactantPythonCallExt/overlays.jl
@@ -1,6 +1,10 @@
 @reactant_overlay function PythonCall.pycall(f::Py, args...)
     if Reactant.looped_any(Reactant.use_overlayed_version, args)
-        return pycall_with_jax_tracing(f, args...)
+        if is_torch_module(f)
+            return pycall_with_torch_export(f, args...)
+        else
+            return pycall_with_jax_tracing(f, args...)
+        end
     else
         return Reactant.call_with_native(PythonCall.pycall, f, args...)
     end

--- a/ext/ReactantPythonCallExt/pytorch.jl
+++ b/ext/ReactantPythonCallExt/pytorch.jl
@@ -76,6 +76,16 @@ _install_state_order_fix()
 def _torch_to_stablehlo_inputs_first(model, example_inputs, strict):
     blocker = _TritonBlocker()
     sys.meta_path.insert(0, blocker)
+    # Enable jax's 64-bit mode for the lowering so float64 models keep double
+    # precision. jax disables x64 by default and would otherwise canonicalize float64
+    # weights, inputs, and avals to float32, producing an f64/f32 mismatch when
+    # Reactant feeds the original float64 operands to hlo_call. Save and restore the
+    # flag so this stays scoped to the export and does not change global jax behavior
+    # (for example the jax tracing path in pycall.jl). The weights and the exported
+    # program are materialized inside this window, so they retain their dtype after
+    # the flag is restored.
+    prev_x64 = _jax.config.jax_enable_x64
+    _jax.config.update("jax_enable_x64", True)
     try:
         exported = _torch.export.export(model, example_inputs, strict=strict)
         weights, func = _txe.exported_program_to_jax(exported)
@@ -91,6 +101,7 @@ def _torch_to_stablehlo_inputs_first(model, example_inputs, strict):
         jax_export = _jax.export.export(_jax.jit(reordered))((jax_avals,), weights)
         return weights, jax_export, len(jax_avals)
     finally:
+        _jax.config.update("jax_enable_x64", prev_x64)
         try:
             sys.meta_path.remove(blocker)
         except ValueError:
@@ -203,12 +214,15 @@ function pycall_with_torch_export(model::Py, args...)
     matmul_precision = pyconvert(
         String, pyimport("builtins").str(jaxptr[].config.jax_default_matmul_precision)
     )
-    @warn "Tracing a PyTorch model: jax will lower float32 matmuls with \
-           jax_default_matmul_precision=$(matmul_precision). A value of None means jax's \
-           platform default, which can be reduced (TF32-style) precision on a \
-           GPU-initialized jax and will differ from a CPU run. Set \
-           jax_default_matmul_precision=\"highest\" before tracing for full float32 \
-           precision." maxlog = 1
+    @warn "Tracing a PyTorch model: jax is lowering float32 matmuls with \
+           jax_default_matmul_precision=$(matmul_precision), and that precision is frozen \
+           into the exported StableHLO. jax picks it from the platform it detects at \
+           trace time, not the backend Reactant executes on, so the two can disagree: \
+           with GPUs visible jax can bake reduced (TF32-style) precision even if \
+           execution falls back to CPU, and with only CPU detected it bakes full \
+           float32 even if you later run on a GPU (and TF32 itself needs an Ampere or \
+           newer GPU). Set jax_default_matmul_precision=\"highest\" before tracing for \
+           deterministic full float32." maxlog = 1
 
     # Export with strict=false (the non-Dynamo tracer). Besides being required for
     # TorchScript, strict=true routes through Dynamo, whose accelerator/stream

--- a/ext/ReactantPythonCallExt/pytorch.jl
+++ b/ext/ReactantPythonCallExt/pytorch.jl
@@ -24,6 +24,7 @@
 const TORCH_TO_STABLEHLO_INPUTS_FIRST_PY = """
 import sys
 import jax as _jax
+import jax.numpy as _jnp
 import torch as _torch
 import torchax.export as _txe
 
@@ -33,62 +34,88 @@ class _TritonBlocker:
             raise ImportError("triton import blocked by ReactantPythonCallExt to avoid an LLVM clash with Reactant")
         return None
 
-# torchax's `_extract_states_from_exported_program` builds the positional state
-# list as params + buffers + lifted-constants, but torch.export can order the graph
-# placeholders differently (e.g. params, constant, buffers). The interpreter binds
-# states to placeholders by position, so the default order can feed the wrong tensor
-# to each placeholder (a scalar constant where a conv buffer is expected, etc.),
-# silently corrupting any model whose placeholder order differs. Override it to emit
-# states in the graph's own `input_specs` order. This patches the torchax.export
-# module global that `exported_program_to_jax` looks up at call time.
-def _install_state_order_fix():
-    _InputKind = _torch.export.graph_signature.InputKind
-    def _extract_states_in_input_spec_order(exported_program):
-        gs = exported_program.graph_signature
-        state_dict = dict(exported_program.state_dict)
-        constants = dict(getattr(exported_program, "constants", None) or {})
-        names, values = [], []
-        for spec in gs.input_specs:
-            if spec.kind == _InputKind.USER_INPUT:
-                continue
-            target = spec.target
-            if spec.kind in (_InputKind.PARAMETER, _InputKind.BUFFER):
-                v = state_dict[target]
-            elif spec.kind == _InputKind.CONSTANT_TENSOR:
-                v = constants[target]
-            else:
-                v = constants.get(target, state_dict.get(target))
-            names.append(target)
-            values.append(v)
-        return names, values
-    # Fail loudly if the symbol we override has moved or been renamed: a plain
-    # attribute assignment would otherwise succeed silently, leave torchax calling
-    # its original function, and reintroduce the state-corruption bug this fixes.
-    if not hasattr(_txe, "_extract_states_from_exported_program"):
-        raise AttributeError(
-            "torchax.export._extract_states_from_exported_program is missing; "
-            "the installed torchax version is incompatible with ReactantPythonCallExt"
+# torchax binds the model's states (parameters, buffers, lifted constants) to the
+# decomposed graph's non-user placeholders by position, in graph order. It extracts
+# them in `params + buffers + lifted-constants` order, but torch.export can order the
+# placeholders differently (e.g. params, constant, buffers), so the default order can
+# feed the wrong tensor to each placeholder (a scalar constant where a conv buffer is
+# expected, etc.), silently corrupting any model whose placeholder order differs.
+#
+# `_reorder_weights_to_placeholder_order` below fixes this without monkey patching
+# torchax: it recovers the decomposed `ExportedProgram` that the returned `func` binds
+# to (it is captured in `func`'s closure) and permutes the already-converted weight
+# list into the graph's own `input_specs` order before we feed it to `func`. Reading
+# the order from the exact program `func` uses avoids any assumption about torchax's
+# decomposition sequence; an incompatible torchax fails loudly here rather than
+# producing silently wrong results.
+def _reorder_weights_to_placeholder_order(weights, func):
+    # `func` is the closure returned by `exported_program_to_jax`; it runs the
+    # interpreter over a decomposed `ExportedProgram` it captured. Recover that program
+    # by type (independent of closure cell order).
+    decomposed = next(
+        (cell.cell_contents for cell in (func.__closure__ or [])
+         if isinstance(cell.cell_contents, _torch.export.ExportedProgram)),
+        None,
+    )
+    if decomposed is None:
+        raise RuntimeError(
+            "could not recover the decomposed ExportedProgram from torchax's func "
+            "closure; the installed torchax version is incompatible with ReactantPythonCallExt"
         )
-    _txe._extract_states_from_exported_program = _extract_states_in_input_spec_order
+    _InputKind = _torch.export.graph_signature.InputKind
+    gs = decomposed.graph_signature
+    # The order torchax extracted `weights` in (mirrors its
+    # `_extract_states_from_exported_program`).
+    extracted = (list(gs.parameters) + list(gs.buffers)
+                 + list(getattr(gs, "lifted_tensor_constants", [])))
+    # The order the interpreter consumes the states in: the graph's own placeholders.
+    placeholder_order = [s.target for s in gs.input_specs if s.kind != _InputKind.USER_INPUT]
+    if sorted(placeholder_order) != sorted(extracted):
+        raise RuntimeError(
+            "torchax state/placeholder set mismatch; the installed torchax version is "
+            "incompatible with ReactantPythonCallExt"
+        )
+    pos = {name: i for i, name in enumerate(extracted)}
+    return [weights[pos[target]] for target in placeholder_order]
 
-_install_state_order_fix()
+def _demote_weak_scalar_constants(weights):
+    # Reproduce PyTorch's weak-scalar promotion: a float64 *scalar* constant (a Python
+    # float literal) binds to the dtype of the tensor it operates on instead of upcasting
+    # it. jax materializes it as a strong float64 array that (with x64 on) upcasts and
+    # then collides with float32 operands (e.g. a 0.001 constant reaching a float32 conv).
+    # Cast 0-dim float64 constants to float32 so the constant's precision follows its
+    # operands; genuine multi-dim float64 data is left alone, and jax promotes a demoted
+    # scalar back to float64 wherever it meets a real float64 tensor.
+    return [w.astype(_jnp.float32)
+            if (getattr(w, "ndim", None) == 0 and getattr(w, "dtype", None) == _jnp.float64)
+            else w
+            for w in weights]
 
 def _torch_to_stablehlo_inputs_first(model, example_inputs, strict):
     blocker = _TritonBlocker()
     sys.meta_path.insert(0, blocker)
-    # Enable jax's 64-bit mode for the lowering so float64 models keep double
-    # precision. jax disables x64 by default and would otherwise canonicalize float64
-    # weights, inputs, and avals to float32, producing an f64/f32 mismatch when
-    # Reactant feeds the original float64 operands to hlo_call. Save and restore the
-    # flag so this stays scoped to the export and does not change global jax behavior
-    # (for example the jax tracing path in pycall.jl). The weights and the exported
-    # program are materialized inside this window, so they retain their dtype after
-    # the flag is restored.
+    # Enable jax's 64-bit mode for the lowering so genuinely double-precision models keep
+    # their dtype. jax disables x64 by default and would otherwise canonicalize float64
+    # weights, inputs, and avals to float32, producing an f64/f32 mismatch when Reactant
+    # feeds the original float64 operands to hlo_call. PyTorch's weak-scalar promotion (a
+    # float64 Python-float constant binds to its operand's dtype rather than upcasting it)
+    # is reproduced by `_demote_weak_scalar_constants`, so a float32 model's incidental
+    # float64 scalars do not collide with float32 operands in strict ops (dot_general,
+    # conv). Save and restore the flag so this stays scoped to the export and does not
+    # change global jax behavior (for example the jax tracing path in pycall.jl): jax is
+    # shared process-wide here, unlike a dedicated export process, so we do not set x64
+    # globally. The weights and the exported program are materialized inside this window,
+    # so they retain their dtype after the flag is restored.
     prev_x64 = _jax.config.jax_enable_x64
     _jax.config.update("jax_enable_x64", True)
     try:
         exported = _torch.export.export(model, example_inputs, strict=strict)
         weights, func = _txe.exported_program_to_jax(exported)
+        # torchax extracts `weights` in params+buffers+constants order, which can
+        # diverge from the order `func` binds them to the graph placeholders. Reorder
+        # into placeholder order so each weight reaches the correct placeholder.
+        weights = _reorder_weights_to_placeholder_order(weights, func)
+        weights = _demote_weak_scalar_constants(weights)
         jax_avals = _txe.extract_avals(exported)
         def reordered(inputs, weights):
             return func(weights, inputs)

--- a/ext/ReactantPythonCallExt/pytorch.jl
+++ b/ext/ReactantPythonCallExt/pytorch.jl
@@ -82,6 +82,12 @@ def _torch_to_stablehlo_inputs_first(model, example_inputs, strict):
         jax_avals = _txe.extract_avals(exported)
         def reordered(inputs, weights):
             return func(weights, inputs)
+        # Matmul precision follows jax's default for the active platform, so float32
+        # dot_general may lower at reduced (TF32-style) precision when jax initializes
+        # for a GPU. This mirrors normal jax/torchax behavior and lets callers trade
+        # accuracy for speed. Callers that need full precision can set
+        # jax_default_matmul_precision="highest" before invoking the model (the tests
+        # do this for deterministic comparisons against eager torch).
         jax_export = _jax.export.export(_jax.jit(reordered))((jax_avals,), weights)
         return weights, jax_export, len(jax_avals)
     finally:
@@ -189,6 +195,20 @@ function pycall_with_torch_export(model::Py, args...)
         push!(example, torch.from_numpy(np_zeros))
     end
     py_args = pytuple(Tuple(example))
+
+    # Report (once per session) the matmul precision jax will use to lower the model.
+    # When this is left at jax's default, float32 matmuls may lower at reduced
+    # (TF32-style) precision on a GPU-initialized jax (see the note in
+    # `_torch_to_stablehlo_inputs_first`), which changes results relative to a CPU run.
+    matmul_precision = pyconvert(
+        String, pyimport("builtins").str(jaxptr[].config.jax_default_matmul_precision)
+    )
+    @warn "Tracing a PyTorch model: jax will lower float32 matmuls with \
+           jax_default_matmul_precision=$(matmul_precision). A value of None means jax's \
+           platform default, which can be reduced (TF32-style) precision on a \
+           GPU-initialized jax and will differ from a CPU run. Set \
+           jax_default_matmul_precision=\"highest\" before tracing for full float32 \
+           precision." maxlog = 1
 
     # Export with strict=false (the non-Dynamo tracer). Besides being required for
     # TorchScript, strict=true routes through Dynamo, whose accelerator/stream

--- a/ext/ReactantPythonCallExt/pytorch.jl
+++ b/ext/ReactantPythonCallExt/pytorch.jl
@@ -196,11 +196,11 @@ function _ensure_torchscript_patches()
     return nothing
 end
 
-is_torch_module(f::Py) =
-    TORCH_EXPORT_SUPPORTED[] && pyisinstance(f, torchptr[].nn.Module)
+is_torch_module(f::Py) = TORCH_EXPORT_SUPPORTED[] && pyisinstance(f, torchptr[].nn.Module)
 
-is_torchscript_module(f::Py) =
-    TORCH_EXPORT_SUPPORTED[] && pyisinstance(f, torchptr[].jit.ScriptModule)
+function is_torchscript_module(f::Py)
+    return TORCH_EXPORT_SUPPORTED[] && pyisinstance(f, torchptr[].jit.ScriptModule)
+end
 
 function pycall_with_torch_export(model::Py, args...)
     TORCH_EXPORT_SUPPORTED[] || throw("torch/torchax could not be loaded.")
@@ -229,7 +229,9 @@ function pycall_with_torch_export(model::Py, args...)
         T = Reactant.unwrapped_eltype(arg)
         haskey(NUMPY_SIMPLE_TYPES, T) ||
             error("pycall_with_torch_export: no numpy dtype mapping for $T")
-        np_zeros = np.zeros(pytuple(collect(Int, size(arg))); dtype=string(NUMPY_SIMPLE_TYPES[T]))
+        np_zeros = np.zeros(
+            pytuple(collect(Int, size(arg))); dtype=string(NUMPY_SIMPLE_TYPES[T])
+        )
         push!(example, torch.from_numpy(np_zeros))
     end
     py_args = pytuple(Tuple(example))

--- a/ext/ReactantPythonCallExt/pytorch.jl
+++ b/ext/ReactantPythonCallExt/pytorch.jl
@@ -153,11 +153,10 @@ function _ensure_torchscript_patches()
 end
 
 is_torch_module(f::Py) =
-    TORCH_EXPORT_SUPPORTED[] && pyconvert(Bool, pybuiltins.isinstance(f, torchptr[].nn.Module))
+    TORCH_EXPORT_SUPPORTED[] && pyisinstance(f, torchptr[].nn.Module)
 
 is_torchscript_module(f::Py) =
-    TORCH_EXPORT_SUPPORTED[] &&
-        pyconvert(Bool, pybuiltins.isinstance(f, torchptr[].jit.ScriptModule))
+    TORCH_EXPORT_SUPPORTED[] && pyisinstance(f, torchptr[].jit.ScriptModule)
 
 function pycall_with_torch_export(model::Py, args...)
     TORCH_EXPORT_SUPPORTED[] || throw("torch/torchax could not be loaded.")

--- a/ext/ReactantPythonCallExt/pytorch.jl
+++ b/ext/ReactantPythonCallExt/pytorch.jl
@@ -1,0 +1,208 @@
+# Import a PyTorch model into a Reactant trace.
+#
+# A `torch.nn.Module` is Python-callable, so invoking it inside `@compile`/`@jit`
+# with Reactant arrays routes through the `PythonCall.pycall` overlay just like a
+# JAX function does (see overlays.jl and pycall.jl). This file provides the torch
+# analog of `pycall_with_jax_tracing`: it traces the module with `torch.export`,
+# lowers it to StableHLO with torchax, and splices that StableHLO into the current
+# trace via `@opcall hlo_call`. The module's parameters and buffers are carried
+# across as inlined constants, mirroring how JAX closure parameters are captured.
+
+# Trace `model` and lower it to StableHLO. torchax emits StableHLO whose entry
+# signature is `(weights..., inputs...)`; this re-exports the lowered program
+# through jax so the signature becomes `(inputs..., weights...)`, the order we build
+# the hlo_call operand list in below. Returns `(weights, jax_export, n_inputs)` where
+# `weights` is an indexable sequence of the materialized weight arrays, `jax_export`
+# exposes `mlir_module()` and `module_kept_var_idx`, and `n_inputs` is the number of
+# input arguments.
+#
+# `torch.export` opportunistically imports `triton`. triton ships its own copy of
+# LLVM whose static initializers clash with the LLVM already loaded by Reactant when
+# triton is loaded second, segfaulting the process. triton is not needed for this
+# lowering path, so block its import for the duration of the export; this makes the
+# conversion work regardless of whether torch or Reactant was imported first.
+const TORCH_TO_STABLEHLO_INPUTS_FIRST_PY = """
+import sys
+import jax as _jax
+import torch as _torch
+import torchax.export as _txe
+
+class _TritonBlocker:
+    def find_spec(self, name, path, target=None):
+        if name == "triton" or name.startswith("triton."):
+            raise ImportError("triton import blocked by ReactantPythonCallExt to avoid an LLVM clash with Reactant")
+        return None
+
+# torchax's `_extract_states_from_exported_program` builds the positional state
+# list as params + buffers + lifted-constants, but torch.export can order the graph
+# placeholders differently (e.g. params, constant, buffers). The interpreter binds
+# states to placeholders by position, so the default order can feed the wrong tensor
+# to each placeholder (a scalar constant where a conv buffer is expected, etc.),
+# silently corrupting any model whose placeholder order differs. Override it to emit
+# states in the graph's own `input_specs` order. This patches the torchax.export
+# module global that `exported_program_to_jax` looks up at call time.
+def _install_state_order_fix():
+    _InputKind = _torch.export.graph_signature.InputKind
+    def _extract_states_in_input_spec_order(exported_program):
+        gs = exported_program.graph_signature
+        state_dict = dict(exported_program.state_dict)
+        constants = dict(getattr(exported_program, "constants", None) or {})
+        names, values = [], []
+        for spec in gs.input_specs:
+            if spec.kind == _InputKind.USER_INPUT:
+                continue
+            target = spec.target
+            if spec.kind in (_InputKind.PARAMETER, _InputKind.BUFFER):
+                v = state_dict[target]
+            elif spec.kind == _InputKind.CONSTANT_TENSOR:
+                v = constants[target]
+            else:
+                v = constants.get(target, state_dict.get(target))
+            names.append(target)
+            values.append(v)
+        return names, values
+    _txe._extract_states_from_exported_program = _extract_states_in_input_spec_order
+
+_install_state_order_fix()
+
+def _torch_to_stablehlo_inputs_first(model, example_inputs, strict):
+    blocker = _TritonBlocker()
+    sys.meta_path.insert(0, blocker)
+    try:
+        exported = _torch.export.export(model, example_inputs, strict=strict)
+        weights, func = _txe.exported_program_to_jax(exported)
+        jax_avals = _txe.extract_avals(exported)
+        def reordered(inputs, weights):
+            return func(weights, inputs)
+        jax_export = _jax.export.export(_jax.jit(reordered))((jax_avals,), weights)
+        return weights, jax_export, len(jax_avals)
+    finally:
+        try:
+            sys.meta_path.remove(blocker)
+        except ValueError:
+            pass
+"""
+
+# TorchScript artifacts (`torch.jit.script` / `torch.jit.trace`) need three
+# adjustments before `torch.export` accepts them:
+#   1. JIT modules store parameters as plain tensors; the exporter's verifier
+#      requires real `torch.nn.Parameter`, so re-wrap each leaf parameter.
+#   2. JIT graphs emit the deprecated `aten._convolution.default` overload, which
+#      torchax does not register. Install a handler that drops the cuDNN flags and
+#      delegates to the supported `aten.convolution`. This mutates the global
+#      torchax dispatch registry, so it runs once per process.
+#   3. `torch.export` expects an `nn.Module`; wrap the `ScriptModule` in a minimal
+#      forwarding module.
+const TORCHSCRIPT_PATCHES_PY = """
+import torch as _torch
+from torchax.ops import ops_registry as _ops_registry, jaten as _jaten
+
+def _fix_jit_parameters(mod):
+    for name in list(mod._parameters.keys()):
+        p = mod._parameters[name]
+        if p is not None and not isinstance(p, _torch.nn.Parameter):
+            mod._parameters[name] = _torch.nn.Parameter(p.detach().clone(), requires_grad=False)
+    for child in mod._modules.values():
+        if child is not None:
+            _fix_jit_parameters(child)
+
+def _register_aten_convolution_default_handler():
+    aten = _torch.ops.aten
+    def _conv_handler(input, weight, bias, stride, padding, dilation, transposed,
+                      output_padding, groups, benchmark, deterministic, cudnn_enabled, allow_tf32):
+        return _jaten._aten_convolution(input, weight, bias, stride, padding, dilation,
+                                         transposed, output_padding, groups)
+    _ops_registry.register_torch_dispatch_op(aten._convolution.default, _conv_handler)
+
+class _JitWrapper(_torch.nn.Module):
+    def __init__(self, jit_mod):
+        super().__init__()
+        self.jit_mod = jit_mod
+    def forward(self, *args):
+        return self.jit_mod(*args)
+"""
+
+const _torchscript_patched = Ref{Bool}(false)
+
+function _ensure_torchscript_patches()
+    _torchscript_patched[] && return nothing
+    pyexec(TORCHSCRIPT_PATCHES_PY, @__MODULE__)
+    pyeval("_register_aten_convolution_default_handler", @__MODULE__)()
+    _torchscript_patched[] = true
+    return nothing
+end
+
+is_torch_module(f::Py) =
+    TORCH_EXPORT_SUPPORTED[] && pyconvert(Bool, pybuiltins.isinstance(f, torchptr[].nn.Module))
+
+is_torchscript_module(f::Py) =
+    TORCH_EXPORT_SUPPORTED[] &&
+        pyconvert(Bool, pybuiltins.isinstance(f, torchptr[].jit.ScriptModule))
+
+function pycall_with_torch_export(model::Py, args...)
+    TORCH_EXPORT_SUPPORTED[] || throw("torch/torchax could not be loaded.")
+    @assert all(Base.Fix2(isa, Union{TracedRArray,TracedRNumber}), args) "pycall_with_torch_export: all inputs must be Reactant traced arrays or numbers"
+
+    torch = torchptr[]
+    np = npptr[]
+
+    is_script = is_torchscript_module(model)
+    if is_script
+        _ensure_torchscript_patches()
+        model.eval()
+        pyeval("_fix_jit_parameters", @__MODULE__)(model)
+        model = pyeval("_JitWrapper", @__MODULE__)(model)
+    else
+        model.eval()
+    end
+
+    # Build torch example inputs with the same shape and dtype as the traced
+    # Reactant arguments. Reactant maps a value's logical shape directly onto its
+    # MLIR tensor shape (see `Ops.mlir_type`), so the torch example shape equals
+    # `size(arg)` with no reversal, and the resulting StableHLO input types match
+    # the operands we feed to `hlo_call`.
+    example = Py[]
+    for arg in args
+        T = Reactant.unwrapped_eltype(arg)
+        haskey(NUMPY_SIMPLE_TYPES, T) ||
+            error("pycall_with_torch_export: no numpy dtype mapping for $T")
+        np_zeros = np.zeros(pytuple(collect(Int, size(arg))); dtype=string(NUMPY_SIMPLE_TYPES[T]))
+        push!(example, torch.from_numpy(np_zeros))
+    end
+    py_args = pytuple(Tuple(example))
+
+    # Export with strict=false (the non-Dynamo tracer). Besides being required for
+    # TorchScript, strict=true routes through Dynamo, whose accelerator/stream
+    # handling conflicts with the torchax "jax" device and fails on current
+    # torch+torchax. strict=false is also the direction torch.export is moving.
+    result = torch_to_stablehlo_inputs_first[](model, py_args, false)
+    weights_py = result[0]
+    jax_export = result[1]
+    n_inputs = pyconvert(Int, result[2])
+    n_inputs == length(args) || error(
+        "pycall_with_torch_export: model expects $n_inputs flattened tensor inputs " *
+        "but was called with $(length(args)) arguments (nested/non-tensor inputs are unsupported)",
+    )
+
+    text = pyconvert(String, jax_export.mlir_module())
+
+    # `module_kept_var_idx` lists, in signature order, the flattened positions that
+    # survived dead-code elimination. Positions `< n_inputs` are request inputs
+    # (the traced args); positions `>= n_inputs` are weights at offset
+    # `idx - n_inputs`. Pruned parameters/buffers (e.g. BatchNorm running stats that
+    # fold away) simply never appear here, keeping operands aligned with the entry.
+    kept_idx = Int[pyconvert(Int, i) for i in jax_export.module_kept_var_idx]
+    operands = Union{TracedRArray,TracedRNumber}[]
+    for g in kept_idx
+        if g < n_inputs
+            push!(operands, args[g + 1])
+        else
+            w = weights_py[g - n_inputs]
+            jl = pyconvert(Array, np.asarray(w))
+            push!(operands, @opcall constant(jl))
+        end
+    end
+
+    res = @opcall hlo_call(text, operands...)
+    return length(res) == 0 ? nothing : (length(res) == 1 ? res[1] : res)
+end

--- a/ext/ReactantPythonCallExt/pytorch.jl
+++ b/ext/ReactantPythonCallExt/pytorch.jl
@@ -61,6 +61,14 @@ def _install_state_order_fix():
             names.append(target)
             values.append(v)
         return names, values
+    # Fail loudly if the symbol we override has moved or been renamed: a plain
+    # attribute assignment would otherwise succeed silently, leave torchax calling
+    # its original function, and reintroduce the state-corruption bug this fixes.
+    if not hasattr(_txe, "_extract_states_from_exported_program"):
+        raise AttributeError(
+            "torchax.export._extract_states_from_exported_program is missing; "
+            "the installed torchax version is incompatible with ReactantPythonCallExt"
+        )
     _txe._extract_states_from_exported_program = _extract_states_in_input_spec_order
 
 _install_state_order_fix()
@@ -108,6 +116,18 @@ def _fix_jit_parameters(mod):
 
 def _register_aten_convolution_default_handler():
     aten = _torch.ops.aten
+    # Fail loudly if the overloads or helpers we rely on have moved, rather than
+    # registering against a stale symbol or calling a missing function later.
+    if not hasattr(aten, "_convolution") or not hasattr(aten._convolution, "default"):
+        raise AttributeError(
+            "torch.ops.aten._convolution.default is missing; "
+            "the installed torch version is incompatible with ReactantPythonCallExt"
+        )
+    if not hasattr(_jaten, "_aten_convolution"):
+        raise AttributeError(
+            "torchax.ops.jaten._aten_convolution is missing; "
+            "the installed torchax version is incompatible with ReactantPythonCallExt"
+        )
     def _conv_handler(input, weight, bias, stride, padding, dilation, transposed,
                       output_padding, groups, benchmark, deterministic, cudnn_enabled, allow_tf32):
         return _jaten._aten_convolution(input, weight, bias, stride, padding, dilation,

--- a/test/integration/pytorch.jl
+++ b/test/integration/pytorch.jl
@@ -1,0 +1,124 @@
+using Reactant
+using Test
+
+# Jax (and therefore torchax) on GitHub CI dislikes x86 macOS, matching python.jl.
+@static if !Sys.isapple() || Sys.ARCH != :x86_64
+    using PythonCall
+
+    const ReactantPythonCallExt = Base.get_extension(Reactant, :ReactantPythonCallExt)
+
+    # Relative error metric: max|diff| / max|ref|, robust to scale.
+    function relerr(actual, reference)
+        ref = Array(reference)
+        denom = maximum(abs, ref)
+        denom = denom == 0 ? one(denom) : denom
+        return maximum(abs, Array(actual) .- ref) / denom
+    end
+
+    # Convert a torch tensor to a Julia Array with matching logical shape.
+    torch_to_julia(t) = pyconvert(Array, pyimport("numpy").asarray(t.detach().cpu()))
+
+    torch_available =
+        ReactantPythonCallExt !== nothing && ReactantPythonCallExt.TORCH_EXPORT_SUPPORTED[]
+
+    if !torch_available
+        @warn "torch/torchax not available; skipping PyTorch import tests."
+    end
+
+    @testset "PyTorch import" begin
+        if !torch_available
+            @test_skip false
+        else
+            torch = pyimport("torch")
+            nn = pyimport("torch.nn")
+            np = pyimport("numpy")
+
+            @testset "Eager nn.Linear chain" begin
+                torch.manual_seed(0)
+                model = nn.Sequential(nn.Linear(8, 16), nn.ReLU(), nn.Linear(16, 4))
+                model.eval()
+
+                # Reactant array shape is the torch shape directly (batch first), no
+                # reversal: (batch, features).
+                xdata = randn(Float32, 4, 8)
+                x_torch = torch.from_numpy(np.asarray(xdata))
+                y_native = model(x_torch)
+
+                x_ra = Reactant.to_rarray(xdata)
+                y = @jit model(x_ra)
+
+                @test y isa ConcreteRArray{Float32,2}
+                @test size(y) == (4, 4)
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
+            end
+
+            @testset "BatchNorm exercises module_kept_var_idx" begin
+                torch.manual_seed(0)
+                model = nn.Sequential(nn.Linear(6, 6), nn.BatchNorm1d(6), nn.ReLU())
+                model.eval()  # use running stats, not per-batch stats
+
+                xdata = randn(Float32, 5, 6)
+                x_torch = torch.from_numpy(np.asarray(xdata))
+                y_native = model(x_torch)
+
+                x_ra = Reactant.to_rarray(xdata)
+                y = @jit model(x_ra)
+
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
+            end
+
+            @testset "BatchNorm + lifted constant (state ordering)" begin
+                # Conv+BatchNorm with a literal constant in forward. After
+                # torch.export's decompositions the lifted constant is ordered before
+                # the BatchNorm running-stat buffers in the graph placeholders, which
+                # diverges from torchax's default (params, buffers, then constants)
+                # state order. Without the input_specs state-ordering fix the constant
+                # is bound to a running-stat slot and the result is corrupted. This
+                # pattern (conv net + BatchNorm + any constant) is common.
+                torch.manual_seed(0)
+                pyexec(
+                    """
+import torch, torch.nn as nn
+class _ConvBNConst(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.c1 = nn.Conv2d(3, 4, 3)
+        self.bn = nn.BatchNorm2d(4)
+        self.c2 = nn.Conv2d(4, 2, 3)
+    def forward(self, x):
+        return self.c2(torch.relu(self.bn(self.c1(x))) + torch.tensor(0.5))
+""",
+                    @__MODULE__,
+                )
+                model = pyeval("_ConvBNConst", @__MODULE__)()
+                model.eval()
+
+                xdata = randn(Float32, 1, 3, 16, 16)  # NCHW
+                y_native = model(torch.from_numpy(np.asarray(xdata)))
+
+                y = @jit model(Reactant.to_rarray(xdata))
+
+                @test size(y) == (1, 2, 12, 12)
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
+            end
+
+            @testset "TorchScript Conv2d (trace)" begin
+                torch.manual_seed(0)
+                conv = nn.Conv2d(3, 4, 3)
+                conv.eval()
+                example = torch.randn(1, 3, 8, 8)
+                scripted = torch.jit.trace(conv, example)
+
+                xdata = randn(Float32, 1, 3, 8, 8)  # NCHW, torch order
+                x_torch = torch.from_numpy(np.asarray(xdata))
+                y_native = scripted(x_torch)
+
+                x_ra = Reactant.to_rarray(xdata)
+                y = @jit scripted(x_ra)
+
+                @test size(y) == (1, 4, 6, 6)
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
+            end
+        end
+    end
+end

--- a/test/integration/pytorch.jl
+++ b/test/integration/pytorch.jl
@@ -119,6 +119,76 @@ class _ConvBNConst(nn.Module):
                 @test size(y) == (1, 4, 6, 6)
                 @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
             end
+
+            @testset "Multiple inputs (operand ordering)" begin
+                # forward(self, a, b) takes two tensors. Exercises the
+                # (inputs..., weights...) reordering and the n_inputs accounting for
+                # length(args) > 1, which the single-input tests never hit.
+                torch.manual_seed(0)
+                pyexec(
+                    """
+import torch, torch.nn as nn
+class _TwoInput(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(8, 4)
+    def forward(self, a, b):
+        return self.lin(a) + b
+""",
+                    @__MODULE__,
+                )
+                model = pyeval("_TwoInput", @__MODULE__)()
+                model.eval()
+
+                adata = randn(Float32, 3, 8)
+                bdata = randn(Float32, 3, 4)
+                y_native = model(
+                    torch.from_numpy(np.asarray(adata)), torch.from_numpy(np.asarray(bdata))
+                )
+
+                a_ra = Reactant.to_rarray(adata)
+                b_ra = Reactant.to_rarray(bdata)
+                y = @jit model(a_ra, b_ra)
+
+                @test size(y) == (3, 4)
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
+            end
+
+            @testset "Multiple outputs (result ordering)" begin
+                # forward returns a tuple of two tensors. Exercises the length(res) > 1
+                # branch of pycall_with_torch_export and output ordering.
+                torch.manual_seed(0)
+                pyexec(
+                    """
+import torch, torch.nn as nn
+class _TwoOutput(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(8, 4)
+    def forward(self, x):
+        h = self.lin(x)
+        return h, torch.relu(h)
+""",
+                    @__MODULE__,
+                )
+                model = pyeval("_TwoOutput", @__MODULE__)()
+                model.eval()
+
+                xdata = randn(Float32, 3, 8)
+                native = model(torch.from_numpy(np.asarray(xdata)))
+                y0_native = native[0]
+                y1_native = native[1]
+
+                x_ra = Reactant.to_rarray(xdata)
+                y = @jit model(x_ra)
+
+                @test y isa Tuple
+                @test length(y) == 2
+                @test size(y[1]) == (3, 4)
+                @test size(y[2]) == (3, 4)
+                @test relerr(y[1], torch_to_julia(y0_native)) < 1.0f-4
+                @test relerr(y[2], torch_to_julia(y1_native)) < 1.0f-4
+            end
         end
     end
 end

--- a/test/integration/pytorch.jl
+++ b/test/integration/pytorch.jl
@@ -33,6 +33,14 @@ using Test
             nn = pyimport("torch.nn")
             np = pyimport("numpy")
 
+            # The import path leaves matmul precision at jax's platform default (see
+            # pytorch.jl), which on a GPU-initialized jax lowers float32 matmuls at
+            # reduced (TF32-style) precision and diverges from eager torch by ~5e-4.
+            # The tests want exact, deterministic comparisons, so force full float32
+            # precision here. This is a test-only setting; it does not change the
+            # default behavior of the import path for users.
+            pyimport("jax").config.update("jax_default_matmul_precision", "highest")
+
             @testset "Eager nn.Linear chain" begin
                 torch.manual_seed(0)
                 model = nn.Sequential(nn.Linear(8, 16), nn.ReLU(), nn.Linear(16, 4))
@@ -49,7 +57,11 @@ using Test
 
                 @test y isa ConcreteRArray{Float32,2}
                 @test size(y) == (4, 4)
-                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
+                # 1e-4 holds across CPU and GPU because the lowering pins matmul
+                # precision to "highest" (see pytorch.jl). Without that pin jax
+                # lowers float32 matmuls at reduced precision when it initializes for
+                # a GPU platform, pushing the error against eager torch to ~5e-4.
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
             end
 
             @testset "BatchNorm exercises module_kept_var_idx" begin
@@ -64,7 +76,7 @@ using Test
                 x_ra = Reactant.to_rarray(xdata)
                 y = @jit model(x_ra)
 
-                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
             end
 
             @testset "BatchNorm + lifted constant (state ordering)" begin
@@ -99,7 +111,7 @@ class _ConvBNConst(nn.Module):
                 y = @jit model(Reactant.to_rarray(xdata))
 
                 @test size(y) == (1, 2, 12, 12)
-                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
             end
 
             @testset "TorchScript Conv2d (trace)" begin
@@ -117,7 +129,7 @@ class _ConvBNConst(nn.Module):
                 y = @jit scripted(x_ra)
 
                 @test size(y) == (1, 4, 6, 6)
-                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
             end
 
             @testset "Multiple inputs (operand ordering)" begin

--- a/test/integration/pytorch.jl
+++ b/test/integration/pytorch.jl
@@ -135,6 +135,47 @@ class _ConvBNConst(nn.Module):
                 @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
             end
 
+            @testset "Weak scalar constant (FP64 promotion under x64)" begin
+                # A float32 model whose forward adds a 0-dim float64 scalar tensor.
+                # PyTorch's scalar (0-dim) promotion rule keeps the result float32:
+                # the float64 scalar binds to its float32 operand instead of
+                # upcasting it. The export helper enables jax x64 (see pytorch.jl),
+                # under which jax would otherwise keep the constant a strong float64
+                # array that upcasts and collides with the float32 operands in strict
+                # ops. _demote_weak_scalar_constants demotes the 0-dim float64
+                # constant back to float32 so the result stays Float32 and matches
+                # eager torch. (Bare Python float literals are constant-folded by
+                # torch.export and never reach this path, so use an explicit float64
+                # scalar tensor to exercise it.)
+                torch.manual_seed(0)
+                pyexec(
+                    """
+import torch, torch.nn as nn
+class _WeakScalar(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(8, 4)
+    def forward(self, x):
+        return self.lin(x) + torch.tensor(0.5, dtype=torch.float64)
+""",
+                    @__MODULE__,
+                )
+                model = pyeval("_WeakScalar", @__MODULE__)()
+                model.eval()
+
+                xdata = randn(Float32, 3, 8)
+                y_native = model(torch.from_numpy(np.asarray(xdata)))
+
+                @test pyconvert(String, pyimport("builtins").str(y_native.dtype)) ==
+                    "torch.float32"
+
+                y = @jit model(Reactant.to_rarray(xdata))
+
+                @test y isa ConcreteRArray{Float32,2}
+                @test size(y) == (3, 4)
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
+            end
+
             @testset "TorchScript Conv2d (trace)" begin
                 torch.manual_seed(0)
                 conv = nn.Conv2d(3, 4, 3)

--- a/test/integration/pytorch.jl
+++ b/test/integration/pytorch.jl
@@ -49,7 +49,7 @@ using Test
 
                 @test y isa ConcreteRArray{Float32,2}
                 @test size(y) == (4, 4)
-                @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
+                @test relerr(y, torch_to_julia(y_native)) < 1.0f-3
             end
 
             @testset "BatchNorm exercises module_kept_var_idx" begin

--- a/test/integration/pytorch.jl
+++ b/test/integration/pytorch.jl
@@ -64,6 +64,27 @@ using Test
                 @test relerr(y, torch_to_julia(y_native)) < 1.0f-4
             end
 
+            @testset "Float64 (double precision)" begin
+                # Double precision is common in the Julia scientific ecosystem. jax
+                # disables 64-bit by default, so the export helper enables it for the
+                # lowering (see pytorch.jl); otherwise the model would be downcast to
+                # float32 and hlo_call would reject the float64 operands. The result
+                # should stay Float64 and match eager torch to near machine epsilon.
+                torch.manual_seed(0)
+                model = nn.Sequential(nn.Linear(8, 16), nn.ReLU(), nn.Linear(16, 4))
+                model.double()
+                model.eval()
+
+                xdata = randn(Float64, 4, 8)
+                y_native = model(torch.from_numpy(np.asarray(xdata)))
+
+                y = @jit model(Reactant.to_rarray(xdata))
+
+                @test y isa ConcreteRArray{Float64,2}
+                @test size(y) == (4, 4)
+                @test relerr(y, torch_to_julia(y_native)) < 1.0e-12
+            end
+
             @testset "BatchNorm exercises module_kept_var_idx" begin
                 torch.manual_seed(0)
                 model = nn.Sequential(nn.Linear(6, 6), nn.BatchNorm1d(6), nn.ReLU())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,9 +39,12 @@ if (
     "integration" ∈ parsed_args.positionals ||
     "integration/pytorch" ∈ parsed_args.positionals
 )
-    # A CPU build of torch is recommended: a CUDA torch wheel ships libtorch_cuda.so
-    # that clashes with Reactant's runtime when imported afterwards, in which case the
-    # extension's torch import fails and integration/pytorch skips itself gracefully.
+    # A CPU build of torch is required: the default PyPI torch wheel on Linux is a
+    # CUDA build whose libtorch_cuda.so clashes with Reactant's runtime and fails to
+    # import after Reactant loads, which would make the extension disable torch
+    # support and integration/pytorch skip itself instead of running. CondaPkg cannot
+    # pin a per-package index, so we let it resolve torch and torchax normally, then
+    # reinstall the resolved torch as its CPU variant from the PyTorch CPU index.
     #
     # torchax is pinned to the versions whose internal API layout ReactantPythonCallExt
     # depends on (see ext/ReactantPythonCallExt/pytorch.jl). Note that torchax >=0.0.10
@@ -51,6 +54,19 @@ if (
     try
         CondaPkg.add_pip("torch"; version=">=2.4")
         CondaPkg.add_pip("torchax"; version=">=0.0.10,<0.0.13")
+        # Swap to the CPU torch build. We read the resolved version from package
+        # metadata (not by importing torch, since the CUDA build may fail to import)
+        # and force-reinstall the matching CPU wheel with --no-deps, since all of
+        # torch's dependencies are already present from the resolve above.
+        CondaPkg.withenv() do
+            run(`python -m ensurepip --upgrade`)
+            torch_version = readchomp(
+                `python -c "import importlib.metadata as m; print(m.version('torch').split('+')[0])"`,
+            )
+            run(
+                `python -m pip install --index-url https://download.pytorch.org/whl/cpu --no-deps --force-reinstall "torch==$(torch_version)"`,
+            )
+        end
         TORCH_INSTALLED[] = true
     catch
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,9 +42,15 @@ if (
     # A CPU build of torch is recommended: a CUDA torch wheel ships libtorch_cuda.so
     # that clashes with Reactant's runtime when imported afterwards, in which case the
     # extension's torch import fails and integration/pytorch skips itself gracefully.
+    #
+    # torchax is pinned to the versions whose internal API layout ReactantPythonCallExt
+    # depends on (see ext/ReactantPythonCallExt/pytorch.jl). Note that torchax >=0.0.10
+    # declares jax>=0.6.2 while the enzymejax block above pins jax==0.5, so these two
+    # cannot share one environment: the pytorch integration tests are expected to run in
+    # a job that does not also install jax==0.5 (i.e. not the enzymejax/full run).
     try
         CondaPkg.add_pip("torch"; version=">=2.4")
-        CondaPkg.add_pip("torchax")
+        CondaPkg.add_pip("torchax"; version=">=0.0.10,<0.0.13")
         TORCH_INSTALLED[] = true
     catch
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ parsed_args = parse_args(ARGS)
 
 const ENZYMEJAX_INSTALLED = Ref(false)
 const NUMPYRO_INSTALLED = Ref(false)
+const TORCH_INSTALLED = Ref(false)
 
 # Install specific packages. Pkg.test doesn't pick up CondaPkg.toml in test folder
 if (
@@ -29,6 +30,22 @@ if (
     try
         CondaPkg.add_pip("numpyro")
         NUMPYRO_INSTALLED[] = true
+    catch
+    end
+end
+
+if (
+    isempty(parsed_args.positionals) ||
+    "integration" ∈ parsed_args.positionals ||
+    "integration/pytorch" ∈ parsed_args.positionals
+)
+    # A CPU build of torch is recommended: a CUDA torch wheel ships libtorch_cuda.so
+    # that clashes with Reactant's runtime when imported afterwards, in which case the
+    # extension's torch import fails and integration/pytorch skips itself gracefully.
+    try
+        CondaPkg.add_pip("torch"; version=">=2.4")
+        CondaPkg.add_pip("torchax")
+        TORCH_INSTALLED[] = true
     catch
     end
 end
@@ -66,6 +83,10 @@ end
 
 if !NUMPYRO_INSTALLED[]
     delete!(testsuite, "integration/numpyro")
+end
+
+if !TORCH_INSTALLED[]
+    delete!(testsuite, "integration/pytorch")
 end
 
 include("test_helpers.jl")


### PR DESCRIPTION
Note: this isn't quite ready for full review yet. 

Implements https://github.com/EnzymeAD/Reactant.jl/issues/2065

It includes monkey patching that is potentially brittle due to an inputs ordering difference in torch.export and torchax. It might be possible to avoid the monkey patch, I'm looking into alternative solutions. For torchscript there likely is not an alternative for the workarounds I implemented here. At the end of the day we are dealing with a format that has been deprecated for over 5 years now.

TODO:

- [x] Investigate potential alternatives to monkey patch for input/param ordering
- [x] Document matmul precision behavior when torchax sees a GPU vs when it doesn't - potential footgun
- [x] FP64 support w/ tests
- [x] Scalar type promotion matches PyTorch w/ Jax x64 mode
- [ ] Find a way to make torch install without requiring CPU version workaround