### PR TITLE
[MLIR] print Type and Attribute as plain text

### DIFF
--- a/src/mlir/IR/Attribute.jl
+++ b/src/mlir/IR/Attribute.jl
@@ -911,7 +911,7 @@ Unlike [`show`](@ref), this emits just the attribute, which is what you want whe
 interpolating it into MLIR source text.
 """
 function Base.print(io::IO, attribute::Attribute)
-    c_print_callback = @cfunction(API.print_callback, Cvoid, (API.MlirStringRef, Any))
+    c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
     ref = Ref(io)
     API.mlirAttributePrint(attribute, c_print_callback, ref)
     return nothing

--- a/src/mlir/IR/Attribute.jl
+++ b/src/mlir/IR/Attribute.jl
@@ -903,11 +903,23 @@ function Base.getindex(attr::Attribute)
     end
 end
 
-function Base.show(io::IO, attribute::Attribute)
-    print(io, "Attribute(#= ")
-    c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
+"""
+    print(io, attribute)
+
+Print `attribute` in MLIR's textual form, e.g. `#aie<bd_dim_layout_array[]>`.
+Unlike [`show`](@ref), this emits just the attribute, which is what you want when
+interpolating it into MLIR source text.
+"""
+function Base.print(io::IO, attribute::Attribute)
+    c_print_callback = @cfunction(API.print_callback, Cvoid, (API.MlirStringRef, Any))
     ref = Ref(io)
     API.mlirAttributePrint(attribute, c_print_callback, ref)
+    return nothing
+end
+
+function Base.show(io::IO, attribute::Attribute)
+    print(io, "Attribute(#= ")
+    print(io, attribute)
     return print(io, " =#)")
 end
 

--- a/src/mlir/IR/Type.jl
+++ b/src/mlir/IR/Type.jl
@@ -869,7 +869,7 @@ this emits just the type, which is what you want when interpolating it into MLIR
 source text.
 """
 function Base.print(io::IO, type::Type)
-    c_print_callback = @cfunction(API.print_callback, Cvoid, (API.MlirStringRef, Any))
+    c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
     ref = Ref(io)
     API.mlirTypePrint(type, c_print_callback, ref)
     return nothing

--- a/src/mlir/IR/Type.jl
+++ b/src/mlir/IR/Type.jl
@@ -861,10 +861,22 @@ function julia_type(type::Type)
     end
 end
 
-function Base.show(io::IO, type::Type)
-    print(io, "Type(#= ")
-    c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
+"""
+    print(io, type)
+
+Print `type` in MLIR's textual form, e.g. `memref<1024xi32>`. Unlike [`show`](@ref),
+this emits just the type, which is what you want when interpolating it into MLIR
+source text.
+"""
+function Base.print(io::IO, type::Type)
+    c_print_callback = @cfunction(API.print_callback, Cvoid, (API.MlirStringRef, Any))
     ref = Ref(io)
     API.mlirTypePrint(type, c_print_callback, ref)
+    return nothing
+end
+
+function Base.show(io::IO, type::Type)
+    print(io, "Type(#= ")
+    print(io, type)
     return print(io, " =#)")
 end


### PR DESCRIPTION
Type and Attribute only had a show, which wraps the text as Type(#= ... =#),
leaving no way to obtain the plain MLIR form -- the one to interpolate into
source text, e.g. building !aie.objectfifo<memref<1024xi32>> around a memref
type. Add print for both and define show in terms of it.

Ref https://github.com/JuliaLLVM/MLIR.jl/pull/89

Co-Authored-By: Claude Opus 4.8 noreply@anthropic.com
