### PR TITLE
Fix broadcasting functions with constant results over traced arrays

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -398,10 +398,12 @@ function _copyto!(dest::AnyTracedRArray, bc::Broadcasted)
 
     args = (Reactant.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
 
-    res = Reactant.promote_to(
-        TracedRArray{unwrapped_eltype(dest),ndims(dest)},
-        TracedUtils.elem_apply(bc.f, args...),
-    )
+    res0 = TracedUtils.elem_apply(bc.f, args...)
+    if !(res0 isa Reactant.TracedType)
+        # `bc.f` returned a constant that does not depend on its arguments:
+        res0 = Reactant.broadcast_to_size(res0, size(dest))
+    end
+    res = Reactant.promote_to(TracedRArray{unwrapped_eltype(dest),ndims(dest)}, res0)
     TracedUtils.set_mlir_data!(dest, res.mlir_data)
     return dest
 end

--- a/test/core/bcast.jl
+++ b/test/core/bcast.jl
@@ -278,3 +278,13 @@ end
     views_bcast!(du_jl, u_jl)
     @test Array(du_ra) ≈ du_jl
 end
+
+@testset "broadcasted function with constant result" begin
+    x = Reactant.ConcreteRArray(rand(10))
+
+    f(x) = broadcast(xj -> true, x)
+    @test Array(@jit f(x)) == fill(true, 10)
+
+    g(x) = all(broadcast(xj -> true, x))
+    @test Bool(@jit g(x))
+end


### PR DESCRIPTION
Stumbled on this while trying to make MeasureBase.jl Reactant-compatible:

when a broadcasted function ignores its arguments, elem_apply returns a plain constant. _copyto! promoted that constant to a single-element traced array and stamped its data into a destination of a different size, producing invalid IR:

`func.call` op operand type mismatch: expected operand type `tensor<10xi1>`, but provided `tensor<1xi1>`
Minimal repro: @jit (x -> all(broadcast(xj -> true, x)))(x) — a shape that comes up naturally in vectorized support checks (insupport-style masks). _copyto! now broadcasts non-traced constants to the destination size.

Code changes generated by Claude Fable at max effort.

Related to (but independent from) #3049 .