### PR TITLE
Fix StructArrayStyle broadcast over separate arrays

### DIFF
--- a/ext/ReactantStructArraysExt.jl
+++ b/ext/ReactantStructArraysExt.jl
@@ -53,10 +53,9 @@ function Base.copyto!(
     bc = Broadcast.preprocess(dest, bc)
 
     args = (Reactant.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
-    res = Reactant.TracedUtils.elem_apply_via_while_loop(
-        bc.f, args...; track_numbers=Union{}
+    Reactant.TracedUtils.elem_apply_via_while_loop!(
+        dest, bc.f, args...; track_numbers=Union{}
     )
-    copyto!(dest, res)
 
     return dest
 end
@@ -75,10 +74,9 @@ function Base.copyto!(
 
     bc = Broadcast.preprocess(dest, bc)
     args = (Reactant.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
-    res = Reactant.TracedUtils.elem_apply_via_while_loop(
-        bc.f, args...; track_numbers=Union{}
+    return Reactant.TracedUtils.elem_apply_via_while_loop!(
+        dest, bc.f, args...; track_numbers=Union{}
     )
-    return copyto!(dest, res)
 end
 
 function alloc_sarr(bc, T)

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -1154,18 +1154,39 @@ scalar_arg(arg) = arg isa Base.RefValue || !(arg isa AbstractArray)
 flattenarg(arg) = ReactantCore.materialize_traced_array(vec(arg))
 flattenarg(arg::Ref) = RefFillVector(arg)
 
-function elem_apply_via_while_loop(f, args::Vararg{Any,Nargs}; kwargs...) where {Nargs}
+function elem_apply_via_while_loop!(
+    result, f, args::Vararg{Any,Nargs}; kwargs...
+) where {Nargs}
     non_ref_args = [arg for arg in args if !scalar_arg(arg)]
     if !isempty(non_ref_args)
         @assert allequal(size.(non_ref_args)) "All args must have the same size"
     end
-    out_size = isempty(non_ref_args) ? () : size(first(non_ref_args))
     L = isempty(non_ref_args) ? 1 : length(first(non_ref_args))
     # flattening the tensors makes the auto-batching pass work nicer
     flat_args = [flattenarg(arg) for arg in args]
 
+    ind_var = zeros(TracedRArray{Int}, ())
+    f_ref = Ref(f)
+    result_ref = Ref(result)
+    args_ref = Ref(flat_args)
+    limit_ref = Ref(L)
+
+    ReactantCore.traced_while(
+        __elem_apply_loop_condition,
+        __elem_apply_loop_body,
+        (ind_var, f_ref, result_ref, args_ref, limit_ref);
+        kwargs...,
+    )
+
+    return result
+end
+
+function elem_apply_via_while_loop(f, args::Vararg{Any,Nargs}; kwargs...) where {Nargs}
+    non_ref_args = [arg for arg in args if !scalar_arg(arg)]
+    out_size = isempty(non_ref_args) ? () : size(first(non_ref_args))
+
     # This wont be a mutating function so we can safely execute it once
-    scalar_seed_args = [@allowscalar(arg[1]) for arg in flat_args]
+    scalar_seed_args = [@allowscalar(flattenarg(arg)[1]) for arg in args]
     res_tmp = @allowscalar(f(scalar_seed_args...))
 
     # TODO: perhaps instead of this logic, we should have
@@ -1183,18 +1204,7 @@ function elem_apply_via_while_loop(f, args::Vararg{Any,Nargs}; kwargs...) where 
     bc = Base.Broadcast.Broadcasted(f, Tuple(args))
     result = similar(bc, T_res)
 
-    ind_var = zeros(TracedRArray{Int}, ())
-    f_ref = Ref(f)
-    result_ref = Ref(result)
-    args_ref = Ref(flat_args)
-    limit_ref = Ref(L)
-
-    ReactantCore.traced_while(
-        __elem_apply_loop_condition,
-        __elem_apply_loop_body,
-        (ind_var, f_ref, result_ref, args_ref, limit_ref);
-        kwargs...,
-    )
+    elem_apply_via_while_loop!(result, f, args...; kwargs...)
 
     return ReactantCore.materialize_traced_array(reshape(result, out_size))
 end

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -1157,13 +1157,15 @@ flattenarg(arg::Ref) = RefFillVector(arg)
 function elem_apply_via_while_loop!(
     result, f, args::Vararg{Any,Nargs}; kwargs...
 ) where {Nargs}
-    non_ref_args = [arg for arg in args if !scalar_arg(arg)]
+    # tuples instead of vectors: collecting args of mixed eltypes would trigger
+    # `convert` to a non-concrete `TracedRArray` type, which `promote_to` rejects
+    non_ref_args = filter(!scalar_arg, args)
     if !isempty(non_ref_args)
         @assert allequal(size.(non_ref_args)) "All args must have the same size"
     end
     L = isempty(non_ref_args) ? 1 : length(first(non_ref_args))
     # flattening the tensors makes the auto-batching pass work nicer
-    flat_args = [flattenarg(arg) for arg in args]
+    flat_args = map(flattenarg, args)
 
     ind_var = zeros(TracedRArray{Int}, ())
     f_ref = Ref(f)
@@ -1182,11 +1184,11 @@ function elem_apply_via_while_loop!(
 end
 
 function elem_apply_via_while_loop(f, args::Vararg{Any,Nargs}; kwargs...) where {Nargs}
-    non_ref_args = [arg for arg in args if !scalar_arg(arg)]
+    non_ref_args = filter(!scalar_arg, args)
     out_size = isempty(non_ref_args) ? () : size(first(non_ref_args))
 
     # This wont be a mutating function so we can safely execute it once
-    scalar_seed_args = [@allowscalar(flattenarg(arg)[1]) for arg in args]
+    scalar_seed_args = map(arg -> @allowscalar(flattenarg(arg)[1]), args)
     res_tmp = @allowscalar(f(scalar_seed_args...))
 
     # TODO: perhaps instead of this logic, we should have

--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -1154,6 +1154,8 @@ scalar_arg(arg) = arg isa Base.RefValue || !(arg isa AbstractArray)
 flattenarg(arg) = ReactantCore.materialize_traced_array(vec(arg))
 flattenarg(arg::Ref) = RefFillVector(arg)
 
+scalar_seed_arg(arg) = @allowscalar flattenarg(arg)[1]
+
 function elem_apply_via_while_loop!(
     result, f, args::Vararg{Any,Nargs}; kwargs...
 ) where {Nargs}
@@ -1188,7 +1190,7 @@ function elem_apply_via_while_loop(f, args::Vararg{Any,Nargs}; kwargs...) where 
     out_size = isempty(non_ref_args) ? () : size(first(non_ref_args))
 
     # This wont be a mutating function so we can safely execute it once
-    scalar_seed_args = map(arg -> @allowscalar(flattenarg(arg)[1]), args)
+    scalar_seed_args = map(scalar_seed_arg, args)
     res_tmp = @allowscalar(f(scalar_seed_args...))
 
     # TODO: perhaps instead of this logic, we should have

--- a/test/integration/structarrays.jl
+++ b/test/integration/structarrays.jl
@@ -91,6 +91,27 @@ end
     @test @jit(sum(sr)) ≈ sum(s2)
 end
 
+two_col_nt(x, y) = (; s=x + y, p=x * y)
+
+# Struct-array-styled broadcast over individual columns, as done e.g. by
+# PropertyFunctions.jl:
+function structbcast_over_columns(a, b)
+    style = StructArrays.StructArrayStyle{typeof(Base.Broadcast.combine_styles(a, b)),1}()
+    return Base.Broadcast.materialize(Base.Broadcast.broadcasted(style, two_col_nt, a, b))
+end
+
+@testset "struct-returning broadcast over plain columns" begin
+    a = rand(10)
+    b = rand(Float32, 10)
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+
+    res = @jit structbcast_over_columns(a_ra, b_ra)
+    @test res isa StructVector
+    @test res.s ≈ a .+ b
+    @test res.p ≈ a .* b
+end
+
 @testset "structarray with complex numbers" begin
     s = randn(64)
 


### PR DESCRIPTION
Ran into this why trying to make PropertyFunctions.jl Reactant-compatible:

This fixes `StructArrays.StructArrayStyle` broadcasts where the input is not a `StructArray` but one or several plain arrays.

Limitation: struct-returning broadcasts over plain arrays, with no StructArrays involvement anywhere, (like a simple `broadcast((x,y) -> (s=x+y,), a, b)` without `StructArrayStyle`) will still fail as before. Fixing that would requite Reactant depending on StructArrays.

Claude Fable-5:

elem_apply_via_while_loop allocated its own result via similar(Broadcasted(f, args), T_res) even when its callers in ReactantStructArraysExt already hold a correctly-typed destination. For struct-returning functions broadcast over plain Reactant arrays under a StructArray broadcast style (as done e.g. by PropertyFunctions.jl to broadcast over individual columns), that internal allocation fails, since similar on the plain Reactant broadcast style only supports primitive and TracedRNumber element types.

Split out elem_apply_via_while_loop!(result, f, args...), which writes into a caller-provided destination, and use it in the StructArrays extension's copyto! methods. This also removes an allocate-then-copy round trip.