### PR TITLE
Carry closures called in traced loops as loop arguments

### DIFF
--- a/lib/ReactantCore/src/ReactantCore.jl
+++ b/lib/ReactantCore/src/ReactantCore.jl
@@ -258,10 +258,10 @@ macro trace(args...)
     Meta.isexpr(expr, :if) && return esc(trace_if(expr; track_numbers))
 
     Meta.isexpr(expr, :for) &&
-        return (esc(trace_for(expr; track_numbers, checkpointing, mincut)))
+        return (esc(trace_for(__module__, expr; track_numbers, checkpointing, mincut)))
 
     Meta.isexpr(expr, :while) &&
-        return (esc(trace_while(expr; track_numbers, checkpointing, mincut)))
+        return (esc(trace_while(__module__, expr; track_numbers, checkpointing, mincut)))
 
     return error(
         "Only `if-elseif-else` blocks, function definitions, `function calls`, `for` and \
@@ -370,7 +370,7 @@ function _check_aliasing_unchanged(pre_ids::Tuple, post_ids::Tuple, varnames::Tu
     end
 end
 
-function trace_while(expr; track_numbers, mincut, checkpointing, first_arg=nothing)
+function trace_while(mod, expr; track_numbers, mincut, checkpointing, first_arg=nothing)
     Meta.isexpr(expr, :while, 2) || error("expected while expr")
     cond, body = expr.args
 
@@ -397,6 +397,20 @@ function trace_while(expr; track_numbers, mincut, checkpointing, first_arg=nothi
     union!(external_syms, cond_symbols.assignments)
     union!(external_syms, body_symbols.references)
     union!(external_syms, body_symbols.assignments)
+    # Locally defined callables (e.g. closures over traced values) that are
+    # called in the loop must become loop-carried arguments as well, so that
+    # traced values captured by them become while-loop operands instead of
+    # closure captures of the generated body function (which would result in
+    # region block arguments without matching operands). Only plain names that
+    # don't resolve to globals of the calling module can refer to local
+    # callables:
+    for symbols_state in (cond_symbols, body_symbols)
+        for fn in symbols_state.funccalls
+            if length(fn.parts) == 1 && !isdefined(mod, only(fn.parts))
+                union!(external_syms, fn.parts)
+            end
+        end
+    end
     filter!(∉(SPECIAL_SYMBOLS), external_syms)
 
     all_syms = Expr(:tuple, external_syms...)
@@ -487,7 +501,7 @@ function trace_while(expr; track_numbers, mincut, checkpointing, first_arg=nothi
     end
 end
 
-function trace_for(expr; track_numbers, checkpointing, mincut)
+function trace_for(mod, expr; track_numbers, checkpointing, mincut)
     Meta.isexpr(expr, :for, 2) || error("expected for expr")
     assign, body = expr.args
 
@@ -577,6 +591,7 @@ function trace_for(expr; track_numbers, checkpointing, mincut)
         $num_iters += one($num_iters)
 
         $(trace_while(
+            mod,
             Expr(
                 :while,
                 quote

--- a/test/core/control_flow.jl
+++ b/test/core/control_flow.jl
@@ -1397,3 +1397,44 @@ end
     testr = @compile test.(b)
     @test testr(b) == test.(a)
 end
+
+function while_loop_calling_closure(d, B)
+    applyA = P -> d .* P
+    X = zero(B)
+    R = copy(B)
+    conv = one(eltype(B))
+    i = 0
+    @trace while (i < 10) & (conv > 1e-12)
+        AP = applyA(R)
+        X = X .+ AP
+        R = R .- AP .* 0.5
+        conv = maximum(sum(abs2, R; dims=1))
+        i += 1
+    end
+    return X
+end
+
+function for_loop_calling_closure(d, B)
+    applyA = P -> d .* P
+    X = zero(B)
+    R = copy(B)
+    @trace for i in 1:10
+        AP = applyA(R)
+        X = X .+ AP
+        R = R .- AP .* 0.5
+    end
+    return X
+end
+
+@testset "traced loops calling closures that capture traced values" begin
+    d = rand(3) .+ 1
+    B = rand(3, 4)
+    rd = Reactant.to_rarray(d)
+    rB = Reactant.to_rarray(B)
+
+    while_compiled = @compile while_loop_calling_closure(rd, rB)
+    @test Array(while_compiled(rd, rB)) ≈ while_loop_calling_closure(d, B)
+
+    for_compiled = @compile for_loop_calling_closure(rd, rB)
+    @test Array(for_compiled(rd, rB)) ≈ for_loop_calling_closure(d, B)
+end


### PR DESCRIPTION
AI-generated (Claude Fable at max effort), human reviewed:

Traced values captured by closures that are called (but not otherwise referenced) inside `@trace` `while`/`for` bodies became block arguments of the while regions without matching while-loop operands, failing MLIR verification with `expect operands to be compatible with body block arguments`.

Treat single-name function calls in the loop condition and body as external symbols, so such closures become loop-carried arguments and the traced values they capture become proper while-loop operands. As suggested by @Pangoraw in https://github.com/EnzymeAD/Reactant.jl/pull/3030#discussion_r2532542427, names that resolve to globals of the calling module (checked via `isdefined(__module__, name)` at macro expansion time) are excluded, to avoid inflating the loop-carried arguments with references to ordinary functions. One consequence: a local callable that shadows a module-level global of the same name won't be detected, and module functions defined *after* the macro expansion site are still carried (harmless, just an extra argument).

Split out of #3030 as requested there.
