### PR TITLE
Fix ability of failing jobs to open issues

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,7 @@ permissions:
   statuses: read
   deployments: write # deployments permission to deploy GitHub pages website
   pull-requests: write
+  issues: write
 
 on:
   schedule:

--- a/.github/workflows/regenerate-mlir-bindings.yml
+++ b/.github/workflows/regenerate-mlir-bindings.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - uses: julia-actions/setup-julia@v3
         with:


### PR DESCRIPTION
see https://github.com/EnzymeAD/Reactant.jl/actions/runs/30055712154/job/89366797807

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Run jayqi/failed-build-issue-action@v1
Checking if label 'build failed' exists...
(node:9698) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:9698) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.
Finding latest open issue with label 'build failed'...
No open issue found.
Creating new issue...
[@octokit/request] "POST https://api.github.com/repos/EnzymeAD/Reactant.jl/issues" is deprecated. It is scheduled to be removed on Fri, 10 Mar 2028 00:00:00 GMT. See https://docs.github.com/en/rest/about-the-rest-api/api-versions
Error: Resource not accessible by integration
```