### PR TITLE
CUDAExt: Set GPUCompiler.current_job to the job

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -693,6 +693,8 @@ function compile(job)
         end
         opt_level = 2
         tm = GPUCompiler.llvm_machine(job.config.target)
+
+        GPUCompiler.current_job = job
         LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
             LLVM.register!(pb, GPULowerCPUFeaturesPass())
             LLVM.register!(pb, GPULowerPTLSPass())

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -694,36 +694,43 @@ function compile(job)
         opt_level = 2
         tm = GPUCompiler.llvm_machine(job.config.target)
 
+        prev_job =
+            isdefined(GPUCompiler, :current_job) ? GPUCompiler.current_job : nothing
         GPUCompiler.current_job = job
-        LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
-            LLVM.register!(pb, GPULowerCPUFeaturesPass())
-            LLVM.register!(pb, GPULowerPTLSPass())
-            LLVM.register!(pb, GPULowerGCFramePass())
-            LLVM.register!(pb, AddKernelStatePass())
-            LLVM.register!(pb, LowerKernelStatePass())
-            LLVM.register!(pb, CleanupKernelStatePass())
 
-            LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
-                GPUCompiler.buildNewPMPipeline!(mpm, job, opt_level)
+        try
+            LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
+                LLVM.register!(pb, GPULowerCPUFeaturesPass())
+                LLVM.register!(pb, GPULowerPTLSPass())
+                LLVM.register!(pb, GPULowerGCFramePass())
+                LLVM.register!(pb, AddKernelStatePass())
+                LLVM.register!(pb, LowerKernelStatePass())
+                LLVM.register!(pb, CleanupKernelStatePass())
+
+                LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
+                    GPUCompiler.buildNewPMPipeline!(mpm, job, opt_level)
+                end
+                LLVM.run!(pb, mod, tm)
             end
-            LLVM.run!(pb, mod, tm)
-        end
-        if Reactant.Compiler.DUMP_LLVMIR[]
-            println("cuda.jl pre vendor IR\n", string(mod))
-        end
-
-        LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
-            LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
-                LLVM.add!(mpm, LLVM.AlwaysInlinerPass())
+            if Reactant.Compiler.DUMP_LLVMIR[]
+                println("cuda.jl pre vendor IR\n", string(mod))
             end
-            LLVM.run!(pb, mod, tm)
-        end
 
-        GPUCompiler.optimize_module!(job, mod)
-        if Reactant.Compiler.DUMP_LLVMIR[]
-            println("cuda.jl post vendor IR\n", string(mod))
+            LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
+                LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
+                    LLVM.add!(mpm, LLVM.AlwaysInlinerPass())
+                end
+                LLVM.run!(pb, mod, tm)
+            end
+
+            GPUCompiler.optimize_module!(job, mod)
+            if Reactant.Compiler.DUMP_LLVMIR[]
+                println("cuda.jl post vendor IR\n", string(mod))
+            end
+            LLVM.run!(GPUCompiler.DeadArgumentEliminationPass(), mod, tm)
+        finally
+            GPUCompiler.current_job = prev_job
         end
-        LLVM.run!(GPUCompiler.DeadArgumentEliminationPass(), mod, tm)
 
         for fname in ("gpu_report_exception", "gpu_signal_exception")
             if LLVM.haskey(LLVM.functions(mod), fname)

--- a/test/integration/kernelabstractions.jl
+++ b/test/integration/kernelabstractions.jl
@@ -1,4 +1,4 @@
-using CUDA, KernelAbstractions, Reactant, Test
+using CUDA, KernelAbstractions, Reactant, Test, FileCheck
 
 # Simple kernel for matrix multiplication
 @kernel function matmul_kernel!(output, a)
@@ -101,4 +101,31 @@ end
     c_cpu = sin.((1:(N + 2)) ./ 3.0)
     expected = (2 / 3) ./ c_cpu[1:N] .+ (1 / 3) ./ c_cpu[2:(N + 1)]
     @test Array(out) ≈ expected
+end
+
+@kernel function fma_kernel!(out, @Const(a), @Const(b), @Const(c))
+    i = @index(Global)
+    @inbounds out[i] = fma(a[i], b[i], c[i])
+end
+
+function run_fma!(out, a, b, c)
+    backend = KernelAbstractions.get_backend(out)
+    kernel! = fma_kernel!(backend)
+    kernel!(out, a, b, c; ndrange=length(out))
+    return out
+end
+
+@testset "Compile FMA" begin
+    a = Reactant.to_rarray(Float64[1.0, 2.0, 3.0, 4.0])
+    b = Reactant.to_rarray(Float64[2.0, 3.0, 4.0, 5.0])
+    c = Reactant.to_rarray(Float64[0.5, 0.5, 0.5, 0.5])
+    out = Reactant.to_rarray(zeros(Float64, 4))
+
+    ir = repr(Reactant.@code_hlo raise = true run_fma!(out, a, b, c))
+    @test @filecheck begin
+        @check "%0 = stablehlo.multiply %arg1, %arg2 : tensor<4xf64>"
+        @check_next "%1 = stablehlo.add %0, %arg3 : tensor<4xf64>"
+        @check_next "return %1 : tensor<4xf64>"
+        ir
+    end
 end


### PR DESCRIPTION
Needed since some passes use that global variable, notably lower cpu features (have_fma).

https://github.com/JuliaGPU/GPUCompiler.jl/blob/03ae9a5a6ac7f69658a71dc20cef3e25849deb1e/src/optim.jl#L429
