### PR TITLE
ProbProg: disable log_simplify

### DIFF
--- a/src/compiler/OptimizationPasses.jl
+++ b/src/compiler/OptimizationPasses.jl
@@ -92,6 +92,11 @@ function optimization_passes(
         lower_passes_str, "associative_binary_op_reordering<1>;" => ""
     )
 
+    if compile_options.optimization_passes === :probprog
+        main_passes_str = replace(main_passes_str, "log_simplify;" => "")
+        lower_passes_str = replace(lower_passes_str, "log_simplify;" => "")
+    end
+
     transform_passes = join(
         [
             "enzyme-hlo-generate-td{patterns=" * main_passes_str * "}",


### PR DESCRIPTION
Larger-iteration cross framework checks need a numerical fix in https://github.com/EnzymeAD/Enzyme/pull/2915 (that distinguishes between log(a*b) and log(a) + log(b)) which can be eliminated by `log_simplify`