### PR TITLE
Set TMPDIR inside the workspace on Windows CI too

### DIFF
--- a/.github/workflows/CommonCI.yml
+++ b/.github/workflows/CommonCI.yml
@@ -84,6 +84,23 @@ jobs:
           mkdir -p "$TMPDIR"
           echo "TMPDIR=$TMPDIR" >> $GITHUB_ENV
 
+      - name: Set TMPDIR and create directory (Windows)
+        # Same idea as the step above, but Julia's `tempdir()` goes through libuv's
+        # `uv_os_tmpdir`, which on Windows calls `GetTempPath` and so only consults
+        # TMP/TEMP -- TMPDIR alone would have no effect. Without this the temporary
+        # directory lives outside the workspace, and the "Upload MLIR modules" step
+        # below silently uploads nothing (`No files were found with the provided
+        # path: **/*.mlir`), which loses the module dumps written when a pass
+        # pipeline fails.
+        if: ${{ startsWith(inputs.os, 'windows-') }}
+        shell: pwsh
+        run: |
+          $tmp = Join-Path $env:GITHUB_WORKSPACE 'tmp'
+          New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+          "TMPDIR=$tmp" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "TMP=$tmp" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "TEMP=$tmp" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - uses: julia-actions/setup-julia@v3
         if: ${{ ! inputs.assertions }}
         with:


### PR DESCRIPTION
## Problem

The "Set TMPDIR and create directory" step in `CommonCI.yml` is gated on `if: ${{ !startsWith(inputs.os, 'windows-') }}`, so on Windows the temporary directory stays at `C:\Users\RUNNER~1\AppData\Local\Temp`.

When an MLIR pass pipeline fails, Reactant dumps the offending module there (`Pass.jl` uses `mktempdir(; prefix="reactant_", cleanup=false)`). That path is outside the workspace, so the `Upload MLIR modules` step matches nothing:

```
##[warning]No files were found with the provided path: **/*.mlir. No artifacts will be uploaded.
```

Every Windows occurrence of a pass-pipeline failure has therefore been throwing away its own reproducer. That is exactly what happened while debugging the `__real@3fe0000000000000` JIT failure — the module dump existed on the runner and was never uploaded.

## Fix

Add the Windows equivalent of the existing step.

One detail worth calling out: setting `TMPDIR` alone would do nothing on Windows. Julia's `tempdir()` calls libuv's `uv_os_tmpdir`, which on Windows is a `GetTempPath` wrapper, and `GetTempPath` only consults `TMP`, then `TEMP`, then `USERPROFILE` — it never looks at `TMPDIR`. So the new step sets all three.

Uses `pwsh` rather than `bash` because `$GITHUB_WORKSPACE` is a backslashed Windows path that Git Bash mangles.

## Checks

- Both workflow files parse as YAML, and the two TMPDIR steps have mutually exclusive `if:` conditions, so exactly one runs per job.
- The upload step's `**/*.mlir` glob is workspace-relative, which is what the new temp location makes reachable.
- CI on this PR is the real check: the Windows jobs should now surface `tmp/` inside the workspace, and any `.mlir` dumps should start appearing as artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)