### PR TITLE
WIP: investigate stacked-batch forward AD

### DIFF
--- a/src/Enzyme.jl
+++ b/src/Enzyme.jl
@@ -325,6 +325,9 @@ function overload_autodiff(
     if width == 0
         throw(ErrorException("Cannot differentiate with a batch size of 0"))
     end
+    stacked_batch = any(
+        a -> a isa Union{StackedBatchDuplicated,StackedBatchDuplicatedNoNeed}, args
+    )
 
     primf = f.val
     primargs = ((v.val for v in args)...,)
@@ -494,6 +497,8 @@ function overload_autodiff(
     dresult = if CMode <: ForwardMode && !(A <: Const)
         if width == 1
             deepcopy(result)
+        elseif stacked_batch
+            nothing
         else
             ntuple(Val(width)) do i
                 Base.@_inline_meta
@@ -517,6 +522,13 @@ function overload_autodiff(
                 tval = TracedUtils.transpose_val(MLIR.IR.result(res, residx))
                 if width == 1
                     TracedUtils.set!(dresult, path[2:end], tval)
+                elseif stacked_batch
+                    dresult === nothing || throw(
+                        ArgumentError(
+                            "StackedBatchDuplicated currently requires a single array result."
+                        ),
+                    )
+                    dresult = TracedRArray(tval)
                 else
                     ttval = TracedRArray(tval)
                     for (i, sl) in enumerate(eachslice(ttval; dims=ndims(ttval)))

--- a/src/Interpreter.jl
+++ b/src/Interpreter.jl
@@ -85,7 +85,12 @@ end
         return Core.Compiler.abstract_call(interp, arginfo2::ArgInfo, si2, sv, max_methods)
     end
 
-    if !should_rewrite_call(Core.Typeof(f))
+    # `should_rewrite_call` is installed later in Reactant's initialization (after
+    # the traced types it inspects).  This callback can outlive that loading world,
+    # so evaluate the host-side predicate in the current world.
+    if !Core._call_in_world_total(
+        Base.get_world_counter(), should_rewrite_call, Core.Typeof(f)
+    )
         ninterp = Core.Compiler.NativeInterpreter(interp.world)
         # Note: mildly sus, but gabe said this was fine?
         @static if VERSION >= v"1.12"

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -104,6 +104,12 @@ include("xla/XLA.jl")
 include("Configuration.jl")
 include("Sharding.jl")
 include("Devices.jl")
+# `set_reactant_abi` in Interpreter.jl handles calls to these bindings. Declare them
+# before loading the interpreter so Julia's inference machinery sees stable globals.
+function call_with_reactant end
+function should_rewrite_call end
+struct EnsureReturnType{T} end
+
 include("Interpreter.jl")
 include("Profiler.jl")
 include("Types.jl")

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -391,6 +391,20 @@ function Base.copyto!(dest::AnyTracedRArray, src::Array)
     return copyto!(dest, Reactant.promote_to(TracedRArray, src))
 end
 
+_elementwise_apply(f, args...) = TracedUtils.elem_apply(f, args...)
+
+# `enzyme.batch` handles general broadcasted Julia functions.  Unary `tanh` has a
+# direct StableHLO operation, though, and keeping it as such lets Enzyme's forward
+# pass see its tensor shape instead of scalarizing a batched derivative.
+function _elementwise_tanh(x::AnyTracedRArray{<:AbstractFloat})
+    op = MLIR.Dialects.stablehlo.tanh(get_mlir_data(x))
+    return TracedRArray(MLIR.IR.result(op, 1))
+end
+_elementwise_apply(::typeof(Base.tanh), x::AnyTracedRArray{<:AbstractFloat}) =
+    _elementwise_tanh(x)
+_elementwise_apply(::typeof(Base.FastMath.tanh_fast), x::AnyTracedRArray{<:AbstractFloat}) =
+    _elementwise_tanh(x)
+
 function _copyto!(dest::AnyTracedRArray, bc::Broadcasted)
     axes(dest) == axes(bc) || Broadcast.throwdm(axes(dest), axes(bc))
     isempty(dest) && return dest
@@ -398,7 +412,7 @@ function _copyto!(dest::AnyTracedRArray, bc::Broadcasted)
 
     args = (Reactant.broadcast_to_size(Base.materialize(a), size(bc)) for a in bc.args)
 
-    res0 = TracedUtils.elem_apply(bc.f, args...)
+    res0 = _elementwise_apply(bc.f, args...)
     if !(res0 isa Reactant.TracedType)
         # `bc.f` returned a constant that does not depend on its arguments:
         res0 = Reactant.broadcast_to_size(res0, size(dest))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -119,8 +119,6 @@ function apply(f::F, args...; kwargs...) where {F}
     return f(args...; kwargs...)
 end
 
-function call_with_reactant end
-
 function maybe_argextype(@nospecialize(x), src)
     return try
         Core.Compiler.argextype(x, src)
@@ -377,8 +375,6 @@ function is_reactant_method(mi::Core.MethodInstance)
     mt = meth.external_mt
     return mt === REACTANT_METHOD_TABLE
 end
-
-struct EnsureReturnType{T} end
 
 @generated function applyiterate_with_reactant(
     ert::EnsureReturnType, iteratefn, applyfn, args::Vararg{Any,N}

--- a/test/core/autodiff.jl
+++ b/test/core/autodiff.jl
@@ -236,6 +236,23 @@ end
     @test res2[1][4] ≈ 8
     @test res2[1][5] ≈ 10
     @test res2[1][6] ≈ 12
+
+    # Keep the batch axis stacked through a broadcasted nonlinearity.  Splitting
+    # it into scalar slices leaves `enzyme.extract` operations that XLA cannot
+    # lower, while scalarizing `tanh` loses the batch axis during forward AD.
+    W = Float32[1 4; 2 5; 3 6]
+    b = Float32[1, 2, 3]
+    x_dense = Float32[1, 2]
+    dx_dense = Float32[1 0; 0 1]
+    W_ra, b_ra, x_dense_ra, dx_dense_ra = Reactant.to_rarray((W, b, x_dense, dx_dense))
+    dense_tanh(x) = tanh.(W_ra * x .+ b_ra)
+
+    dense_res = @jit Enzyme.autodiff(
+        Forward, dense_tanh, StackedBatchDuplicated(x_dense_ra, dx_dense_ra)
+    )
+    dense_primal = W * x_dense .+ b
+    dense_expected = (1 .- tanh.(dense_primal) .^ 2) .* W
+    @test only(dense_res) ≈ dense_expected
 end
 
 function fn2!(y, x)


### PR DESCRIPTION
## Status

**Incomplete; do not merge.** This draft records the Reactant-side reproducer and an initialization fix, but its direct `tanh` lowering is an MWE-specific workaround, not a general solution.

## Actual issue

Generic broadcasts are lowered through `enzyme.batch`. Combining that batching axis with Enzyme forward vector mode introduces a second independent batch axis. The current Enzyme MLIR/Enzyme-JAX lowering does not preserve that composition correctly, leading to rank mismatches such as `tensor<16xf32>` versus `tensor<4x16xf32>`.

A correct fix must make the `enzyme.batch` forward-AD lowering compose both axes for arbitrary scalar broadcast functions. It must not infer activity by evaluating a copied function or copied inputs (the unsound approach in #1822).

## Included regression

The dense-plus-`tanh` test is retained only as the original reproduction; it is insufficient as acceptance coverage. The final fix needs generic broadcast tests (at least multiple unary and binary scalar functions) that exercise the composed batch axes.

## Current check

```
JULIA_NUM_THREADS=1 julia --project=test --startup-file=no test/runtests.jl --jobs=1 core/autodiff
```