### PR TITLE
Unify julia cache key

### DIFF
--- a/.github/workflows/CommonCI.yml
+++ b/.github/workflows/CommonCI.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: julia-actions/cache@v3
         id: julia-cache
         with:
-          cache-name: julia-cache;workflow=${{ inputs.julia_version }}-${{ inputs.os }}-${{ inputs.runtime }}-assertions=${{ inputs.assertions }}-${{ github.event_name }}-${{ inputs.test_args }}-${{ inputs.downgrade_testing }}-${{ inputs.localjll || inputs.enzymejax_commit != '' }}-${{ inputs.enzymejax_commit }}
+          cache-name: julia-cache;workflow=${{ inputs.julia_version }}-${{ inputs.os }}-${{ inputs.runtime }}-assertions=${{ inputs.assertions }}-${{ inputs.downgrade_testing }}-${{ inputs.localjll || inputs.enzymejax_commit != '' }}-${{ inputs.enzymejax_commit }}
           gcp-bucket: ${{ contains(inputs.os, 'linux') && 'enzyme-ci-transient' || '' }}
 
       - uses: julia-actions/julia-downgrade-compat@v2


### PR DESCRIPTION
we shouldn't need different caches for different test args / events, right?

reason being that we evict the gh cache too much