### PR TITLE
[linalg] fix `axp[b]y` with `TracedRNumber` scalars

### DIFF
--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -514,9 +514,6 @@ function LinearAlgebra._kron!(C::AnyTracedRMatrix, A::AnyTracedRMatrix, B::AnyTr
     return C
 end
 
-_convert(T, x) = T(x)
-_convert(T, x::TracedRNumber) = TracedRNumber{T}(x)
-
 function LinearAlgebra.axpy!(α::Number, x::TracedRArray{T}, y::TracedRArray{T}) where {T}
     if length(x) != length(y)
         throw(
@@ -525,7 +522,9 @@ function LinearAlgebra.axpy!(α::Number, x::TracedRArray{T}, y::TracedRArray{T})
             ),
         )
     end
-    ax = @opcall multiply(x, Reactant.broadcast_to_size(_convert(T, α), size(x)))
+    T1 = unwrapped_eltype(T)
+    α = Reactant.promote_to(TracedRNumber{T1}, α)
+    ax = @opcall multiply(x, Reactant.broadcast_to_size(α, size(x)))
 
     set_mlir_data!(y, get_mlir_data(@opcall add(y, ax)))
     return y
@@ -541,8 +540,11 @@ function LinearAlgebra.axpby!(
             ),
         )
     end
-    ax = @opcall multiply(x, Reactant.broadcast_to_size(_convert(T, α), size(x)))
-    by = @opcall multiply(y, Reactant.broadcast_to_size(_convert(T, β), size(y)))
+    T1 = unwrapped_eltype(T)
+    α = Reactant.promote_to(TracedRNumber{T1}, α)
+    β = Reactant.promote_to(TracedRNumber{T1}, β)
+    ax = @opcall multiply(x, Reactant.broadcast_to_size(α, size(x)))
+    by = @opcall multiply(y, Reactant.broadcast_to_size(β, size(y)))
 
     set_mlir_data!(y, get_mlir_data(@opcall add(ax, by)))
     return y

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -514,6 +514,9 @@ function LinearAlgebra._kron!(C::AnyTracedRMatrix, A::AnyTracedRMatrix, B::AnyTr
     return C
 end
 
+_convert(T, x) = T(x)
+_convert(T, x::TracedRNumber) = TracedRNumber{T}(x)
+
 function LinearAlgebra.axpy!(α::Number, x::TracedRArray{T}, y::TracedRArray{T}) where {T}
     if length(x) != length(y)
         throw(
@@ -522,7 +525,7 @@ function LinearAlgebra.axpy!(α::Number, x::TracedRArray{T}, y::TracedRArray{T})
             ),
         )
     end
-    ax = @opcall multiply(x, Reactant.broadcast_to_size(T(α), size(x)))
+    ax = @opcall multiply(x, Reactant.broadcast_to_size(_convert(T, α), size(x)))
 
     set_mlir_data!(y, get_mlir_data(@opcall add(y, ax)))
     return y
@@ -538,8 +541,8 @@ function LinearAlgebra.axpby!(
             ),
         )
     end
-    ax = @opcall multiply(x, Reactant.broadcast_to_size(T(α), size(x)))
-    by = @opcall multiply(y, Reactant.broadcast_to_size(T(β), size(y)))
+    ax = @opcall multiply(x, Reactant.broadcast_to_size(_convert(T, α), size(x)))
+    by = @opcall multiply(y, Reactant.broadcast_to_size(_convert(T, β), size(y)))
 
     set_mlir_data!(y, get_mlir_data(@opcall add(ax, by)))
     return y

--- a/test/integration/linear_algebra.jl
+++ b/test/integration/linear_algebra.jl
@@ -261,6 +261,15 @@ end
 
     @jit axpy!(α, x_ra, y_ra)
     @test y_ra ≈ axpy!(α, x, y)
+
+    α = Reactant.ConcreteRNumber(3)
+    x = Reactant.TestUtils.construct_test_array(Int64, 4)
+    x_ra = Reactant.to_rarray(x)
+    y = Reactant.TestUtils.construct_test_array(Int64, 4)
+    y_ra = Reactant.to_rarray(y)
+
+    @jit axpy!(α, x_ra, y_ra)
+    @test y_ra ≈ axpy!(Reactant.to_number(α), x, y)
 end
 
 @testset "axpby!" begin
@@ -302,6 +311,16 @@ end
 
     @jit axpby!(α, x_ra, β, y_ra)
     @test y_ra ≈ axpby!(α, x, β, y)
+
+    α = Reactant.ConcreteRNumber(3)
+    β = Reactant.ConcreteRNumber(2)
+    x = Reactant.TestUtils.construct_test_array(Int64, 4)
+    y = Reactant.TestUtils.construct_test_array(Int64, 4)
+    x_ra = Reactant.to_rarray(x)
+    y_ra = Reactant.to_rarray(y)
+
+    @jit axpby!(α, x_ra, β, y_ra)
+    @test y_ra ≈ axpby!(Reactant.to_number(α), x, Reactant.to_number(β), y)
 end
 
 @testset "Dot" begin


### PR DESCRIPTION
Previously, this would call `T(α::TracedRNumber)` which throws a MethodError when `T` is not a `TracedNumber`
