### PR TITLE
Pretty print compilation error diagnostics

### DIFF
--- a/src/compiler/CompilationError.jl
+++ b/src/compiler/CompilationError.jl
@@ -1,0 +1,175 @@
+using ..Reactant: MLIR
+
+# ── Location helpers ─────────────────────────────────────────────────────────
+
+function _sprint_diagnostic(diagnostic::MLIR.IR.Diagnostic)
+    io = IOBuffer()
+    show(io, diagnostic)
+    for i in 1:MLIR.IR.nnotes(diagnostic)
+        print(io, "\n  note: ")
+        show(io, MLIR.IR.note(diagnostic, i))
+    end
+    return String(take!(io))
+end
+
+function _sprint_leaf_location(loc::MLIR.IR.Location)
+    MLIR.IR.mlirIsNull(loc.ref) && return "unknown"
+    if MLIR.API.mlirLocationIsAFileLineColRange(loc)
+        filename = String(MLIR.API.mlirLocationFileLineColRangeGetFilename(loc))
+        line = Int(MLIR.API.mlirLocationFileLineColRangeGetStartLine(loc))
+        col = Int(MLIR.API.mlirLocationFileLineColRangeGetStartColumn(loc))
+        return "$filename:$line:$col"
+    elseif MLIR.API.mlirLocationIsAName(loc)
+        name = String(MLIR.API.mlirLocationNameGetName(loc))
+        child = MLIR.IR.Location(MLIR.API.mlirLocationNameGetChildLoc(loc))
+        child_str = _sprint_leaf_location(child)
+        return if (MLIR.IR.mlirIsNull(child.ref) || MLIR.API.mlirLocationIsAUnknown(child))
+            "\"$name\""
+        else
+            "\"$name\" at $child_str"
+        end
+    elseif MLIR.API.mlirLocationIsAUnknown(loc)
+        return "unknown"
+    else
+        io = IOBuffer()
+        c_print_callback = @cfunction(
+            MLIR.IR.print_callback, Cvoid, (MLIR.API.MlirStringRef, Any)
+        )
+        MLIR.API.mlirLocationPrint(loc, c_print_callback, Ref(io))
+        return String(take!(io))
+    end
+end
+
+# A single frame in a diagnostic stack trace.
+# `name` comes from a NameLoc (e.g. a Julia function name); may be empty.
+# `location` is the file:line:col string; may be empty for name-only frames.
+struct StackFrame
+    name::String
+    location::String
+end
+
+# NameLoc("fname", child) → StackFrame("fname", sprint(child))
+# Everything else         → StackFrame("", sprint(loc))
+function _loc_to_frame(loc::MLIR.IR.Location)
+    MLIR.IR.mlirIsNull(loc.ref) && return StackFrame("", "unknown")
+    if MLIR.API.mlirLocationIsAName(loc)
+        name = String(MLIR.API.mlirLocationNameGetName(loc))
+        child = MLIR.IR.Location(MLIR.API.mlirLocationNameGetChildLoc(loc))
+        loc_str =
+            if (!MLIR.IR.mlirIsNull(child.ref) && !MLIR.API.mlirLocationIsAUnknown(child))
+                _sprint_leaf_location(child)
+            else
+                ""
+            end
+        return StackFrame(name, loc_str)
+    else
+        return StackFrame("", _sprint_leaf_location(loc))
+    end
+end
+
+# Walk a location tree and collect one StackFrame per frame, innermost first.
+# CallSiteLoc encodes a call stack: callee = inner frame, caller = outer frame.
+# FusedLoc holds multiple locations for the same op (e.g. inlined sites).
+function _collect_frames!(frames::Vector{StackFrame}, loc::MLIR.IR.Location)
+    MLIR.IR.mlirIsNull(loc.ref) && return frames
+    if MLIR.API.mlirLocationIsACallSite(loc)
+        callee = MLIR.IR.Location(MLIR.API.mlirLocationCallSiteGetCallee(loc))
+        caller = MLIR.IR.Location(MLIR.API.mlirLocationCallSiteGetCaller(loc))
+        _collect_frames!(frames, callee)
+        _collect_frames!(frames, caller)
+    elseif MLIR.API.mlirLocationIsAFused(loc)
+        n = Int(MLIR.API.mlirLocationFusedGetNumLocations(loc))
+        raw_locs = Vector{MLIR.API.MlirLocation}(undef, n)
+        MLIR.API.mlirLocationFusedGetLocations(loc, pointer(raw_locs))
+        for raw in raw_locs
+            _collect_frames!(frames, MLIR.IR.Location(raw))
+        end
+    elseif !MLIR.API.mlirLocationIsAUnknown(loc)
+        push!(frames, _loc_to_frame(loc))
+    end
+    return frames
+end
+
+function _collect_location_frames(loc::MLIR.IR.Location)
+    return _collect_frames!(StackFrame[], loc)
+end
+
+# ── CompilationError ─────────────────────────────────────────────────────────
+
+struct DiagnosticMessage
+    severity::MLIR.API.MlirDiagnosticSeverity
+    message::String
+    frames::Vector{StackFrame}
+end
+
+struct CompilationError <: Exception
+    key::String
+    diagnostics::Vector{DiagnosticMessage}
+end
+
+function _severity_label(sev::MLIR.API.MlirDiagnosticSeverity)
+    sev == MLIR.API.MlirDiagnosticError && return "error"
+    sev == MLIR.API.MlirDiagnosticWarning && return "warning"
+    sev == MLIR.API.MlirDiagnosticNote && return "note"
+    return "remark"
+end
+
+function _severity_color(sev::MLIR.API.MlirDiagnosticSeverity)
+    sev == MLIR.API.MlirDiagnosticError && return :red
+    sev == MLIR.API.MlirDiagnosticWarning && return :yellow
+    sev == MLIR.API.MlirDiagnosticNote && return :cyan
+    return :light_black
+end
+
+function _print_frame(io::IO, j::Int, frame::StackFrame)
+    print(io, "  ")
+    printstyled(io, "[$j]"; color=:light_black)
+    if isempty(frame.name)
+        print(io, " ")
+        printstyled(io, "@"; color=:cyan)
+        print(io, " ")
+        printstyled(io, frame.location; color=:light_black)
+        println(io)
+    elseif isempty(frame.location)
+        print(io, " ")
+        printstyled(io, frame.name; bold=true)
+        println(io)
+    else
+        print(io, " ")
+        printstyled(io, frame.name; bold=true)
+        println(io)
+        print(io, "     ")
+        printstyled(io, "@"; color=:cyan)
+        print(io, " ")
+        printstyled(io, frame.location; color=:light_black)
+        println(io)
+    end
+end
+
+function _print_diagnostics(io::IO, diagnostics::Vector{DiagnosticMessage})
+    for (i, diag) in enumerate(diagnostics)
+        i > 1 && println(io)
+        label = _severity_label(diag.severity)
+        printstyled(io, label; color=_severity_color(diag.severity), bold=true)
+        println(io, ": $(diag.message)")
+        if !isempty(diag.frames)
+            printstyled(io, "Stacktrace:"; bold=true)
+            println(io)
+            for (j, frame) in enumerate(diag.frames)
+                _print_frame(io, j, frame)
+            end
+        end
+    end
+end
+
+function Base.showerror(io::IO, err::CompilationError)
+    if isempty(err.key)
+        print(io, "CompilationError: MLIR pass pipeline failed")
+    else
+        print(io, "CompilationError: MLIR pass pipeline \"$(err.key)\" failed")
+    end
+    if !isempty(err.diagnostics)
+        println(io, "\n")
+        _print_diagnostics(io, err.diagnostics)
+    end
+end

--- a/src/compiler/CompilationError.jl
+++ b/src/compiler/CompilationError.jl
@@ -121,11 +121,14 @@ function _severity_color(sev::MLIR.API.MlirDiagnosticSeverity)
     return :light_black
 end
 
-function _print_frame(io::IO, j::Int, frame::StackFrame)
-    print(io, "  ")
-    printstyled(io, "[$j]"; color=:light_black)
+function _print_frame(io::IO, j::Int, frame::StackFrame, num_frames::Int)
+    max_size = ndigits(num_frames) + 4
+    printstyled(io, lpad("[$j]", max_size); color=:light_black)
     if isempty(frame.name)
         print(io, " ")
+        printstyled(io, "unknown"; bold=true)
+        println(io)
+        print(io, " "^(max_size - 1))
         printstyled(io, "@"; color=:cyan)
         print(io, " ")
         printstyled(io, frame.location; color=:light_black)
@@ -138,7 +141,7 @@ function _print_frame(io::IO, j::Int, frame::StackFrame)
         print(io, " ")
         printstyled(io, frame.name; bold=true)
         println(io)
-        print(io, "     ")
+        print(io, " "^(max_size - 1))
         printstyled(io, "@"; color=:cyan)
         print(io, " ")
         printstyled(io, frame.location; color=:light_black)
@@ -189,7 +192,7 @@ function _print_diagnostics(io::IO, diagnostics::Vector{DiagnosticMessage})
             printstyled(io, "Stacktrace:"; bold=true)
             println(io)
             for (j, frame) in enumerate(diag.frames)
-                _print_frame(io, j, frame)
+                _print_frame(io, j, frame, length(diag.frames))
             end
         end
     end

--- a/src/compiler/CompilationError.jl
+++ b/src/compiler/CompilationError.jl
@@ -146,12 +146,45 @@ function _print_frame(io::IO, j::Int, frame::StackFrame)
     end
 end
 
+function _print_julia_code_snippet(io::IO, frames)
+    isempty(frames) && return nothing
+    frame = frames[@something findfirst(
+        frame -> !occursin("Reactant.jl", frame.location), frames
+    ) firstindex(frames)]
+    if isnothing(match(r".*:\d+:\d+", frame.location))
+        return nothing
+    end
+
+    file, line, col = split(frame.location, ":"; keepempty=false)
+    endswith(file, ".jl") || return nothing
+
+    line, col = parse(Int, line), parse(Int, col)
+
+    iszero(col) || return nothing
+
+    isfile(file) || return nothing
+
+    border = 1
+
+    println(io)
+    println(io, frame.location)
+
+    lines = readlines(file)
+    line_range = max(line - border, firstindex(lines)):min(line + border, lastindex(lines))
+    num_digits = div(maximum(line_range), 10, RoundUp)
+    for li in line_range
+        printstyled(io, lpad(string(li), num_digits), " | "; color=:light_black)
+        println(io, lines[li])
+    end
+end
+
 function _print_diagnostics(io::IO, diagnostics::Vector{DiagnosticMessage})
     for (i, diag) in enumerate(diagnostics)
         i > 1 && println(io)
         label = _severity_label(diag.severity)
         printstyled(io, label; color=_severity_color(diag.severity), bold=true)
         println(io, ": $(diag.message)")
+        _print_julia_code_snippet(io, diag.frames)
         if !isempty(diag.frames)
             printstyled(io, "Stacktrace:"; bold=true)
             println(io)

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -22,6 +22,7 @@ import Reactant: OptimizeCommunicationOptions, ShardyPropagationOptions, Compile
 using Reactant_jll: Reactant_jll
 
 include("Macros.jl")
+include("CompilationError.jl")
 include("OptimizationPasses.jl")
 include("Codegen.jl")
 include("Thunk.jl")

--- a/src/compiler/OptimizationPasses.jl
+++ b/src/compiler/OptimizationPasses.jl
@@ -152,12 +152,43 @@ function impulse_pass(;
     return "expand-impulse{debug-dump=$debug_dump postpasses=\"arith-raise{stablehlo=true}\"}"
 end
 
+# ── run! wrapper ─────────────────────────────────────────────────────────────
+
+# Wraps MLIR.IR.run! to capture diagnostics.
+# On failure: throws CompilationError containing all diagnostics.
+# On success: prints any non-remark diagnostics to stderr using the same format.
+function run!(pm::MLIR.IR.PassManager, op, key::String="")
+    diagnostics = DiagnosticMessage[]
+    handler =
+        MLIR.IR.attach_diagnostic_handler!(; context=MLIR.IR.current_context()) do diag
+            push!(
+                diagnostics,
+                DiagnosticMessage(
+                    MLIR.IR.severity(diag),
+                    _sprint_diagnostic(diag),
+                    _collect_location_frames(MLIR.IR.location(diag)),
+                ),
+            )
+            return false  # allow other handlers to also see the diagnostic
+        end
+    result = try
+        MLIR.IR.run!(pm, op, key)
+    catch
+        MLIR.IR.detach_diagnostic_handler!(handler)
+        throw(CompilationError(key, diagnostics))
+    end
+    MLIR.IR.detach_diagnostic_handler!(handler)
+    visible = filter(d -> d.severity != MLIR.API.MlirDiagnosticRemark, diagnostics)
+    isempty(visible) || _print_diagnostics(stderr, visible)
+    return result
+end
+
 function run_pass_pipeline!(mod, pass_pipeline, key=""; enable_verifier=true)
     pm = MLIR.IR.PassManager()
     MLIR.IR.enable_verifier!(pm, enable_verifier)
     opm = MLIR.IR.OpPassManager(pm)
     MLIR.IR.add_pipeline!(opm, pass_pipeline)
-    MLIR.IR.run!(pm, MLIR.IR.Operation(mod), key)
+    run!(pm, MLIR.IR.Operation(mod), key)
     return mod
 end
 
@@ -178,7 +209,7 @@ function run_pass_pipeline!(
         propagation_options.skip_inline::UInt8,
         propagation_options.enable_insert_explicit_collectives::UInt8,
     )::Cvoid
-    MLIR.IR.run!(pm, mod, "sdy_prop")
+    run!(pm, mod, "sdy_prop")
     return mod
 end
 

--- a/src/compiler/OptimizationPasses.jl
+++ b/src/compiler/OptimizationPasses.jl
@@ -11,6 +11,9 @@ const OpenMP = Ref{Bool}(true)
 const SROA_ATTRIBUTOR = Ref{Bool}(true)
 const DEBUG_PROBPROG_DUMP_VALUE = Ref(false)
 const DEBUG_PROBPROG_DISABLE_OPT = Ref(true)
+const DEBUG_MLIR_DIAGNOSTIC_LEVEL = Ref{MLIR.API.MlirDiagnosticSeverity}(
+    MLIR.API.MlirDiagnosticError
+)
 
 const WHILE_CONCAT = Ref(false)
 const DUS_TO_CONCAT = Ref(false)
@@ -161,10 +164,12 @@ function run!(pm::MLIR.IR.PassManager, op, key::String="")
     diagnostics = DiagnosticMessage[]
     handler =
         MLIR.IR.attach_diagnostic_handler!(; context=MLIR.IR.current_context()) do diag
+            severity = MLIR.IR.severity(diag)
+            severity > DEBUG_MLIR_DIAGNOSTIC_LEVEL[] && return false
             push!(
                 diagnostics,
                 DiagnosticMessage(
-                    MLIR.IR.severity(diag),
+                    severity,
                     _sprint_diagnostic(diag),
                     _collect_location_frames(MLIR.IR.location(diag)),
                 ),
@@ -174,12 +179,11 @@ function run!(pm::MLIR.IR.PassManager, op, key::String="")
     result = try
         MLIR.IR.run!(pm, op, key)
     catch
-        MLIR.IR.detach_diagnostic_handler!(handler)
         throw(CompilationError(key, diagnostics))
+    finally
+        MLIR.IR.detach_diagnostic_handler!(handler)
     end
-    MLIR.IR.detach_diagnostic_handler!(handler)
-    visible = filter(d -> d.severity != MLIR.API.MlirDiagnosticRemark, diagnostics)
-    isempty(visible) || _print_diagnostics(stderr, visible)
+    isempty(diagnostics) || _print_diagnostics(stderr, diagnostics)
     return result
 end
 

--- a/src/mlir/IR/DiagnosticHandler.jl
+++ b/src/mlir/IR/DiagnosticHandler.jl
@@ -1,0 +1,129 @@
+"""
+    Diagnostic
+
+Represents an MLIR diagnostic. Only valid during the execution of a diagnostic
+handler callback — must not be stored or used outside of it.
+"""
+struct Diagnostic
+    ref::API.MlirDiagnostic
+end
+
+Base.cconvert(::Core.Type{API.MlirDiagnostic}, d::Diagnostic) = d
+Base.unsafe_convert(::Core.Type{API.MlirDiagnostic}, d::Diagnostic) = d.ref
+
+"""
+    location(diagnostic)
+
+Returns the location at which the diagnostic is reported.
+"""
+location(diagnostic::Diagnostic) = Location(API.mlirDiagnosticGetLocation(diagnostic))
+
+"""
+    severity(diagnostic)
+
+Returns the severity of the diagnostic (one of `MlirDiagnosticError`,
+`MlirDiagnosticWarning`, `MlirDiagnosticNote`, or `MlirDiagnosticRemark`).
+"""
+severity(diagnostic::Diagnostic) = API.mlirDiagnosticGetSeverity(diagnostic)
+
+"""
+    nnotes(diagnostic)
+
+Returns the number of notes attached to the diagnostic.
+"""
+nnotes(diagnostic::Diagnostic) = Int(API.mlirDiagnosticGetNumNotes(diagnostic))
+
+"""
+    note(diagnostic, pos)
+
+Returns the `pos`-th note (1-based) attached to the diagnostic.
+"""
+note(diagnostic::Diagnostic, pos) =
+    Diagnostic(API.mlirDiagnosticGetNote(diagnostic, pos - one(pos)))
+
+function Base.show(io::IO, diagnostic::Diagnostic)
+    c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
+    ref = Ref(io)
+    return API.mlirDiagnosticPrint(diagnostic, c_print_callback, ref)
+end
+
+# Global registry: maps a UInt64 key → Julia callback.
+# Keeping the callback here (rather than via a raw pointer) ensures the GC
+# never collects it while the MLIR handler is registered.
+const _handler_registry = Dict{UInt64,Any}()
+const _handler_registry_key = Threads.Atomic{UInt64}(0)
+
+# Internal trampoline called by the C diagnostic engine.
+# `userdata` is a UInt64 key reinterpreted as Ptr{Cvoid}; we look the real
+# callback up in _handler_registry to avoid any raw-pointer / GC interaction.
+function _diagnostic_handler_trampoline(
+    raw::API.MlirDiagnostic, userdata::Ptr{Cvoid}
+)::API.MlirLogicalResult
+    key = reinterpret(UInt64, userdata)
+    callback = get(_handler_registry, key, nothing)
+    callback === nothing && return failure().ref
+    try
+        result = callback(Diagnostic(raw))
+        return (result === nothing || result === true) ? success().ref : failure().ref
+    catch ex
+        @error "Diagnostic handler threw an exception" exception = (ex, catch_backtrace())
+        return failure().ref
+    end
+end
+
+"""
+    DiagnosticHandler
+
+Represents an attached diagnostic handler. Use [`detach_diagnostic_handler!`](@ref)
+to remove it, or let it be cleaned up when the context is destroyed.
+"""
+mutable struct DiagnosticHandler
+    id::API.MlirDiagnosticHandlerID
+    context::Context
+    key::UInt64  # key into _handler_registry
+end
+
+"""
+    attach_diagnostic_handler!(f; context=current_context()) -> DiagnosticHandler
+
+Attaches `f` as a diagnostic handler to `context`. `f` is called as
+`f(diagnostic::Diagnostic)` and should return `true` (or `nothing`) if it
+handled the diagnostic completely, or `false` to let other handlers try.
+
+Handlers are invoked in reverse order of attachment. Returns a
+[`DiagnosticHandler`](@ref) token that can be passed to
+[`detach_diagnostic_handler!`](@ref).
+"""
+function attach_diagnostic_handler!(f; context::Context=current_context())
+    key = Threads.atomic_add!(_handler_registry_key, UInt64(1))
+    _handler_registry[key] = f
+    userdata = reinterpret(Ptr{Cvoid}, key)
+    # @cfunction must be created here (not at module scope) so that the function
+    # pointer is compiled fresh at call time and is valid after precompilation.
+    c_trampoline = @cfunction(
+        _diagnostic_handler_trampoline,
+        API.MlirLogicalResult,
+        (API.MlirDiagnostic, Ptr{Cvoid})
+    )
+    id = API.mlirContextAttachDiagnosticHandler(context, c_trampoline, userdata, C_NULL)
+    return DiagnosticHandler(id, context, key)
+end
+
+"""
+    detach_diagnostic_handler!(handler::DiagnosticHandler)
+
+Detaches a previously attached diagnostic handler from its context.
+"""
+function detach_diagnostic_handler!(handler::DiagnosticHandler)
+    delete!(_handler_registry, handler.key)
+    API.mlirContextDetachDiagnosticHandler(handler.context, handler.id)
+    return nothing
+end
+
+"""
+    emit_error(location, message)
+
+Emits an error diagnostic at the given location through the diagnostics engine.
+"""
+emit_error(location::Location, message::AbstractString) =
+    API.mlirEmitError(location, message)

--- a/src/mlir/IR/IR.jl
+++ b/src/mlir/IR/IR.jl
@@ -43,9 +43,20 @@ end
 # WARN do not export `Type` nor `Module` as they are already defined in Core
 # also, use `Core.Type` and `Core.Module` inside this module to avoid clash with
 # MLIR `Type` and `Module`
-export Attribute, Block, Context, Dialect, Location, Operation, Region, Value
+export Attribute,
+    Block,
+    Context,
+    Dialect,
+    Diagnostic,
+    DiagnosticHandler,
+    Location,
+    Operation,
+    Region,
+    Value
 export activate, deactivate, dispose, enable_multithreading!
 export context, current_context, has_context, @with_context
+export severity,
+    nnotes, note, attach_diagnostic_handler!, detach_diagnostic_handler!, emit_error
 export block, current_block, has_block, @with_block
 export current_module, has_module, @with_module
 export type, settype!, location, typeid, dialect
@@ -63,6 +74,7 @@ include("LogicalResult.jl")
 include("Context.jl")
 include("Dialect.jl")
 include("Location.jl")
+include("DiagnosticHandler.jl")
 include("Type.jl")
 include("TypeID.jl")
 include("Operation.jl")


### PR DESCRIPTION
Example display

```
error: binomial checkpointing: budget of 1 is too small for binomial checkpointing. Use periodic checkpointing instead.
  note: see current operation: 
%3:2 = "stablehlo.while"(%1, %arg0) ({
^bb0(%arg6: tensor<i64>, %arg7: tensor<3xf32>):
  %8 = "stablehlo.compare"(%arg6, %arg1) <{comparison_direction = #stablehlo<comparison_direction LT>}> : (tensor<i64>, tensor<i64>) -> tensor<i1>
  "stablehlo.return"(%8) : (tensor<i1>) -> ()
}, {
^bb0(%arg4: tensor<i64>, %arg5: tensor<3xf32>):
  %6 = "stablehlo.add"(%arg4, %2) : (tensor<i64>, tensor<i64>) -> tensor<i64>
  %7 = "stablehlo.sine"(%arg5) : (tensor<3xf32>) -> tensor<3xf32>
  "stablehlo.return"(%6, %7) : (tensor<i64>, tensor<3xf32>) -> ()
}) {enzyme.disable_mincut, enzymexla.binomial_checkpointing, enzymexla.checkpoint_period = 1 : i64, enzymexla.enable_checkpointing = true} : (tensor<i64>, tensor<3xf32>) -> (tensor<i64>, tensor<3xf32>)
Stacktrace:
  [1] traced_while/while_loop
     @ /mnt/pangoraw/Reactant.jl/src/ControlFlow.jl:20:0
  [2] (::Main.var"#binom_budget1_body")(::Reactant.TracedRArray{Float32, 1}, ::Reactant.TracedRNumber{Int64}, ::ReactantCore.Binomial)
     @ /mnt/pangoraw/Reactant.jl/test/core/binomial_checkpointing.jl:4:0
  [3] overload_autodiff(::EnzymeCore.ReverseMode{false, false, false, EnzymeCore.FFIABI, false, true}, ::EnzymeCore.Const{Main.var"#binom_budget1_body"}, ::Type{EnzymeCore.Active}, ::EnzymeCore.Duplicated{Reactant.TracedRArray{Float32, 1}}, ::EnzymeCore.Const{Reactant.TracedRNumber{Int64}}, ::EnzymeCore.Const{ReactantCore.Binomial})
     @ /mnt/pangoraw/Reactant.jl/src/Enzyme.jl:319:0
  [4] (::Main.var"#binom_budget1_grad")(::Reactant.TracedRArray{Float32, 1}, ::Reactant.TracedRNumber{Int64}, ::ReactantCore.Binomial)
     @ /mnt/pangoraw/Reactant.jl/test/core/binomial_checkpointing.jl:11:0
