### PR TITLE
Stop KA ConcreteRArray allocation within compile

### DIFF
--- a/ext/ReactantKernelAbstractionsExt.jl
+++ b/ext/ReactantKernelAbstractionsExt.jl
@@ -25,7 +25,15 @@ function Base.getproperty(x::ReactantBackend, sym::Symbol)
 end
 
 function KA.allocate(::ReactantBackend, ::Type{T}, dims::Tuple) where {T}
-    return Reactant.ConcreteRArray{T}(undef, dims)
+    ET = Reactant.unwrapped_eltype(T)
+
+    # Inside a trace there is no uninitialized device memory to hand back, and a concrete array
+    # cannot take part in the traced program: filling or otherwise mutating one re-enters the
+    # compiler. Return a traced array instead, mirroring what `similar` already does when it is
+    # asked for a traced element type.
+    Reactant.within_compile() && return Reactant.Ops.fill(zero(ET), dims)
+
+    return Reactant.ConcreteRArray{ET}(undef, dims)
 end
 
 function KA.zeros(b::ReactantBackend, ::Type{T}, dims::Tuple) where {T}

--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -780,12 +780,24 @@ function Base.zero(x::ConcreteIFRTArray{T,N}) where {T,N}
     )
 end
 
+# `fill!` on a concrete array is implemented by compiling a `fill!` kernel and running it. Reached
+# from inside a trace, that compile step traces `fill!`, which lands back on the same method, and
+# the recursion is unbounded. It shows up whenever an array is allocated *during* tracing, since
+# allocation routines such as `KernelAbstractions.zeros` fill their result before returning it.
+#
+# Broadcast assignment lowers directly and does not re-enter `fill!`, so it is the traced path.
+@inline function fill_while_tracing!(a, val)
+    a .= val
+    return a
+end
+
 function Base.fill!(a::ConcretePJRTArray{<:TracedRNumber}, val::TracedRNumber)
     throw(MethodError(fill!, (a, val)))
 end
 
 function Base.fill!(a::ConcretePJRTArray{T,N}, val) where {T,N}
     isempty(a) && throw("Cannot setindex! to empty buffer")
+    within_compile() && return fill_while_tracing!(a, val)
 
     wait(a)
     if buffer_on_cpu(a) && !Sharding.is_sharded(a)
@@ -806,6 +818,7 @@ end
 
 function Base.fill!(a::ConcreteIFRTArray{T,N}, val) where {T,N}
     isempty(a) && throw("Cannot setindex! to empty buffer")
+    within_compile() && return fill_while_tracing!(a, val)
 
     fn = compile(fill!, (a, val))
     fn(a, val)
@@ -817,6 +830,8 @@ function Base.fill!(a::ConcreteIFRTArray{<:TracedRNumber}, val::TracedRNumber)
 end
 
 function Base.fill!(x::UnionAnyConcreteRArray, val)
+    within_compile() && return fill_while_tracing!(x, val)
+
     fn = compile(fill!, (x, val))
     fn(x, val)
     return x

--- a/src/ConcreteRArray.jl
+++ b/src/ConcreteRArray.jl
@@ -780,24 +780,12 @@ function Base.zero(x::ConcreteIFRTArray{T,N}) where {T,N}
     )
 end
 
-# `fill!` on a concrete array is implemented by compiling a `fill!` kernel and running it. Reached
-# from inside a trace, that compile step traces `fill!`, which lands back on the same method, and
-# the recursion is unbounded. It shows up whenever an array is allocated *during* tracing, since
-# allocation routines such as `KernelAbstractions.zeros` fill their result before returning it.
-#
-# Broadcast assignment lowers directly and does not re-enter `fill!`, so it is the traced path.
-@inline function fill_while_tracing!(a, val)
-    a .= val
-    return a
-end
-
 function Base.fill!(a::ConcretePJRTArray{<:TracedRNumber}, val::TracedRNumber)
     throw(MethodError(fill!, (a, val)))
 end
 
 function Base.fill!(a::ConcretePJRTArray{T,N}, val) where {T,N}
     isempty(a) && throw("Cannot setindex! to empty buffer")
-    within_compile() && return fill_while_tracing!(a, val)
 
     wait(a)
     if buffer_on_cpu(a) && !Sharding.is_sharded(a)
@@ -818,7 +806,6 @@ end
 
 function Base.fill!(a::ConcreteIFRTArray{T,N}, val) where {T,N}
     isempty(a) && throw("Cannot setindex! to empty buffer")
-    within_compile() && return fill_while_tracing!(a, val)
 
     fn = compile(fill!, (a, val))
     fn(a, val)
@@ -830,8 +817,6 @@ function Base.fill!(a::ConcreteIFRTArray{<:TracedRNumber}, val::TracedRNumber)
 end
 
 function Base.fill!(x::UnionAnyConcreteRArray, val)
-    within_compile() && return fill_while_tracing!(x, val)
-
     fn = compile(fill!, (x, val))
     fn(x, val)
     return x

--- a/test/integration/kernelabstractions.jl
+++ b/test/integration/kernelabstractions.jl
@@ -129,3 +129,45 @@ end
         ir
     end
 end
+
+# Scratch allocated *inside* a traced call must come back traced: a concrete array cannot take
+# part in the traced program. `KA.allocate` used to return a `ConcreteRArray` unconditionally, so
+# `KA.zeros` then hit `fill!` on it, which compiles a `fill!` kernel, which traces `fill!`, which
+# recursed until the stack overflowed. Asking for a traced element type failed even earlier, while
+# trying to build an XLA buffer whose elements were `TracedRNumber`s.
+#
+# This is the shape any backend-agnostic package hits when it allocates a temporary during a
+# traced call, so both element-type spellings are covered.
+
+@kernel function double_kernel!(y, @Const(x))
+    i = @index(Global)
+    @inbounds y[i] = 2 * x[i]
+end
+
+allocate_zeros(x, ::Type{T}) where {T} =
+    KernelAbstractions.zeros(KernelAbstractions.get_backend(x), T, size(x))
+
+function allocate_and_double(x, ::Type{T}) where {T}
+    backend = KernelAbstractions.get_backend(x)
+    y = allocate_zeros(x, T)
+    double_kernel!(backend)(y, x; ndrange=size(x))
+    return y
+end
+
+@testset "KernelAbstractions allocation within compile" begin
+    x = Reactant.to_rarray(Float64[1.0, 2.0, 3.0, 4.0])
+
+    # `eltype` of a traced array is `TracedRNumber{Float64}`, which has to be unwrapped before it
+    # can name a buffer element type, so both spellings are covered.
+    concrete_zeros(x) = allocate_zeros(x, Float64)
+    traced_zeros(x) = allocate_zeros(x, eltype(x))
+
+    @test Array(Reactant.@jit concrete_zeros(x)) ≈ zeros(4)
+    @test Array(Reactant.@jit traced_zeros(x)) ≈ zeros(4)
+
+    concrete_double(x) = allocate_and_double(x, Float64)
+    traced_double(x) = allocate_and_double(x, eltype(x))
+
+    @test Array(Reactant.@jit raise = true concrete_double(x)) ≈ 2 .* Array(x)
+    @test Array(Reactant.@jit raise = true traced_double(x)) ≈ 2 .* Array(x)
+end

--- a/test/integration/kernelabstractions.jl
+++ b/test/integration/kernelabstractions.jl
@@ -144,8 +144,9 @@ end
     @inbounds y[i] = 2 * x[i]
 end
 
-allocate_zeros(x, ::Type{T}) where {T} =
-    KernelAbstractions.zeros(KernelAbstractions.get_backend(x), T, size(x))
+function allocate_zeros(x, ::Type{T}) where {T}
+    return KernelAbstractions.zeros(KernelAbstractions.get_backend(x), T, size(x))
+end
 
 function allocate_and_double(x, ::Type{T}) where {T}
     backend = KernelAbstractions.get_backend(x)


### PR DESCRIPTION
```julia
using Reactant

y = Reactant.to_rarray(zeros(4))

f(x) = (fill!(y, 1.0); x .+ y)

x = Reactant.to_rarray(rand(4))

@compile f(x)
```
```
ERROR: LoadError: StackOverflowError:
Stacktrace:
     [1] _has_debugcache()
       @ Reactant.Compiler ~/.julia/packages/Reactant/NeviQ/src/compiler/Compiler.jl:1535
     [2] debugcache(; throw_error::Bool)
       @ Reactant.Compiler ~/.julia/packages/Reactant/NeviQ/src/compiler/Compiler.jl:1540
     [3] debugcache
       @ ~/.julia/packages/Reactant/NeviQ/src/compiler/Compiler.jl:1539 [inlined]
     [4] push_debug_stack!(fname::String, file::String, line::Int64)
       @ Reactant ~/.julia/packages/Reactant/NeviQ/src/utils.jl:682
     [5] call_with_reactant(::Reactant.EnsureReturnType{Any}, ::typeof(fill!), ::ConcreteIFRTArray{Float64, 1, Nothing}, ::Float64)
       @ Reactant ~/.julia/packages/Reactant/NeviQ/src/utils.jl:1195
     [6] fill!
       @ ~/.julia/packages/Reactant/NeviQ/src/ConcreteRArray.jl:811--- the above 2 lines are repeated 19992 more times ---
```