### PR TITLE
Check if current_job global is defined

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -701,12 +701,54 @@ function compile(job)
 
         try
             LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
-                LLVM.register!(pb, GPULowerCPUFeaturesPass())
-                LLVM.register!(pb, GPULowerPTLSPass())
-                LLVM.register!(pb, GPULowerGCFramePass())
-                LLVM.register!(pb, AddKernelStatePass())
-                LLVM.register!(pb, LowerKernelStatePass())
-                LLVM.register!(pb, CleanupKernelStatePass())
+                LLVM.register!(
+                    pb,
+                    if isdefined(GPUCompiler, :CPUFeatures)
+                        GPULowerCPUFeaturesPass(job)
+                    else
+                        GPULowerCPUFeaturesPass()
+                    end,
+                )
+                LLVM.register!(
+                    pb,
+                    if isdefined(GPUCompiler, :LowerPTLS)
+                        GPULowerPTLSPass(job)
+                    else
+                        GPULowerPTLSPass()
+                    end,
+                )
+                LLVM.register!(
+                    pb,
+                    if isdefined(GPUCompiler, :LowerGCFrame)
+                        GPULowerGCFramePass(job)
+                    else
+                        GPULowerGCFramePass()
+                    end,
+                )
+                LLVM.register!(
+                    pb,
+                    if isdefined(GPUCompiler, :AddKernelState)
+                        AddKernelStatePass(job)
+                    else
+                        AddKernelStatePass()
+                    end,
+                )
+                LLVM.register!(
+                    pb,
+                    if isdefined(GPUCompiler, :LowerKernelState)
+                        LowerKernelStatePass(job)
+                    else
+                        LowerKernelStatePass()
+                    end,
+                )
+                LLVM.register!(
+                    pb,
+                    if isdefined(GPUCompiler, :CleanupKernelState)
+                        CleanupKernelStatePass(job)
+                    else
+                        CleanupKernelStatePass()
+                    end,
+                )
 
                 LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
                     GPUCompiler.buildNewPMPipeline!(mpm, job, opt_level)

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -694,9 +694,10 @@ function compile(job)
         opt_level = 2
         tm = GPUCompiler.llvm_machine(job.config.target)
 
-        prev_job =
-            isdefined(GPUCompiler, :current_job) ? GPUCompiler.current_job : nothing
-        GPUCompiler.current_job = job
+        if isdefined(GPUCompiler, :current_job)
+            prev_job = GPUCompiler.current_job
+            GPUCompiler.current_job = job
+        end
 
         try
             LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
@@ -729,7 +730,9 @@ function compile(job)
             end
             LLVM.run!(GPUCompiler.DeadArgumentEliminationPass(), mod, tm)
         finally
-            GPUCompiler.current_job = prev_job
+            if isdefined(GPUCompiler, :current_job)
+                GPUCompiler.current_job = prev_job
+            end
         end
 
         for fname in ("gpu_report_exception", "gpu_signal_exception")

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -636,12 +636,35 @@ end
     )
 end
 
-function GPULowerCPUFeaturesPass()
-    return LLVM.NewPMModulePass("GPULowerCPUFeatures", GPUCompiler.cpu_features!)
+function GPULowerCPUFeaturesPass(job)
+    return LLVM.NewPMModulePass(
+        "GPULowerCPUFeatures",
+        if isdefined(GPUCompiler, :CPUFeatures)
+            GPUCompiler.CPUFeatures(job)
+        else
+            GPUCompiler.cpu_features!
+        end,
+    )
 end
-GPULowerPTLSPass() = LLVM.NewPMModulePass("GPULowerPTLS", GPUCompiler.lower_ptls!)
-function GPULowerGCFramePass()
-    return LLVM.NewPMFunctionPass("GPULowerGCFrame", GPUCompiler.lower_gc_frame!)
+function GPULowerPTLSPass(job)
+    return LLVM.NewPMModulePass(
+        "GPULowerPTLS",
+        if isdefined(GPUCompiler, :LowerPTLS)
+            GPUCompiler.LowerPTLS(job)
+        else
+            GPUCompiler.lower_ptls!
+        end,
+    )
+end
+function GPULowerGCFramePass(job)
+    return LLVM.NewPMFunctionPass(
+        "GPULowerGCFrame",
+        if isdefined(GPUCompiler, :LowerGCFrame)
+            GPUCompiler.LowerGCFrame(job)
+        else
+            GPUCompiler.lower_gc_frame!
+        end,
+    )
 end
 function noop_pass(x)
     return false
@@ -701,54 +724,12 @@ function compile(job)
 
         try
             LLVM.@dispose pb = LLVM.NewPMPassBuilder() begin
-                LLVM.register!(
-                    pb,
-                    if isdefined(GPUCompiler, :CPUFeatures)
-                        GPULowerCPUFeaturesPass(job)
-                    else
-                        GPULowerCPUFeaturesPass()
-                    end,
-                )
-                LLVM.register!(
-                    pb,
-                    if isdefined(GPUCompiler, :LowerPTLS)
-                        GPULowerPTLSPass(job)
-                    else
-                        GPULowerPTLSPass()
-                    end,
-                )
-                LLVM.register!(
-                    pb,
-                    if isdefined(GPUCompiler, :LowerGCFrame)
-                        GPULowerGCFramePass(job)
-                    else
-                        GPULowerGCFramePass()
-                    end,
-                )
-                LLVM.register!(
-                    pb,
-                    if isdefined(GPUCompiler, :AddKernelState)
-                        AddKernelStatePass(job)
-                    else
-                        AddKernelStatePass()
-                    end,
-                )
-                LLVM.register!(
-                    pb,
-                    if isdefined(GPUCompiler, :LowerKernelState)
-                        LowerKernelStatePass(job)
-                    else
-                        LowerKernelStatePass()
-                    end,
-                )
-                LLVM.register!(
-                    pb,
-                    if isdefined(GPUCompiler, :CleanupKernelState)
-                        CleanupKernelStatePass(job)
-                    else
-                        CleanupKernelStatePass()
-                    end,
-                )
+                LLVM.register!(pb, GPULowerCPUFeaturesPass(job))
+                LLVM.register!(pb, GPULowerPTLSPass(job))
+                LLVM.register!(pb, GPULowerGCFramePass(job))
+                LLVM.register!(pb, AddKernelStatePass())
+                LLVM.register!(pb, LowerKernelStatePass())
+                LLVM.register!(pb, CleanupKernelStatePass())
 
                 LLVM.add!(pb, LLVM.NewPMModulePassManager()) do mpm
                     GPUCompiler.buildNewPMPipeline!(mpm, job, opt_level)


### PR DESCRIPTION
GPUCompiler.jl will remove `current_job` entirely.

https://github.com/JuliaGPU/GPUCompiler.jl/commit/04e9aa9499aac962080b4f85d655db8ebc5bd6dc

So harden Reactant usage so that it shouldn't run into issues. Someone who is more involved with Reactant should double check that if passes are called from GPUCompiler that those now take a `job` argument.
