### PR TITLE
Make convert to non-concrete TracedRArray types a no-op when possible

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -27,7 +27,12 @@ Base.elsize(::Type{<:TracedRArray{T,N}}) where {T,N} = sizeof(T)
 
 # This is required otherwise we will copy a tracedrarray each time
 # we use it
-Base.convert(T::Type{<:TracedRArray}, x::AbstractArray) = Reactant.promote_to(T, x)
+function Base.convert(T::Type{<:TracedRArray}, x::AbstractArray)
+    # non-concrete `T` (e.g. from `promote_typejoin` when collecting mixed-eltype
+    # traced arrays) has no `promote_to` methods; `x isa T` needs no conversion
+    x isa T && return x
+    return Reactant.promote_to(T, x)
+end
 
 # Base.complex
 Base.complex(x::TracedRArray{<:Real}) = complex.(x)

--- a/test/core/tracing.jl
+++ b/test/core/tracing.jl
@@ -455,3 +455,25 @@ end
         @test iszero(t.compile_time)
     end
 end
+
+function _sum_collected_mixed(a, b)
+    # on Julia 1.10/1.11 `collect` widens the eltype to the non-concrete
+    # `TracedRArray{<:Any,1}` via `promote_typejoin`
+    v = [x for x in (a, b)]
+    return sum(v[1]) + sum(v[2])
+end
+
+@testset "convert to non-concrete TracedRArray types" begin
+    x = Reactant.to_rarray(rand(Float32, 4))
+    x_tr = Reactant.make_tracer(Reactant.OrderedIdDict(), x, (), ConcreteToTraced)
+
+    @test convert(TracedRArray{Float32,1}, x_tr) === x_tr
+    @test convert(TracedRArray{<:Any,1}, x_tr) === x_tr
+    @test convert(TracedRArray, x_tr) === x_tr
+
+    a = rand(Float64, 4)
+    b = rand(Float32, 4)
+    a_ra = Reactant.to_rarray(a)
+    b_ra = Reactant.to_rarray(b)
+    @test @jit(_sum_collected_mixed(a_ra, b_ra)) ≈ sum(a) + sum(b)
+end


### PR DESCRIPTION
`Base.convert(T::Type{<:TracedRArray}, x::AbstractArray)` unconditionally
forwards to `promote_to`, which has methods for `TracedRArray`,
`TracedRArray{T}`, and `TracedRArray{T,N}` — but not for non-concrete
targets like `TracedRArray{<:Any,N}`. Julia produces exactly such targets
via `promote_typejoin` when `collect` widens over mixed-eltype traced
arrays (on 1.10/1.11, where inference-based `collect` falls back to
`grow_to!`/`push_widen`). The resulting `convert` call then throws a
`MethodError`, so an innocent comprehension like

```julia
v = [x for x in (a_f64, b_f32)]  # both TracedRArrays
```

fails during tracing. Without Reactant's `convert` override, Base's
generic `convert(::Type{T}, x::T) = x` would have handled this case; this
PR restores that behavior by returning `x` directly when `x isa T`.
Conversions between concrete traced types are unaffected (for those,
`promote_to` was already the identity whenever `x isa T` holds).

Relationship to other PRs:

- This is the root-cause follow-up to the CI failures on #3065, whose new
  mixed-eltype broadcast test was the first to collect heterogeneous
  traced arrays. #3065 now sidesteps the issue locally (tuples instead of
  `Vector`s in `elem_apply_via_while_loop[!]`) — a good change on its own —
  while this PR defuses the whole class for user code. No textual overlap;
  both apply independently.
- Independent of #3067 (tuple-returning broadcasts).

Tests: direct `convert` identity checks (including the previously-throwing
non-concrete target, which fails on all Julia versions without this fix)
plus a traced mixed-eltype `collect` regression test that exercises the
1.10/1.11 widening path on CI.

Created by generative AI.