### PR TITLE
Pass the reduction op to sdyTensorShardingAttrGet

### DIFF
--- a/src/Sharding.jl
+++ b/src/Sharding.jl
@@ -4,6 +4,10 @@ module Sharding
 using ..Reactant: Reactant, XLA, MLIR, ShardyPropagationOptions
 using ReactantCore: ReactantCore
 
+# `mlir::sdy::ReductionOp::SUM`. The reduction op is only meaningful for shardings with
+# unreduced axes, which we never generate, so we always use the default `SUM`.
+const SDY_REDUCTION_OP_SUM = UInt32(0)
+
 """
     Mesh(devices::AbstractArray{XLA.AbstractDevice}, axis_names)
 
@@ -564,6 +568,7 @@ function get_tensor_sharding_attribute(
             MLIR.API.MlirAttribute[],
             0,
             MLIR.API.MlirAttribute[],
+            SDY_REDUCTION_OP_SUM,
         ),
     )
     return tensor_sharding_attr, :sdy

--- a/src/mlir/libMLIR_h.jl
+++ b/src/mlir/libMLIR_h.jl
@@ -13376,6 +13376,7 @@ function sdyTensorShardingAttrGet(
     replicatedAxes,
     nUnreducedAxes,
     unreducedAxes,
+    reductionOp,
 )
     @ccall mlir_c.sdyTensorShardingAttrGet(
         ctx::MlirContext,
@@ -13386,7 +13387,12 @@ function sdyTensorShardingAttrGet(
         replicatedAxes::Ptr{MlirAttribute},
         nUnreducedAxes::Cptrdiff_t,
         unreducedAxes::Ptr{MlirAttribute},
+        reductionOp::UInt32,
     )::MlirAttribute
+end
+
+function sdyTensorShardingAttrGetReductionOp(attr)
+    @ccall mlir_c.sdyTensorShardingAttrGetReductionOp(attr::MlirAttribute)::UInt32
 end
 
 function sdyTensorShardingAttrGetMeshOrRef(attr)


### PR DESCRIPTION
Root cause of most of the failures in the [Enzyme-JAX jax bump CI](https://github.com/EnzymeAD/Enzyme-JAX/actions/runs/30293798235/job/90069681247).

Shardy's C API is

```c
MLIR_CAPI_EXPORTED MlirAttribute sdyTensorShardingAttrGet(
    MlirContext ctx, MlirAttribute meshOrRef, intptr_t nDimShardings,
    const MlirAttribute* dimShardings, intptr_t nReplicatedAxes,
    const MlirAttribute* replicatedAxes, intptr_t nUnreducedAxes,
    const MlirAttribute* unreducedAxes, uint32_t reductionOp);
```

but our binding declares only the first 8 parameters, so the callee reads an uninitialized stack slot for `reductionOp` and does an unchecked `static_cast<sdy::ReductionOp>` on it (`SUM=0, MAX=1, MIN=2`). Every `sdy.sharding` attribute we build for a `NamedSharding` gets an arbitrary reduction op, varying by call site.

That was harmless until now because XLA ignored it. After the bump, `xla::HloSharding` carries a reduction op, `convertToHloSharding` reads `sdySharding.getReductionOp()`, and the op round-trips through the sharding metadata — which is exactly the junk showing up in the modules XLA is handed:

```mlir
%arg0: tensor<12x1024xi64> {mhlo.sharding = "{devices=[4,2]<=[2,4]T(1,0) metadata={op_type=\"sdy::reduction_op\" op_name=\"MAX\"}}", tf.aliasing_output = 0 : i32}
```

(taken from `module_001_reactant_dus2_post_xla_compile.mlir` in that job's artifacts; `MAX` on a plain input sharding is meaningless — XLA only emits a reduction op for `unreduced` shardings, and then it is `SUM`)

Consequences in that CI job:
- 8 `AssertionError: Sharding provided by the user ... does not match the sharding computed by XLA ...`, where the two shardings differ only by that metadata entry
- 3 `StackOverflowError`s inside the XLA compile, all on modules with a donated argument carrying the bogus reduction op (`Sharding with Mutation`, `DUS2`, `MultiRotate`)

The fix declares the parameter and always passes `SUM`, the correct value for a sharding with no unreduced axes. `sdyTensorShardingAttrGetReductionOp` is added as well since it was missing from the bindings.

I have not been able to run this locally (it needs a libReactant built against the new XLA), so the link from the bad reduction op to the stack overflow is inference from the dumped modules rather than something I reproduced. The bogus reduction op itself is confirmed by the C API signature and the dumps.

See also #3121, which makes the sharding assertion ignore metadata; with this fix that metadata should not appear in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)