### PR TITLE
Override optimization parameters in cuda to avoid passes which break …

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1604,6 +1604,8 @@ struct ReactantPTXBackend
     raising::Bool
 end
 
+Base.hash(target::ReactantPTXBackend, h::UInt) = Base.hash(target.raising, h)
+
 const ReactantCUDACompilerConfig = CompilerConfig{ReactantPTXCompilerTarget{ReactantPTXBackend}, CUDACompilerParams}
 const ReactantCUDACompilerJob = CompilerJob{ReactantPTXCompilerTarget{ReactantPTXBackend},CUDACompilerParams}
 

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1600,6 +1600,15 @@ function _convert_bf16_value(
     return src_val
 end
 
+struct ReactantPTXBackend
+    raising::Bool
+end
+
+const ReactantCUDACompilerConfig = CompilerConfig{ReactantPTXCompilerTarget{ReactantPTXBackend}, CUDACompilerParams}
+const ReactantCUDACompilerJob = CompilerJob{ReactantPTXCompilerTarget{ReactantPTXBackend},CUDACompilerParams}
+
+GPUCompiler.optimization_options(job::ReactantCUDACompilerJob) =  (; instcombine=!job.config.target.raising, ptxfastmath=!job.config.target.raising)
+
 Reactant.@reactant_overlay function CUDA.cufunction(
     f::F, tt::TT=Tuple{}; kwargs...
 ) where {F,TT}
@@ -1622,7 +1631,7 @@ Reactant.@reactant_overlay function CUDA.cufunction(
         name = nothing
         debuginfo = false
         config = GPUCompiler.CompilerConfig(
-            GPUCompiler.PTXCompilerTarget(; cap=llvm_cap, ptx=llvm_ptx, debuginfo),
+            ReactantPTXCompilerTarget{ReactantPTXBackend}(; cap=llvm_cap, ptx=llvm_ptx, debuginfo, backendinfo=ReactantPTXBackend(raising())),
             CUDACore.CUDACompilerParams(; cap=cuda_cap, ptx=cuda_ptx);
             kernel,
             name,


### PR DESCRIPTION
…raising

companion to https://github.com/JuliaGPU/GPUCompiler.jl/pull/823

cc @gbaraldi @vchuravy @giordano @maleadt

since GPUCompiler defines several APIs, like optimization_options, on the job itself -- downstream compilers that use the PTX codegen cannot modify these methods without type piracy on all targets, or vendoring the entire api.

Adding a type parameter to PTXCompilerTarget enables this to work without piracy or vendoring large parts of the codebase