### PR TITLE
Skip the CUDA precompile workload on Windows + Julia 1.11

### DIFF
--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1716,7 +1716,20 @@ end
         end
 
         @compile_workload begin
-            @static if Reactant.precompilation_supported() && VERSION != v"1.11.3"
+            # On Windows, Julia v1.11 cannot link the pkgimage this workload
+            # produces. Compiling a GPU kernel during precompilation leaves an
+            # unmarked reference to the `jl_boxed_uint8_cache` runtime global in
+            # the image, and since COFF has no import thunk for data, lld
+            # rejects it:
+            #     lld: error: undefined symbol: jl_boxed_uint8_cache
+            # ReactantCUDAExt then fails to precompile and never loads at all.
+            # Skipping the workload here only costs precompilation: any package
+            # compiling a GPU kernel in its own workload hits this too, so the
+            # actual fix has to come from Julia. Narrow the bound once a v1.11
+            # carrying that fix is released.
+            @static if Reactant.precompilation_supported() &&
+                VERSION != v"1.11.3" &&
+                !(Sys.iswindows() && v"1.11" <= VERSION < v"1.12")
                 function square_kernel!(x)
                     i = CUDA.threadIdx().x
                     x[i] *= x[i]

--- a/ext/ReactantCUDAExt.jl
+++ b/ext/ReactantCUDAExt.jl
@@ -1725,11 +1725,12 @@ end
             # ReactantCUDAExt then fails to precompile and never loads at all.
             # Skipping the workload here only costs precompilation: any package
             # compiling a GPU kernel in its own workload hits this too, so the
-            # actual fix has to come from Julia. Narrow the bound once a v1.11
-            # carrying that fix is released.
+            # actual fix has to come from Julia. The upper bound assumes that
+            # fix ships in the next v1.11 patch release, so that precompilation
+            # resumes on its own; raise it if it slips.
             @static if Reactant.precompilation_supported() &&
                 VERSION != v"1.11.3" &&
-                !(Sys.iswindows() && v"1.11" <= VERSION < v"1.12")
+                !(Sys.iswindows() && v"1.11" <= VERSION <= v"1.11.9")
                 function square_kernel!(x)
                     i = CUDA.threadIdx().x
                     x[i] *= x[i]


### PR DESCRIPTION
Workaround for the long-standing `test (1.11, windows-latest, integration)` failure. This has been red on every completed main run going back to at least 2026-07-14.

## What is broken

`ReactantCUDAExt` fails to **precompile** on Windows + Julia 1.11:

```
lld: error: undefined symbol: jl_boxed_uint8_cache
>>> referenced by jl_XXXX.tmp(text#0.o):(.refptr.jl_boxed_uint8_cache)
Error: Error during loading of extension ReactantCUDAExt of Reactant
```

The extension then never loads, so `Base.get_extension(Reactant, :ReactantCUDAExt)` returns `nothing` and every downstream test errors with `type Nothing has no field CuTracedRNumber`, `CUDA driver not functional`, or `CUDA.jl is not loaded`.

## Why

Compiling a GPU kernel during precompilation leaves an unmarked reference to the `jl_boxed_uint8_cache` runtime global in the pkgimage. COFF resolves an unmarked *function* through an import thunk, but data has no equivalent, and images are linked with `--disable-auto-import --disable-runtime-pseudo-reloc` — so one unmarked data reference fails the link.

Julia's `JuliaVariable::realize` marks these globals only at creation, and only when the module being emitted into targets Windows. An external consumer like GPUCompiler.jl drives codegen with its own module, so a global first realized there is created unmarked and keeps that form once modules are linked.

The evidence is visible inside a single object of the captured pkgimage: `jl_boxed_int8_cache` and `jl_boxed_uint8_cache` come from the same line of `load_i8box` and are declared identically, yet one is referenced as `__imp_jl_boxed_int8_cache` and the other as `.refptr.jl_boxed_uint8_cache`.

## This is a workaround, not a fix

A plain user package that compiles a GPU kernel in its own `@compile_workload` fails identically — I verified that in CI with the extension's own workload disabled. So gating here restores *our* extension and nothing else; users hitting it through their own packages get no benefit. The real fix belongs in Julia and is written but not yet released.

The bound is `v"1.11" <= VERSION <= v"1.11.9"` so that a subsequent 1.11 patch carrying the fix resumes precompiling automatically.

## Verification

Findings come from a 6-variant Windows CI probe rather than inspection: the precompile flags turned out to be irrelevant (a plain load reproduces, so this affects users and not just CI), and disabling this workload makes the extension link with zero lld errors. Locally I confirmed the gate parses, formats clean under the repo's `blue` style, and evaluates correctly — skipping on Windows 1.11.0–1.11.9 and running on Windows 1.11.10+, Windows 1.10/1.12, and all non-Windows platforms.

CI on this PR is the real check: `test (1.11, windows-latest, integration)` should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)