### PR TITLE
Fix long compile time where big structarray is embedded into fn

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -337,7 +337,7 @@ function overload_autodiff(
         primf,
         primargs,
         (),
-        string(f) * "_autodiff",
+        string(FA) * "_autodiff",
         false;
         argprefix,
         resprefix,


### PR DESCRIPTION
string(f) converts the value of f into a string. For a closure capturing a StructArray, Base.show iterates over all N elements in the array to print their values, creating an $O(N)$ megabyte-sized string.

string(FA) converts the type FA into a string. For Const{var"#f#mwe##0"{StructVector{...}}}, the type parameters only contain the type definitions (e.g., Vector{Float64}) and do not contain any array data. Thus, string construction is $O(1)$ with respect to $N$ and remains extremely fast.