### PR TITLE
Disable MLIR default stderr diagnostic handler

### DIFF
--- a/src/compiler/OptimizationPasses.jl
+++ b/src/compiler/OptimizationPasses.jl
@@ -201,7 +201,7 @@ function run!(pm::MLIR.IR.PassManager, op, key::String="")
                     _collect_location_frames(MLIR.IR.location(diag)),
                 ),
             )
-            return false  # allow other handlers to also see the diagnostic
+            return true  # consume the diagnostic
         end
     result = try
         MLIR.IR.run!(pm, op, key)


### PR DESCRIPTION
the goal of #2980 was to hide the default handler output.