### PR TITLE
benchmark DG

### DIFF
--- a/benchmark/dg/Project.toml
+++ b/benchmark/dg/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[sources]
+Reactant = {path = "../.."}

--- a/benchmark/dg/runbenchmarks.jl
+++ b/benchmark/dg/runbenchmarks.jl
@@ -1,0 +1,124 @@
+using Reactant
+using BenchmarkTools
+using ArgParse
+
+include("volumerhs.jl")
+
+# XXX: Add to GPUArrays
+Base.one(A::CuArray) = CUDA.ones(eltype(A), size(A)...)
+
+s = ArgParseSettings()
+@add_arg_table! s begin
+    "N"
+    arg_type = Int
+    default = 4
+    "nmoist"
+    arg_type = Int
+    default = 0
+    "ntrace"
+    arg_type = Int
+    default = 0
+    "nelem"
+    arg_type = Int
+    default = 20_000
+    "--eltype"
+    help = "floating-point type (Float32 or Float64)"
+    arg_type = String
+    default = "Float32"
+    "--seed"
+    help = "random number generator seed for reproducibility"
+    arg_type = Int
+    default = 42
+    "--opt"
+    help = "optimization pass list (:all, :after_enzyme, ...)"
+    arg_type = String
+    default = "all"
+    "--backend"
+    help = "select Reactant backend (cpu, cuda, ...)"
+    arg_type = String
+    "--out"
+    help = "save benchmarks to file"
+    arg_type = String
+end
+parsed_args = parse_args(ARGS, s)
+
+N = parsed_args["N"]
+nmoist = parsed_args["nmoist"]
+ntrace = parsed_args["ntrace"]
+nelem = parsed_args["nelem"]
+DFloat = eval(Meta.parse(parsed_args["eltype"]))
+seed = parsed_args["seed"]
+optimize = Symbol(parsed_args["opt"])
+backend = parsed_args["backend"]
+out = parsed_args["out"]
+
+function workload!(rhs, Q, vgeo, grav, D, N, nmoist, ntrace)
+    @cuda volumerhs!(rhs, Q, vgeo, grav, D, N, nmoist, ntrace)
+end
+
+function diff_workload!(drhs, dQ, dvgeo, grav, dD, N, nmoist, ntrace)
+    @cuda dvolumerhs!(drhs, dQ, dvgeo, grav, dD, N, nmoist, ntrace)
+end
+
+@info "Initializing data..." N nmoist ntrace nelem DFloat seed
+
+rnd = MersenneTwister(seed)
+
+Nq = N + 1
+nvar = _nstate + nmoist + ntrace
+
+Q = 1 .+ rand(rnd, DFloat, Nq, Nq, Nq, nvar, nelem)
+Q[:, :, :, _E, :] .+= 20
+vgeo = rand(rnd, DFloat, Nq, Nq, Nq, _nvgeo, nelem)
+
+# Make sure the entries of the mass matrix satisfy the inverse relation
+vgeo[:, :, :, _MJ, :] .+= 3
+vgeo[:, :, :, _MJI, :] .= 1 ./ vgeo[:, :, :, _MJ, :]
+
+D = rand(rnd, DFloat, Nq, Nq)
+rhs = zeros(DFloat, Nq, Nq, Nq, nvar, nelem)
+
+# CUDA.limit!(CUDA.CU_LIMIT_MALLOC_HEAP_SIZE, 1*1024^3)
+# CUDA.cache_config!(CUDA.CU_FUNC_CACHE_PREFER_L1)
+
+# threads=(N+1, N+1)
+
+# @info "Starting Enzyme run"
+
+# Enzyme.API.EnzymeSetCLBool(:EnzymeRegisterReduce, true)
+# Enzyme.API.EnzymeSetCLString(:EnzymeBCPath, "/home/wmoses/git/Enzyme/enzyme/bclib")
+
+drhs  = Duplicated(rhs,  zero(rhs))
+drhs.dval[1, 1, 1, 2, 1:1] .= 1
+dQ    = Duplicated(Q,    zero(Q))
+dvgeo = Duplicated(vgeo, zero(vgeo))
+dD    = Duplicated(D,    zero(D))
+
+o1 = rhs[1, 1, 1, 2, 1:1]
+Q[1] += 1e-4
+rhs .= 0
+
+rhs_re = Reactant.to_rarray(rhs)
+D_re = Reactant.to_rarray(D)
+Q_re = Reactant.to_rarray(Q)
+vgeo_re = Reactant.to_rarray(vgeo)
+
+drhs_re = Reactant.to_rarray(drhs)
+dD_re = Reactant.to_rarray(dD)
+dQ_re = Reactant.to_rarray(dQ)
+dvgeo_re = Reactant.to_rarray(dvgeo)
+
+# @cuda dvolumerhs!(drhs, dQ, dvgeo, DFloat(grav), dD, Val(N), Val(nmoist), Val(ntrace))
+@info "Compiling..."
+t_primal = @elapsed f_re = @compile optimize=optimize sync=true raise=true workload!(rhs_re, Q_re, vgeo_re, DFloat(grav), D_re, Val(N), Val(nmoist), Val(ntrace))
+t_diff = @elapsed df_re = @compile optimize=optimize sync=true raise=true diff_workload!(drhs_re, dQ_re, dvgeo_re, DFloat(grav), dD_re, Val(N), Val(nmoist), Val(ntrace))
+
+@info "Correctness check..."
+# @cuda volumerhs!(rhs, Q, vgeo, DFloat(grav), D, Val(N), Val(nmoist), Val(ntrace))
+f_re(rhs_re, Q_re, vgeo_re, DFloat(grav), D_re, Val(N), Val(nmoist), Val(ntrace))
+o2 = rhs[1, 1, 1, 2, 1:1]
+@show dQ.dval[1], (o2-o1) / 1e-4
+
+@info "Benchmarking..."
+@benchmark $f_re($rhs_re, $Q_re, $vgeo_re, $DFloat($grav), $D_re, Val($N), Val($nmoist), Val($ntrace))
+@benchmark $df_re($drhs_re, $dQ_re, $dvgeo_re, $DFloat($grav), $dD_re, Val($N), Val($nmoist), Val($ntrace))

--- a/benchmark/dg/utils.jl
+++ b/benchmark/dg/utils.jl
@@ -1,0 +1,84 @@
+struct Unkown end
+struct PartialKnownDims{T, N, Dims, A} <: AbstractArray{T, N}
+    data::A
+    PartialKnownDims{Dims}(A) where Dims = new{eltype(A), ndims(A), Dims, typeof(A)}(A)
+end
+function Base.size(a::PartialKnownDims{T, N, Dims, A}) where {T, N, Dims, A}
+    dims = (Dims.parameters...,)
+    ntuple(Val(N)) do i
+        Base.@_inline_meta
+        st_dim = dims[i]
+        if st_dim isa Unkown
+            return size(a.data, i)
+        else
+            return st_dim
+        end
+    end
+end
+Base.eltype(a::PartialKnownDims) = eltype(a.data)
+Base.IndexStyle(::Type{<:PartialKnownDims}) = IndexLinear()
+
+Base.Experimental.Const(a::PartialKnownDims{T, N,Dims}) where {T, N, Dims} = PartialKnownDims{Dims}(Base.Experimental.Const(a.data))
+Base.@propagate_inbounds Base.getindex(a::PartialKnownDims, i) = Base.getindex(a.data, i)
+Base.@propagate_inbounds Base.setindex!(a::PartialKnownDims, val, i) = Base.setindex!(a.data, val, i)
+
+function loopinfo(name, expr, nodes...)
+    if expr.head != :for
+        error("Syntax error: pragma $name needs a for loop")
+    end
+    push!(expr.args[2].args, Expr(:loopinfo, nodes...))
+    return expr
+end
+
+if parse(Bool, get(ENV, "UNROLLING", "true"))
+    macro unroll(expr)
+        expr = loopinfo("@unroll", expr, (Symbol("llvm.loop.unroll.full"),))
+        return esc(expr)
+    end
+else
+    macro unroll(expr)
+        return esc(expr)
+    end
+end
+
+
+# Poor man's Cassette
+# Needed to get FMA
+for (jlf, f) in zip((:+, :*, :-), (:add, :mul, :sub))
+    for (T, llvmT) in ((Float32, "float"), (Float64, "double"))
+        ir = """
+            %x = f$f contract nsz $llvmT %0, %1
+            ret $llvmT %x
+        """
+        @eval begin
+            # the @pure is necessary so that we can constant propagate.
+            Base.@pure function $jlf(a::$T, b::$T)
+                Base.@_inline_meta
+                Base.llvmcall($ir, $T, Tuple{$T, $T}, a, b)
+            end
+        end
+    end
+    @eval function $jlf(args...)
+        Base.$jlf(args...)
+    end
+end
+
+let (jlf, f) = (:div_arcp, :div)
+    for (T, llvmT) in ((Float32, "float"), (Float64, "double"))
+        ir = """
+            %x = f$f fast $llvmT %0, %1
+            ret $llvmT %x
+        """
+        @eval begin
+            # the @pure is necessary so that we can constant propagate.
+            Base.@pure function $jlf(a::$T, b::$T)
+                @Base._inline_meta
+                Base.llvmcall($ir, $T, Tuple{$T, $T}, a, b)
+            end
+        end
+    end
+    @eval function $jlf(args...)
+        Base.$jlf(args...)
+    end
+end
+rcp(x) = div_arcp(one(x), x) # still leads to rcp.rn which is also a function call

--- a/benchmark/dg/volumerhs.jl
+++ b/benchmark/dg/volumerhs.jl
@@ -1,0 +1,180 @@
+using CUDA
+using Random
+using Enzyme
+using StaticArrays
+
+include("utils.jl")
+
+# note the order of the fields below is also assumed in the code.
+const _nstate = 5
+const _ρ, _U, _V, _W, _E = 1:_nstate
+const stateid = (ρ = _ρ, U = _U, V = _V, W = _W, E = _E)
+
+const _nvgeo = 14
+const _ξx, _ηx, _ζx, _ξy, _ηy, _ζy, _ξz, _ηz, _ζz, _MJ, _MJI,
+_x, _y, _z = 1:_nvgeo
+const vgeoid = (ξx = _ξx, ηx = _ηx, ζx = _ζx,
+                ξy = _ξy, ηy = _ηy, ζy = _ζy,
+                ξz = _ξz, ηz = _ηz, ζz = _ζz,
+                MJ = _MJ, MJI = _MJI,
+                x = _x,   y = _y,   z = _z)
+
+Base.@irrational grav 9.81 BigFloat(9.81)
+Base.@irrational gdm1 0.4 BigFloat(0.4)
+
+function volumerhs!(rhs, Q, vgeo, gravity, D, ::Val{N}, ::Val{nmoist}, ::Val{ntrace}) where {N, nmoist, ntrace}
+    Nq = N + 1
+    nvar = _nstate + nmoist + ntrace
+
+    rhs = PartialKnownDims{Tuple{Nq, Nq, Nq, nvar, Unkown()}}(rhs)
+
+    Q = PartialKnownDims{Tuple{Nq, Nq, Nq, nvar, Unkown()}}(Q)
+    Q = Base.Experimental.Const(Q)
+
+    vgeo = PartialKnownDims{Tuple{Nq, Nq, Nq, _nvgeo, Unkown()}}(vgeo)
+    vgeo = Base.Experimental.Const(vgeo)
+
+    D = PartialKnownDims{Tuple{Nq, Nq}}(D)
+    D = Base.Experimental.Const(D)
+
+    s_D = @cuStaticSharedMem eltype(D) (Nq, Nq)
+    s_F = @cuStaticSharedMem eltype(Q) (Nq, Nq, _nstate)
+    s_G = @cuStaticSharedMem eltype(Q) (Nq, Nq, _nstate)
+
+    r_rhsρ = MArray{Tuple{Nq}, eltype(rhs)}(undef)
+    r_rhsU = MArray{Tuple{Nq}, eltype(rhs)}(undef)
+    r_rhsV = MArray{Tuple{Nq}, eltype(rhs)}(undef)
+    r_rhsW = MArray{Tuple{Nq}, eltype(rhs)}(undef)
+    r_rhsE = MArray{Tuple{Nq}, eltype(rhs)}(undef)
+
+    e = blockIdx().x
+    j = threadIdx().y
+    i = threadIdx().x
+
+    @inbounds begin
+        for k in 1:Nq
+            r_rhsρ[k] = zero(eltype(rhs))
+            r_rhsU[k] = zero(eltype(rhs))
+            r_rhsV[k] = zero(eltype(rhs))
+            r_rhsW[k] = zero(eltype(rhs))
+            r_rhsE[k] = zero(eltype(rhs))
+        end
+
+        # fetch D into shared
+        s_D[i, j] = D[i, j]
+        # let k = 1
+        @unroll for k in 1:Nq
+            sync_threads()
+
+            # Load values will need into registers
+            MJ = vgeo[i, j, k, _MJ, e]
+            ξx, ξy, ξz = vgeo[i,j,k,_ξx,e], vgeo[i,j,k,_ξy,e], vgeo[i,j,k,_ξz,e]
+            ηx, ηy, ηz = vgeo[i,j,k,_ηx,e], vgeo[i,j,k,_ηy,e], vgeo[i,j,k,_ηz,e]
+            ζx, ζy, ζz = vgeo[i,j,k,_ζx,e], vgeo[i,j,k,_ζy,e], vgeo[i,j,k,_ζz,e]
+            z = vgeo[i,j,k,_z,e]
+
+            U, V, W = Q[i, j, k, _U, e], Q[i, j, k, _V, e], Q[i, j, k, _W, e]
+            ρ, E = Q[i, j, k, _ρ, e], Q[i, j, k, _E, e]
+
+            # GPU performance trick
+            # Allow optimizations to use the reciprocal of an argument rather than perform division.
+            # IEEE floating-point division is implemented as a function call
+            ρinv = rcp(ρ)
+            ρ2inv = rcp(2ρ)
+            # ρ2inv = 0.5f0 * pinv
+
+            P = gdm1*(E - (U^2 + V^2 + W^2)*ρ2inv - ρ*gravity*z)
+
+            fluxρ_x = U
+            fluxU_x = ρinv * U * U + P
+            fluxV_x = ρinv * U * V
+            fluxW_x = ρinv * U * W
+            fluxE_x = ρinv * U * (E + P)
+
+            fluxρ_y = V
+            fluxU_y = ρinv * V * U
+            fluxV_y = ρinv * V * V + P
+            fluxW_y = ρinv * V * W
+            fluxE_y = ρinv * V * (E + P)
+
+            fluxρ_z = W
+            fluxU_z = ρinv * W * U
+            fluxV_z = ρinv * W * V
+            fluxW_z = ρinv * W * W + P
+            fluxE_z = ρinv * W * (E + P)
+
+            s_F[i, j,  _ρ] = MJ * (ξx * fluxρ_x + ξy * fluxρ_y + ξz * fluxρ_z)
+            s_F[i, j,  _U] = MJ * (ξx * fluxU_x + ξy * fluxU_y + ξz * fluxU_z)
+            s_F[i, j,  _V] = MJ * (ξx * fluxV_x + ξy * fluxV_y + ξz * fluxV_z)
+            s_F[i, j,  _W] = MJ * (ξx * fluxW_x + ξy * fluxW_y + ξz * fluxW_z)
+            s_F[i, j,  _E] = MJ * (ξx * fluxE_x + ξy * fluxE_y + ξz * fluxE_z)
+
+            s_G[i, j,  _ρ] = MJ * (ηx * fluxρ_x + ηy * fluxρ_y + ηz * fluxρ_z)
+            s_G[i, j,  _U] = MJ * (ηx * fluxU_x + ηy * fluxU_y + ηz * fluxU_z)
+            s_G[i, j,  _V] = MJ * (ηx * fluxV_x + ηy * fluxV_y + ηz * fluxV_z)
+            s_G[i, j,  _W] = MJ * (ηx * fluxW_x + ηy * fluxW_y + ηz * fluxW_z)
+            s_G[i, j,  _E] = MJ * (ηx * fluxE_x + ηy * fluxE_y + ηz * fluxE_z)
+
+            r_Hρ = MJ * (ζx * fluxρ_x + ζy * fluxρ_y + ζz * fluxρ_z)
+            r_HU = MJ * (ζx * fluxU_x + ζy * fluxU_y + ζz * fluxU_z)
+            r_HV = MJ * (ζx * fluxV_x + ζy * fluxV_y + ζz * fluxV_z)
+            r_HW = MJ * (ζx * fluxW_x + ζy * fluxW_y + ζz * fluxW_z)
+            r_HE = MJ * (ζx * fluxE_x + ζy * fluxE_y + ζz * fluxE_z)
+
+            # one shared access per 10 flops
+            for n = 1:Nq
+                Dkn = s_D[k, n]
+
+                r_rhsρ[n] += Dkn * r_Hρ
+                r_rhsU[n] += Dkn * r_HU
+                r_rhsV[n] += Dkn * r_HV
+                r_rhsW[n] += Dkn * r_HW
+                r_rhsE[n] += Dkn * r_HE
+            end
+
+            r_rhsW[k] -= MJ * ρ * gravity
+
+            sync_threads()
+
+            # loop of ξ-grid lines
+            @unroll for n = 1:Nq
+                Dni = s_D[n, i]
+                Dnj = s_D[n, j]
+
+                r_rhsρ[k] += Dni * s_F[n, j, _ρ]
+                r_rhsρ[k] += Dnj * s_G[i, n, _ρ]
+
+                r_rhsU[k] += Dni * s_F[n, j, _U]
+                r_rhsU[k] += Dnj * s_G[i, n, _U]
+
+                r_rhsV[k] += Dni * s_F[n, j, _V]
+                r_rhsV[k] += Dnj * s_G[i, n, _V]
+
+                r_rhsW[k] += Dni * s_F[n, j, _W]
+                r_rhsW[k] += Dnj * s_G[i, n, _W]
+
+                r_rhsE[k] += Dni * s_F[n, j, _E]
+                r_rhsE[k] += Dnj * s_G[i, n, _E]
+            end
+        end # k
+
+        @unroll for k in 1:Nq
+            MJI = vgeo[i, j, k, _MJI, e]
+
+            # Updates are a performance bottleneck
+            # primary source of stall_long_sb
+            rhs[i, j, k, _U, e] += MJI*r_rhsU[k]
+            rhs[i, j, k, _V, e] += MJI*r_rhsV[k]
+            rhs[i, j, k, _W, e] += MJI*r_rhsW[k]
+            rhs[i, j, k, _ρ, e] += MJI*r_rhsρ[k]
+            rhs[i, j, k, _E, e] += MJI*r_rhsE[k]
+        end
+    end
+    return nothing
+end
+
+
+function dvolumerhs!(rhs, Q, vgeo, grav, D, N, nmoist, ntrace)
+    Enzyme.autodiff_no_cassette(volumerhs!, rhs, Q, vgeo, grav, D, N, nmoist, ntrace)
+    return nothing
+end


### PR DESCRIPTION
currently trying to figure out why it gives the following error

```julia
ERROR: InvalidIRError: compiling MethodInstance for volumerhs!(::ReactantCUDAExt.CuTracedArray{…}, ::ReactantCUDAExt.CuTracedArray{…}, ::ReactantCUDAExt.CuTracedArray{…}, ::Float32, ::ReactantCUDAExt.CuTracedArray{…}, ::Val{…}, ::Val{…}, ::Val{…}) resulted in invalid LLVM IR
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:70
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:71
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:72
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:73
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:74
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:76
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:77
Reason: unsupported dynamic function invocation (call to rcp)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:82
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:83
Reason: unsupported dynamic function invocation (call to rcp)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:83
Reason: unsupported dynamic function invocation (call to literal_pow)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:86
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:86
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:86
Reason: unsupported dynamic function invocation (call to -)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:86
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:89
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:89
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:90
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:91
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:92
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:92
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:95
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:96
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:96
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:97
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:98
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:98
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:101
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:102
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:103
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:103
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:104
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:104
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:106
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:106
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:106
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:107
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:107
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:107
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:108
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:108
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:108
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:109
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:109
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:109
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:110
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:110
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:110
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:112
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:112
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:112
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:113
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:113
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:113
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:114
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:114
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:114
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:115
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:115
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:115
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:116
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:116
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:177
 [2] setindex!
   @ ~/.julia/packages/CUDACore/NlVPI/src/device/array.jl:189
 [3] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:116
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:118
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:118
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:119
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:119
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:120
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:120
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:121
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:121
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:122
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:122
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:128
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:128
Reason: unsupported dynamic function invocation (call to setindex!)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:128
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:129
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:129
Reason: unsupported dynamic function invocation (call to setindex!)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:129
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:130
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:130
Reason: unsupported dynamic function invocation (call to setindex!)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:130
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:131
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:131
Reason: unsupported dynamic function invocation (call to setindex!)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:131
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:132
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:132
Reason: unsupported dynamic function invocation (call to setindex!)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:132
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:135
Reason: unsupported dynamic function invocation (call to -)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:135
Reason: unsupported dynamic function invocation (call to setindex!)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:135
Reason: unsupported dynamic function invocation (call to _getindex(::IndexLinear, A::AbstractArray, I::Vararg{Int64, M}) where M @ Base abstractarray.jl:1368)
Stacktrace:
 [1] getindex
   @ ./abstractarray.jl:1342
 [2] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:162
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:166
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:166
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:420
 [2] setindex!
   @ ~/Reactant.jl/benchmark/dg/utils.jl:23
 [3] _setindex!
   @ ./abstractarray.jl:1466
 [4] setindex!
   @ ./abstractarray.jl:1443
 [5] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:166
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:167
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:167
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:420
 [2] setindex!
   @ ~/Reactant.jl/benchmark/dg/utils.jl:23
 [3] _setindex!
   @ ./abstractarray.jl:1466
 [4] setindex!
   @ ./abstractarray.jl:1443
 [5] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:167
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:168
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:168
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:420
 [2] setindex!
   @ ~/Reactant.jl/benchmark/dg/utils.jl:23
 [3] _setindex!
   @ ./abstractarray.jl:1466
 [4] setindex!
   @ ./abstractarray.jl:1443
 [5] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:168
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:169
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:169
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:420
 [2] setindex!
   @ ~/Reactant.jl/benchmark/dg/utils.jl:23
 [3] _setindex!
   @ ./abstractarray.jl:1466
 [4] setindex!
   @ ./abstractarray.jl:1443
 [5] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:169
Reason: unsupported dynamic function invocation (call to *)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:170
Reason: unsupported dynamic function invocation (call to +)
Stacktrace:
 [1] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:170
Reason: unsupported dynamic function invocation (call to convert)
Stacktrace:
 [1] setindex!
   @ /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:420
 [2] setindex!
   @ ~/Reactant.jl/benchmark/dg/utils.jl:23
 [3] _setindex!
   @ ./abstractarray.jl:1466
 [4] setindex!
   @ ./abstractarray.jl:1443
 [5] volumerhs!
   @ ~/Reactant.jl/benchmark/dg/volumerhs.jl:170
Hint: catch this exception as `err` and call `code_typed(err; interactive = true)` to introspect the erroneous code with Cthulhu.jl
Stacktrace:
  [1] (::ReactantCUDAExt.var"#compile##0#compile##1"{GPUCompiler.CompilerJob{…}})(ctx::LLVM.Context)
    @ ReactantCUDAExt /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:793
  [2] JuliaContext(f::ReactantCUDAExt.var"#compile##0#compile##1"{GPUCompiler.CompilerJob{…}}; kwargs::@Kwargs{})
    @ GPUCompiler ~/.julia/packages/GPUCompiler/BSi1T/src/driver.jl:34
  [3] JuliaContext
    @ ~/.julia/packages/GPUCompiler/BSi1T/src/driver.jl:25 [inlined]
  [4] compile(job::GPUCompiler.CompilerJob{GPUCompiler.PTXCompilerTarget, ReactantCUDAExt.ReactantCUDACompilerParams})
    @ ReactantCUDAExt /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:703
  [5] actual_compilation(cache::Dict{…}, src::Core.MethodInstance, world::UInt64, cfg::GPUCompiler.CompilerConfig{…}, compiler::typeof(ReactantCUDAExt.compile), linker::typeof(ReactantCUDAExt.link))
    @ GPUCompiler ~/.julia/packages/GPUCompiler/BSi1T/src/execution.jl:245
  [6] cached_compilation(cache::Dict{…}, src::Core.MethodInstance, cfg::GPUCompiler.CompilerConfig{…}, compiler::Function, linker::Function)
    @ GPUCompiler ~/.julia/packages/GPUCompiler/BSi1T/src/execution.jl:159
  [7] macro expansion
    @ /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:1585 [inlined]
  [8] macro expansion
    @ ./lock.jl:376 [inlined]
  [9] cufunction(f::typeof(volumerhs!), tt::Type{Tuple{…}}; kwargs::@Kwargs{})
    @ ReactantCUDAExt /mnt2/mofeing/Reactant.jl/ext/ReactantCUDAExt.jl:1548
 [10] kernel_compile
    @ ~/.julia/packages/CUDACore/NlVPI/src/compiler/execution.jl:60
 [11] call_with_reactant
    @ ./none:-1 [inlined]
 [12] call_with_reactant(::Reactant.EnsureReturnType{…}, ::typeof(CUDACore.kernel_compile), ::CUDACore.LLVMBackend, ::typeof(volumerhs!), ::Type{…})
    @ Reactant /mnt2/mofeing/Reactant.jl/src/utils.jl:0
 [13] macro expansion
    @ ~/.julia/packages/CUDACore/NlVPI/src/compiler/execution.jl:183 [inlined]
 [14] workload!
    @ ~/Reactant.jl/benchmark/dg/runbenchmarks.jl:56
 [15] call_with_reactant
    @ ./none:-1 [inlined]
 [16] call_with_reactant(::typeof(workload!), ::Reactant.TracedRArray{…}, ::Reactant.TracedRArray{…}, ::Reactant.TracedRArray{…}, ::Float32, ::Reactant.TracedRArray{…}, ::Val{…}, ::Val{…}, ::Val{…})
    @ Reactant /mnt2/mofeing/Reactant.jl/src/utils.jl:0
 [17] make_mlir_fn(f::typeof(workload!), args::Tuple{…}, kwargs::@NamedTuple{}, name::String, concretein::Bool; toscalar::Bool, return_dialect::Symbol, args_in_result::Symbol, construct_function_without_args::Bool, do_transpose::Bool, within_autodiff::Bool, input_shardings::Nothing, output_shardings::Nothing, runtime::Val{…}, verify_arg_names::Nothing, argprefix::Symbol, resprefix::Symbol, resargprefix::Symbol, num_replicas::Int64, optimize_then_pad::Bool)
    @ Reactant.TracedUtils /mnt2/mofeing/Reactant.jl/src/TracedUtils.jl:376
 [18] make_mlir_fn
    @ /mnt2/mofeing/Reactant.jl/src/TracedUtils.jl:299 [inlined]
 [19] compile_mlir!(mod::Reactant.MLIR.IR.Module, f::typeof(workload!), args::Tuple{…}, compile_options::CompileOptions, debugcache::Vector{…}, callcache::Dict{…}, sdycache::Dict{…}, sdygroupidcache::Tuple{…}; fn_kwargs::@NamedTuple{}, backend::String, runtime::Val{…}, legalize_stablehlo_to_mhlo::Bool, client::Reactant.XLA.PJRT.Client, kwargs::@Kwargs{})
    @ Reactant.Compiler /mnt2/mofeing/Reactant.jl/src/compiler/Compiler.jl:279
 [20] compile_xla(ctx::Reactant.MLIR.IR.Context, f::Function, args::Tuple{…}; before_xla_optimizations::Bool, client::Nothing, serializable::Bool, kwargs::@Kwargs{…})
    @ Reactant.Compiler /mnt2/mofeing/Reactant.jl/src/compiler/Compiler.jl:1289
 [21] compile_xla
    @ /mnt2/mofeing/Reactant.jl/src/compiler/Compiler.jl:1264 [inlined]
 [22] compile(ctx::Reactant.MLIR.IR.Context, f::Function, args::Tuple{…}; kwargs::@Kwargs{…})
    @ Reactant.Compiler /mnt2/mofeing/Reactant.jl/src/compiler/Compiler.jl:1381
 [23] macro expansion
    @ /mnt2/mofeing/Reactant.jl/src/compiler/Macros.jl:256 [inlined]
 [24] macro expansion
    @ ~/.julia/packages/LLVM/acmxC/src/base.jl:113 [inlined]
 [25] macro expansion
    @ /mnt2/mofeing/Reactant.jl/src/compiler/Macros.jl:255 [inlined]
 [26] top-level scope
    @ ./timing.jl:461
Some type information was truncated. Use `show(err)` to see complete types.
```