### PR TITLE
Disable argument preservation optimization

### DIFF
--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -1086,7 +1086,8 @@ function compile_mlir!(
     results_mask = falses(length(results))
 
     for (i, op) in enumerate(results)
-        if !MLIR.IR.is_block_arg(op) ||
+        if !XLA_BYPASS_OPTIMIZATION[] ||
+            !MLIR.IR.is_block_arg(op) ||
             !Reactant.TracedUtils.has_idx(linear_results[i], :args) # new buffer
             push!(nresults, op)
             push!(linear_results2, linear_results[i])

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -1086,16 +1086,20 @@ function compile_mlir!(
     results_mask = falses(length(results))
 
     for (i, op) in enumerate(results)
-        if !XLA_BYPASS_OPTIMIZATION[] ||
-            !MLIR.IR.is_block_arg(op) ||
-            !Reactant.TracedUtils.has_idx(linear_results[i], :args) # new buffer
+        arg_num = MLIR.IR.is_block_arg(op) ? MLIR.IR.block_arg_num(op) : -1
+        # Preservation is safe only when the result IS the same traced object as the arg at
+        # block_arg_num's position. Cross-arg aliasing (e.g. state.u⁰ capturing state.u's
+        # block arg) must go through XLA explicitly to avoid in-place buffer corruption.
+        if !MLIR.IR.is_block_arg(op) ||
+            !Reactant.TracedUtils.has_idx(linear_results[i], :args) || # new buffer
+            linear_results[i] !== linear_args[arg_num + 1] # cross-arg aliasing
             push!(nresults, op)
             push!(linear_results2, linear_results[i])
             results_mask[i] = true
             continue
         end
 
-        push!(preserved_args, (linear_results[i], MLIR.IR.block_arg_num(op)))
+        push!(preserved_args, (linear_results[i], arg_num))
     end
 
     MLIR.IR.dispose(ret)
@@ -1146,10 +1150,15 @@ function compile_mlir!(
     # Add a `donated` attr to the function arguments. This doesn't affect XLA, but lets us
     # check which arguments were donated.
     preserved_args_idx = last.(preserved_args)
+    # If a block arg for arg k appears directly in nresults (cross-arg aliasing), donating
+    # arg k would allow XLA to modify its buffer in-place, corrupting the returned value.
+    block_arg_outputs = Set{Int}(
+        MLIR.IR.block_arg_num(op) for op in nresults if MLIR.IR.is_block_arg(op)
+    )
     donated_args_mask = Vector{Bool}(undef, length(linear_args))
     for (i, arg) in enumerate(linear_args)
         if compile_options.donated_args == :auto
-            if (i - 1) ∉ preserved_args_idx
+            if (i - 1) ∉ preserved_args_idx && (i - 1) ∉ block_arg_outputs
                 donated_args_mask[i] = true
 
                 residx = findfirst(Base.Fix1(===, arg), linear_results2)

--- a/src/compiler/OptimizationPasses.jl
+++ b/src/compiler/OptimizationPasses.jl
@@ -14,8 +14,6 @@ const DEBUG_PROBPROG_DISABLE_OPT = Ref(true)
 const DEBUG_MLIR_DIAGNOSTIC_LEVEL = Ref{MLIR.API.MlirDiagnosticSeverity}(
     MLIR.API.MlirDiagnosticError
 )
-const XLA_BYPASS_OPTIMIZATION = Ref{Bool}(false)
-
 const WHILE_CONCAT = Ref(false)
 const DUS_TO_CONCAT = Ref(false)
 const SUM_TO_REDUCEWINDOW = Ref(false)

--- a/src/compiler/OptimizationPasses.jl
+++ b/src/compiler/OptimizationPasses.jl
@@ -14,6 +14,7 @@ const DEBUG_PROBPROG_DISABLE_OPT = Ref(true)
 const DEBUG_MLIR_DIAGNOSTIC_LEVEL = Ref{MLIR.API.MlirDiagnosticSeverity}(
     MLIR.API.MlirDiagnosticError
 )
+const XLA_BYPASS_OPTIMIZATION = Ref{Bool}(false)
 
 const WHILE_CONCAT = Ref(false)
 const DUS_TO_CONCAT = Ref(false)

--- a/test/core/aliasing.jl
+++ b/test/core/aliasing.jl
@@ -55,3 +55,29 @@ end
     @test buffer_equals(x.x, x.y)
     @test !buffer_equals(x.y, z)
 end
+
+mutable struct State{A}
+    u::A
+    u⁰::A
+end
+
+function step!(state)
+    state.u⁰ .= state.u
+    state.u = state.u .+ 1.0
+    return nothing
+end
+
+@testset "Mutable struct aliasing" begin
+    sz = 3
+
+    state_v = State(fill(0.5, sz), fill(0.0, sz))
+    step!(state_v)
+
+    state_r = State(ConcreteRArray(fill(0.5, sz)), ConcreteRArray(fill(0.0, sz)))
+
+    r_step! = Reactant.@compile step!(state_r)
+    r_step!(state_r)
+
+    @test state_v.u == Array(state_r.u)
+    @test state_v.u⁰ == Array(state_r.u⁰)
+end

--- a/test/integration/kernelabstractions.jl
+++ b/test/integration/kernelabstractions.jl
@@ -125,7 +125,7 @@ end
     @test @filecheck begin
         @check "%0 = stablehlo.multiply %arg1, %arg2 : tensor<4xf64>"
         @check_next "%1 = stablehlo.add %0, %arg3 : tensor<4xf64>"
-        @check_next "return %1 : tensor<4xf64>"
+        @check_next "return %1"
         ir
     end
 end

--- a/test/integration/kernelabstractions.jl
+++ b/test/integration/kernelabstractions.jl
@@ -125,7 +125,7 @@ end
     @test @filecheck begin
         @check "%0 = stablehlo.multiply %arg1, %arg2 : tensor<4xf64>"
         @check_next "%1 = stablehlo.add %0, %arg3 : tensor<4xf64>"
-        @check_next "return %1"
+        @check_next "return %1 : tensor<4xf64>"
         ir
     end
 end


### PR DESCRIPTION
we can see if there are potential unwanted side effects of disabling, and remove the optimization altogether if there are none.

But this optimization has caused a few issues in the past
 - #2984 
 - #2722 
