### PR TITLE
Fix if statement variable re-assignemnt

### DIFF
--- a/lib/ReactantCore/Project.toml
+++ b/lib/ReactantCore/Project.toml
@@ -1,7 +1,7 @@
 name = "ReactantCore"
 uuid = "a3311ec8-5e00-46d5-b541-4f83e724a433"
 authors = ["William Moses <wmoses@mit.edu>", "Valentin Churavy <vchuravy@mit.edu>", "Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>", "Paul Berg <paul@plutojl.org>", "Avik Pal <avikpal@mit.edu>"]
-version = "0.1.20"
+version = "0.1.21"
 
 [deps]
 ExpressionExplorer = "21656369-7473-754a-2065-74616d696c43"

--- a/lib/ReactantCore/src/ReactantCore.jl
+++ b/lib/ReactantCore/src/ReactantCore.jl
@@ -666,7 +666,6 @@ function trace_if(expr; store_last_line=nothing, depth=0, track_numbers)
     true_branch_assignments = [
         ExpressionExplorer.compute_symbols_state(true_block).assignments...
     ]
-    all_true_branch_vars = true_branch_input_list ∪ true_branch_assignments
     true_branch_fn_name = gensym(:true_branch)
 
     else_block, discard_vars, _ = if length(expr.args) == 3
@@ -716,14 +715,13 @@ function trace_if(expr; store_last_line=nothing, depth=0, track_numbers)
     false_branch_assignments = [
         ExpressionExplorer.compute_symbols_state(false_block).assignments...
     ]
-    all_false_branch_vars = false_branch_input_list ∪ false_branch_assignments
     false_branch_fn_name = gensym(:false_branch)
 
-    all_input_vars = true_branch_input_list ∪ false_branch_input_list
+    all_input_vars = unique(true_branch_input_list ∪ false_branch_input_list)
     all_output_vars = unique(true_branch_assignments ∪ false_branch_assignments)
     discard_vars !== nothing && setdiff!(all_output_vars, discard_vars)
 
-    all_vars = all_input_vars ∪ all_output_vars
+    all_vars = unique(all_input_vars ∪ all_output_vars)
 
     true_branch_fn = :(
         (args,) -> begin

--- a/lib/ReactantCore/src/ReactantCore.jl
+++ b/lib/ReactantCore/src/ReactantCore.jl
@@ -720,7 +720,7 @@ function trace_if(expr; store_last_line=nothing, depth=0, track_numbers)
     false_branch_fn_name = gensym(:false_branch)
 
     all_input_vars = true_branch_input_list ∪ false_branch_input_list
-    all_output_vars = all_true_branch_vars ∪ all_false_branch_vars
+    all_output_vars = unique(true_branch_assignments ∪ false_branch_assignments)
     discard_vars !== nothing && setdiff!(all_output_vars, discard_vars)
 
     all_vars = all_input_vars ∪ all_output_vars

--- a/test/integration/random.jl
+++ b/test/integration/random.jl
@@ -272,3 +272,30 @@ end
         @test rng_ra.algorithm == "PHILOX"
     end
 end
+
+function _rand_foo3(rng, α)
+    T = typeof(α)
+    boost = one(T)
+    @trace if α < one(T)
+        boost = rand(rng, T)^inv(α)
+    end
+    dv = zero(T)
+    i = 0
+    @trace while (dv == zero(dv))
+        x = rand(rng, T) - 0.5
+        dv = ifelse(x > 0, x, dv)
+    end
+    return boost * dv
+end
+
+@testset "Random state mutation across conditional branches and while loop" begin
+    for val in (0.5, 1.0, 1.5, 2.0)
+        rng = Reactant.ReactantRNG()
+        a = ConcreteRNumber(val)
+        rg = @compile _rand_foo3(rng, a)
+        res1 = rg(rng, a)
+        res2 = rg(rng, a)
+        @test res1 != res2
+    end
+end
+


### PR DESCRIPTION
cc @ptiede fixes https://github.com/EnzymeAD/Reactant.jl/issues/3036

from our llm overlords:

Root Cause: Unintended Variable Shadowing by @trace if
In @trace if (

ReactantCore.jl:L723
), all_output_vars determines which variables are returned from the @trace if macro expansion and assigned back into the enclosing scope:

julia
($(all_output_vars...),) = $(traced_if)(
    $(cond_name),
    $(true_branch_fn_name),
    $(false_branch_fn_name),
    $(args_expr);
    ...
)
Before this fix, all_output_vars was defined as:

julia
all_output_vars = all_true_branch_vars ∪ all_false_branch_vars
where all_true_branch_vars included both variables assigned inside the if block (true_branch_assignments) and variables only referenced/read inside the block (true_branch_input_list).

How this broke _rand_foo3 (α >= 1.0 vs α < 1.0)
In your snippet:

julia
@trace if α < one(T)
    boost = rand(rng, T)^inv(α)
end
Inside if α < one(T), rng is referenced (rand(rng, T)). Because inputs were included in all_output_vars, @trace if returned rng as part of its output tuple ((boost, rng)).
When @trace if compiled (if_condition in 

Ops.jl:L2450-L2883
), tracing the branches created new tracer objects (ReactantRNG / TracedRArray copies) for rng.
In-place mutations to inputs across conditional branches are already handled separately via the :resarg mechanism (if_condition updates the .mlir_data on the original rng.seed argument passed into the function).
However, because rng was included in all_output_vars, the assignment:
julia
(boost, rng) = traced_if(...)
re-assigned the local variable rng inside _rand_foo3 to the branch copy returned by traced_if.
Consequently, any subsequent operations—specifically @trace while (dv == zero(dv))—operated on and mutated that local copy (tb_rng).
When _rand_foo3 completed, finalize_mlir_fn inspected the original argument (traced_args[1].seed) to determine its final mutated state (:resarg 1). Because @trace while mutated the copy rather than the original rng, traced_args[1].seed.mlir_data was left pointing to the state immediately after the @trace if block—completely losing the RNG seed update from the while loop when α >= 1.0.
The Fix
By changing line 723 in 

ReactantCore.jl:L723
 to:

julia
all_output_vars = unique(true_branch_assignments ∪ false_branch_assignments)
@trace if only returns and reassigns variables that are explicitly assigned inside either branch (true_branch_assignments ∪ false_branch_assignments).
Input arguments that are merely referenced/mutated (like rng) are no longer shadowed by a returned copy.
The original local variable rng (traced_args[1]) remains intact after @trace if, so @trace while operates on traced_args[1].
Both conditional branch mutations (@trace if via :resarg) and loop mutations (@trace while) correctly accumulate on traced_args[1].seed, ensuring rg(rng, a) == rg(rng, a) is false across all branches.