### PR TITLE
Support broadcasting tuple/struct-returning functions over traced arrays

### DIFF
--- a/ext/ReactantStructArraysExt.jl
+++ b/ext/ReactantStructArraysExt.jl
@@ -31,6 +31,8 @@ function __init__()
     Reactant.@skip_rewrite_func StructArrays.index_type
 end
 
+Reactant.is_extension_loaded(::Val{:StructArrays}) = true
+
 StructArrays.always_struct_broadcast(::AbstractReactantArrayStyle) = true
 
 function Base.copy(
@@ -81,14 +83,14 @@ function Base.copyto!(
     return copyto!(dest, res)
 end
 
-function alloc_sarr(bc, T)
+function alloc_sarr(bc, T, dims=axes(bc))
     # Short circuit for Complex since in Reactant they are just a regular number
-    T <: Complex && return similar(bc, T)
-    asa = Base.Fix1(alloc_sarr, bc)
+    T <: Complex && return similar(bc, T, dims)
+    asa = FT -> alloc_sarr(bc, FT, dims)
     if StructArrays.isnonemptystructtype(T)
         return StructArrays.buildfromschema(asa, T)
     else
-        return similar(bc, T)
+        return similar(bc, T, dims)
     end
 end
 
@@ -98,6 +100,16 @@ function Base.similar(
     bc′ = convert(Broadcasted{S}, bc)
     # It is possible that we have multiple broadcasted arguments
     return alloc_sarr(bc′, ElType)
+end
+
+# Broadcasted functions returning tuples or structs over traced arrays get a
+# struct-of-arrays result (see issue #1566)
+function Base.similar(
+    bc::Broadcasted{AbstractReactantArrayStyle{N}}, ::Type{T}, dims
+) where {T,N}
+    (T <: Complex || !StructArrays.isnonemptystructtype(T)) &&
+        throw(MethodError(similar, (bc, T, dims)))
+    return alloc_sarr(bc, T, dims)
 end
 
 Base.@propagate_inbounds function StructArrays._getindex(

--- a/ext/ReactantStructArraysExt.jl
+++ b/ext/ReactantStructArraysExt.jl
@@ -83,12 +83,17 @@ function Base.copyto!(
     return copyto!(dest, res)
 end
 
+struct AllocSArr{B,D} <: Function
+    bc::B
+    dims::D
+end
+(asa::AllocSArr)(T) = alloc_sarr(asa.bc, T, asa.dims)
+
 function alloc_sarr(bc, T, dims=axes(bc))
     # Short circuit for Complex since in Reactant they are just a regular number
     T <: Complex && return similar(bc, T, dims)
-    asa = FT -> alloc_sarr(bc, FT, dims)
     if StructArrays.isnonemptystructtype(T)
-        return StructArrays.buildfromschema(asa, T)
+        return StructArrays.buildfromschema(AllocSArr(bc, dims), T)
     else
         return similar(bc, T, dims)
     end

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -393,6 +393,20 @@ function __init__()
                    need to restart the Julia process (even if Revise.jl is loaded).",
             )
         end
+        if exc.f === Base.similar &&
+            !is_extension_loaded(Val(:StructArrays)) &&
+            length(exc.args) ≥ 2 &&
+            exc.args[1] isa
+            Broadcast.Broadcasted{<:TracedRArrayOverrides.AbstractReactantArrayStyle} &&
+            exc.args[2] isa DataType &&
+            Base.isstructtype(exc.args[2]) &&
+            fieldcount(exc.args[2]) > 0
+            print(
+                io,
+                "\nBroadcasting a function that returns tuples or structs over traced \
+                   arrays requires StructArrays.jl. Load it using `using StructArrays`.",
+            )
+        end
     end
     MLIR.Highlight.register_reactant_theme()
     return nothing

--- a/test/integration/structarrays.jl
+++ b/test/integration/structarrays.jl
@@ -101,3 +101,26 @@ end
     @test out isa ConcreteRArray
     @test @jit(sum(sr)) ≈ sum(s)
 end
+
+@noinline duplicate(a) = (a, a)
+@noinline sincos_pair(a) = (sin(a), cos(a))
+@noinline sincos_nt(a) = (; s=sin(a), c=cos(a))
+
+@testset "broadcasted functions returning tuples (#1566)" begin
+    x = randn(Float32, 10)
+    xr = Reactant.to_rarray(x)
+
+    out = @jit duplicate.(xr)
+    @test out isa AbstractVector{<:Tuple}
+    @test collect(out) == duplicate.(x)
+
+    out = @jit sincos_pair.(xr)
+    @test out isa AbstractVector{<:Tuple}
+    @test components(out)[1] ≈ sin.(x)
+    @test components(out)[2] ≈ cos.(x)
+
+    out = @jit sincos_nt.(xr)
+    @test out isa AbstractVector{<:NamedTuple{(:s, :c)}}
+    @test components(out).s ≈ sin.(x)
+    @test components(out).c ≈ cos.(x)
+end


### PR DESCRIPTION
Closes #1566.

Somewhat related, but technically orthogonal to #3065.

Claude Fable-5 max:

Broadcasting a function that returns a tuple or struct over a traced array
(e.g. `foo.(A)` with `foo(a) = (a, a)`) failed with a `MethodError` on
`similar`, because the broadcast eltype is a `Tuple`/struct and no `similar`
method existed for such eltypes under `AbstractReactantArrayStyle`.

The downstream machinery already handled this case: `elem_apply` returns a
struct-of-arrays result and the StructArrays extension already has
`alloc_sarr` for building struct-of-arrays containers plus the matching
`copyto!` fill path. Only the container-allocation hook was missing.

This adds:

- `similar(::Broadcasted{AbstractReactantArrayStyle{N}}, ::Type{T}, dims)` in
  the StructArrays extension, which builds a `StructArray` via `alloc_sarr`
  for tuple/struct eltypes (and otherwise rethrows the original `MethodError`
  so unrelated cases are unaffected). `alloc_sarr` is generalized to thread
  `dims` through instead of always using `axes(bc)`.
- A `MethodError` hint in `Reactant.__init__` telling users to load
  StructArrays.jl when this broadcast is attempted without it.
- Integration tests covering tuple and named-tuple results.

The result is a `StructVector` (still `<: AbstractVector{<:Tuple}`, as the
issue expects), and the broadcast optimizes to clean batched HLO — e.g.
`(sin.(a), cos.(a))` lowers to `stablehlo.sine` + `stablehlo.cosine` over
whole tensors.