### PR TITLE
Self-host Triton dialect C-API wrappers inside ReactantExtra

### DIFF
--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -1,7 +1,8 @@
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "td_library")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("@xla//tools/toolchains/cross_compile/cc:cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 # load("//toolchain:yggdrasil.bzl", "ygg_cc_toolchain")
 licenses(["notice"])
@@ -1087,6 +1088,42 @@ platform(
 )
 
 cc_library(
+    name = "triton_dialect_capi_objects",
+    srcs = ["triton_capi/triton_dialect_capi.cpp"],
+    hdrs = ["triton_capi/triton_dialect_capi.h"],
+    includes = ["triton_capi"],
+    deps = [
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:CAPIIRObjects",
+        "@llvm-project//mlir:IR",
+        "@triton//:TritonDialects",
+    ],
+    alwayslink = True,
+)
+
+cc_test(
+    name = "triton_dialect_capi_test",
+    srcs = ["triton_capi/triton_dialect_capi_test.cpp"],
+    includes = ["triton_capi"],
+    deps = [
+        ":triton_dialect_capi_objects",
+        "@com_google_googletest//:gtest_main",
+        "@llvm-project//mlir:CAPIIR",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+td_library(
+    name = "TritonDialectTdFiles",
+    srcs = [
+        "triton_capi/triton.td",
+    ],
+    deps = [
+        "@triton//:td_files",
+    ],
+)
+
+cc_library(
     name = "ReactantExtraLib",
     srcs = glob(
         [
@@ -1391,7 +1428,7 @@ cc_library(
 
         # Broken upstream x/ref https://github.com/jax-ml/jax/issues/33344
         # "@jax//jaxlib/mosaic:tpu_dialect_capi_objects",
-        "@jax//jaxlib/triton:triton_dialect_capi_objects",
+        ":triton_dialect_capi_objects",
         "@xla//xla/pjrt/plugin/xla_cpu:xla_cpu_pjrt_client",
         "@stablehlo//:linalg_passes",
         "@stablehlo//:tosa_passes",
@@ -1803,10 +1840,10 @@ gentbl_cc_library(
         ),
     ],
     tblgen = "//:mlir-jl-tblgen",
-    td_file = "@jax//jaxlib/triton:triton.td",
+    td_file = "triton_capi/triton.td",
     deps = [
         "@llvm-project//mlir:OpBaseTdFiles",
-        "@triton//:td_files",
+        ":TritonDialectTdFiles",
     ],
 )
 
@@ -1957,7 +1994,7 @@ genrule(
         "@stablehlo//:stablehlo/integrations/c/StablehloDialectApi.h",
         "@stablehlo//:stablehlo/integrations/c/StablehloTypes.h",
         "@shardy//shardy/integrations/c:attributes.h",
-        "@jax//jaxlib/triton:triton_dialect_capi.h",
+        "triton_capi/triton_dialect_capi.h",
         "@jax//jaxlib/mosaic:dialect/tpu/integrations/c/tpu_dialect.h",
         "@jax//jaxlib/mosaic:dialect/tpu/integrations/c/tpu_passes.capi.h.inc",
         "@jax//jaxlib/mosaic/dialect/gpu:integrations/c/attributes.h",
@@ -1973,7 +2010,7 @@ genrule(
         "//:make.jl",
     ],
     outs = ["libMLIR_h.jl"],
-    cmd = "$$JULIA \"--color=yes\" \"--project=$(location //:Project.toml)\" \"$(location //:make.jl)\" \"--extract-api\" \"$(location @llvm-project//mlir:include/mlir-c/Bindings/Python/Interop.h)\" \"$(location @llvm-project//llvm:include/llvm-c/Support.h)\" \"$(locations @llvm-project//mlir:ConversionPassIncGen_filegroup)\" \"$(location @stablehlo//:stablehlo/integrations/c/StablehloAttributes.h)\" \"$(location @shardy//shardy/integrations/c:attributes.h)\" \"$(location @jax//jaxlib/triton:triton_dialect_capi.h)\" \"$(location @jax//jaxlib/mosaic:dialect/tpu/integrations/c/tpu_dialect.h)\" \"$(location @jax//jaxlib/mosaic/dialect/gpu:integrations/c/gpu_dialect.h)\" \"$(location @enzyme_ad//src/enzyme_ad/jax:Integrations/c/EnzymeXLA.h)\" \"$(location @enzyme//:Enzyme/MLIR/Integrations/c/EnzymeMLIR.h)\" \"$@\"",
+    cmd = "$$JULIA \"--color=yes\" \"--project=$(location //:Project.toml)\" \"$(location //:make.jl)\" \"--extract-api\" \"$(location @llvm-project//mlir:include/mlir-c/Bindings/Python/Interop.h)\" \"$(location @llvm-project//llvm:include/llvm-c/Support.h)\" \"$(locations @llvm-project//mlir:ConversionPassIncGen_filegroup)\" \"$(location @stablehlo//:stablehlo/integrations/c/StablehloAttributes.h)\" \"$(location @shardy//shardy/integrations/c:attributes.h)\" \"$(location triton_capi/triton_dialect_capi.h)\" \"$(location @jax//jaxlib/mosaic:dialect/tpu/integrations/c/tpu_dialect.h)\" \"$(location @jax//jaxlib/mosaic/dialect/gpu:integrations/c/gpu_dialect.h)\" \"$(location @enzyme_ad//src/enzyme_ad/jax:Integrations/c/EnzymeXLA.h)\" \"$(location @enzyme//:Enzyme/MLIR/Integrations/c/EnzymeMLIR.h)\" \"$@\"",
     tags = [
         "jlrule",
     ],

--- a/deps/ReactantExtra/triton_capi/triton.td
+++ b/deps/ReactantExtra/triton_capi/triton.td
@@ -1,0 +1,1 @@
+include "triton/Dialect/Triton/IR/TritonOps.td"

--- a/deps/ReactantExtra/triton_capi/triton_dialect_capi.cpp
+++ b/deps/ReactantExtra/triton_capi/triton_dialect_capi.cpp
@@ -1,0 +1,56 @@
+#include "triton_dialect_capi.h"
+
+#include <optional>
+
+#include "llvm/Support/Casting.h"
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "mlir/CAPI/Support.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+
+extern "C" {
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Triton, triton,
+                                      mlir::triton::TritonDialect);
+
+MlirType mlirTritonPointerTypeGet(MlirType pointeeType, int addressSpace) {
+  return wrap(
+      mlir::triton::PointerType::get(unwrap(pointeeType), addressSpace));
+}
+
+bool mlirTritonIsAPointer(MlirType type) {
+  return llvm::isa<mlir::triton::PointerType>(unwrap(type));
+}
+
+MlirType mlirTritonPointerTypeGetPointeeType(MlirType pointerType) {
+  return wrap(llvm::cast<mlir::triton::PointerType>(unwrap(pointerType))
+                  .getPointeeType());
+}
+
+int mlirTritonPointerTypeGetAddressSpace(MlirType pointerType) {
+  return llvm::cast<mlir::triton::PointerType>(unwrap(pointerType))
+      .getAddressSpace();
+}
+
+MlirAttribute mlirTritonInferReduceOpEncoding(MlirAttribute operandEncoding,
+                                              int axis) {
+  auto opEncoding = unwrap(operandEncoding);
+  mlir::Dialect& dialect = opEncoding.getDialect();
+  auto inferLayoutInterface =
+      llvm::dyn_cast<mlir::triton::DialectInferLayoutInterface>(&dialect);
+  mlir::Attribute retEncoding;
+  (void)inferLayoutInterface->inferReduceOpEncoding(opEncoding, axis,
+                                                    retEncoding, std::nullopt);
+  return wrap(retEncoding);
+}
+
+MlirTypeID mlirTritonPointerTypeGetTypeID(void) {
+  return wrap(mlir::triton::PointerType::getTypeID());
+}
+
+}  // extern "C"

--- a/deps/ReactantExtra/triton_capi/triton_dialect_capi.h
+++ b/deps/ReactantExtra/triton_capi/triton_dialect_capi.h
@@ -1,0 +1,29 @@
+#ifndef REACTANT_EXTRA_TRITON_CAPI_TRITON_DIALECT_CAPI_H_
+#define REACTANT_EXTRA_TRITON_CAPI_TRITON_DIALECT_CAPI_H_
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Triton, triton);
+
+MLIR_CAPI_EXPORTED MlirTypeID mlirTritonPointerTypeGetTypeID(void);
+MLIR_CAPI_EXPORTED MlirType mlirTritonPointerTypeGet(MlirType pointeeType,
+                                                     int addressSpace);
+MLIR_CAPI_EXPORTED bool mlirTritonIsAPointer(MlirType type);
+MLIR_CAPI_EXPORTED MlirType
+mlirTritonPointerTypeGetPointeeType(MlirType pointerType);
+MLIR_CAPI_EXPORTED int mlirTritonPointerTypeGetAddressSpace(
+    MlirType pointerType);
+
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirTritonInferReduceOpEncoding(MlirAttribute operandEncoding, int axis);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // REACTANT_EXTRA_TRITON_CAPI_TRITON_DIALECT_CAPI_H_

--- a/deps/ReactantExtra/triton_capi/triton_dialect_capi_test.cpp
+++ b/deps/ReactantExtra/triton_capi/triton_dialect_capi_test.cpp
@@ -1,0 +1,31 @@
+#include "triton_dialect_capi.h"
+
+#include <gtest/gtest.h>
+#include "mlir-c/BuiltinTypes.h"
+#include "mlir-c/IR.h"
+
+TEST(TritonDialectCapiTest, DialectRegistrationAndPointerTypes) {
+  MlirContext context = mlirContextCreate();
+  MlirDialectHandle tritonHandle = mlirGetDialectHandle__triton__();
+  mlirDialectHandleLoadDialect(tritonHandle, context);
+
+  // Test non-pointer type verification
+  MlirType f32 = mlirF32TypeGet(context);
+  EXPECT_FALSE(mlirTritonIsAPointer(f32));
+
+  // Test PointerType creation and inspection
+  int addressSpace = 1;
+  MlirType ptrType = mlirTritonPointerTypeGet(f32, addressSpace);
+  EXPECT_FALSE(mlirTypeIsNull(ptrType));
+  EXPECT_TRUE(mlirTritonIsAPointer(ptrType));
+
+  MlirType pointeeType = mlirTritonPointerTypeGetPointeeType(ptrType);
+  EXPECT_TRUE(mlirTypeEqual(pointeeType, f32));
+  EXPECT_EQ(mlirTritonPointerTypeGetAddressSpace(ptrType), addressSpace);
+
+  // Test TypeID
+  MlirTypeID ptrTypeId = mlirTritonPointerTypeGetTypeID();
+  EXPECT_FALSE(mlirTypeIDIsNull(ptrTypeId));
+
+  mlirContextDestroy(context);
+}


### PR DESCRIPTION
- Move Triton C-API wrapper declarations (`triton_dialect_capi.h/.cpp`) and TableGen wrapper (`triton.td`) directly into `deps/ReactantExtra/triton_capi/`.
- Add `:triton_dialect_capi_objects`, `:triton_dialect_capi_test`, and `:TritonDialectTdFiles` targets in `deps/ReactantExtra/BUILD`.
- Replace `@jax//jaxlib/triton` dependency in `ReactantExtraLib`, `julia_proto_bindings`, and `TritonJLIncGen` with self-hosted targets.
- Add unit test verifying pointer type creation and query functions.