### PR TITLE
Ignore sharding metadata when comparing user and XLA shardings

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -2648,9 +2648,36 @@ hlo_sharding_tile_assignment_devices(xla::HloSharding *hloSharding,
   }
 }
 
+static void clear_op_sharding_metadata(xla::OpSharding &op_sharding) {
+  op_sharding.clear_metadata();
+  for (auto &tuple_sharding : *op_sharding.mutable_tuple_shardings())
+    clear_op_sharding_metadata(tuple_sharding);
+}
+
+// Drops the metadata of `hlo_sharding`. Round-tripping through the proto (as
+// opposed to `xla::HloSharding::WithoutMetadata`) also drops the state derived
+// from the metadata, e.g. `xla::HloSharding::reduction_op` which XLA parses out
+// of the `sdy::reduction_op` metadata entry.
+static xla::HloSharding
+hlo_sharding_without_metadata(const xla::HloSharding &hlo_sharding) {
+  xla::OpSharding op_sharding = hlo_sharding.ToProto();
+  clear_op_sharding_metadata(op_sharding);
+  return MyValueOrThrow(xla::HloSharding::FromProto(op_sharding));
+}
+
 REACTANT_ABI bool hlo_sharding_check_eq(xla::HloSharding *hloSharding,
                                         xla::HloSharding *other) {
   return *hloSharding == *other;
+}
+
+// Same as `hlo_sharding_check_eq`, but only compares how the data is laid out
+// across the devices. In particular the metadata is ignored, which
+// `xla::HloSharding::operator==` takes into account through the reduction op.
+REACTANT_ABI bool
+hlo_sharding_check_eq_ignoring_metadata(xla::HloSharding *hloSharding,
+                                        xla::HloSharding *other) {
+  return hlo_sharding_without_metadata(*hloSharding) ==
+         hlo_sharding_without_metadata(*other);
 }
 
 #pragma endregion

--- a/src/compiler/Codegen.jl
+++ b/src/compiler/Codegen.jl
@@ -715,7 +715,11 @@ function assert_mismatched_sharding(
     hlo_sharding_from_executable::Reactant.XLA.HloSharding,
     _size_x,
 )
-    @assert hlo_sharding_from_executable == hlo_sharding_from_input "Sharding provided by the user ($(string(hlo_sharding_from_input))) does not match the sharding computed by XLA ($(string(hlo_sharding_from_executable))). This generally means that Reactant.jl made an error in generating the executable. Please open an issue with the error message and an MWE."
+    # The metadata is ignored on purpose: XLA attaches things like the shardy reduction op
+    # to the sharding it computes, which doesn't change how the data is laid out.
+    @assert Reactant.XLA.isequal_ignoring_metadata(
+        hlo_sharding_from_executable, hlo_sharding_from_input
+    ) "Sharding provided by the user ($(string(hlo_sharding_from_input))) does not match the sharding computed by XLA ($(string(hlo_sharding_from_executable))). This generally means that Reactant.jl made an error in generating the executable. Please open an issue with the error message and an MWE."
 end
 
 """

--- a/src/mlir/libMLIR_h.jl
+++ b/src/mlir/libMLIR_h.jl
@@ -15546,6 +15546,12 @@ function hlo_sharding_check_eq(hloSharding, other)
     )::Bool
 end
 
+function hlo_sharding_check_eq_ignoring_metadata(hloSharding, other)
+    @ccall mlir_c.hlo_sharding_check_eq_ignoring_metadata(
+        hloSharding::Ptr{HloSharding}, other::Ptr{HloSharding}
+    )::Bool
+end
+
 function ifrt_free_future(Future)
     @ccall mlir_c.ifrt_free_future(Future::Ptr{IfRtFutureType})::Cvoid
 end

--- a/src/xla/Sharding.jl
+++ b/src/xla/Sharding.jl
@@ -297,6 +297,21 @@ function Base.:(==)(hsharding1::HloSharding, hsharding2::HloSharding)
     end
 end
 
+"""
+    isequal_ignoring_metadata(hsharding1::HloSharding, hsharding2::HloSharding)
+
+Same as `hsharding1 == hsharding2`, but only compares how the data is laid out across the
+devices. In particular the metadata is ignored, which XLA takes into account through the
+reduction op (`sdy::reduction_op`).
+"""
+function isequal_ignoring_metadata(hsharding1::HloSharding, hsharding2::HloSharding)
+    GC.@preserve hsharding1 hsharding2 begin
+        return MLIR.API.hlo_sharding_check_eq_ignoring_metadata(
+            hsharding1.ptr, hsharding2.ptr
+        )
+    end
+end
+
 function free_hlo_sharding(hlo_sharding::HloSharding)
     GC.@preserve hlo_sharding begin
         MLIR.API.free_hlo_sharding(hlo_sharding.ptr)


### PR DESCRIPTION
The [Enzyme-JAX jax bump](https://github.com/EnzymeAD/Enzyme-JAX/actions/runs/30293798235/job/90069681247) fails a bunch of sharding tests with e.g.

```
AssertionError: Sharding provided by the user ({devices=[1,8]<=[8]}) does not match the sharding
computed by XLA ({devices=[1,8]<=[8] metadata={op_type="sdy::reduction_op" op_name="MAX"}}).
```

The only difference is the metadata: newer XLA parses a reduction op out of the `sdy::reduction_op` metadata entry (`HloSharding::ExtractReductionOpFromMetadata`) and compares `reduction_op_` in `xla::HloSharding::operator==`, so shardings that lay the data out identically now compare unequal.

Since that assertion only cares about how the data is laid out across devices, this adds a separate `hlo_sharding_check_eq_ignoring_metadata` C API (leaving `hlo_sharding_check_eq`/`==` untouched) which compares the two shardings after round-tripping them through the proto with the metadata cleared — that also clears the metadata-derived reduction op, which `HloSharding::WithoutMetadata` does not.

Note: the same CI job also hits `StackOverflowError`s inside XLA compilation for a few tests; those are a separate issue and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)