### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,8 +38,7 @@ steps:
               using Pkg
               Pkg.test(; coverage="user", test_args=["{{matrix.group}}"])'
         agents:
-          queue: "juliagpu"
-          cuda: "*"
+          queue: "cuda"
         env:
           JULIA_DEBUG: "Reactant,Reactant_jll"
           CUDA_VISIBLE_DEVICES: 0
@@ -68,8 +67,7 @@ steps:
   #           - ext
   #           - lib/ReactantCore/src
   #   agents:
-  #     queue: "juliagpu"
-  #     rocm: "*"
+  #     queue: "rocm"
   #   commands: |
   #     touch LocalPreferences.toml
 


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)