### PR TITLE
Add Ops.geqrf and Ops.orgqr for QR factorization

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -14,6 +14,7 @@ using ..Reactant:
     unwrapped_eltype
 using ReactantCore: ReactantCore
 using GPUArraysCore: GPUArraysCore
+using LinearAlgebra: BlasInt
 
 const GELU_APPROXIMATION_MAP = Dict(
     "NONE" => MLIR.API.ENZYMEXLA_GELU_APPROXIMATION_NONE,
@@ -3963,6 +3964,101 @@ end
     end
 
     return U, S, Vt, info
+end
+
+"""
+    geqrf(
+        x::TracedRArray{T,N};
+        location=mlir_stacktrace("geqrf", @__FILE__, @__LINE__)
+    ) where {T,N}
+
+Compute the unpivoted QR factorization of `x` using Householder reflections, and return the
+factors in LAPACK's packed format, the `tau` vector of reflector scalings, and `info`.
+
+The last two dimensions of `x` are the matrix dimensions; any leading dimensions are batch
+dimensions. For an `m × n` matrix the returned `factors` has the same shape as `x` -- its
+upper triangle is `R` and the reflectors are stored in the strict lower triangle -- and
+`tau` has length `min(m, n)`. `info` is always a scalar, even for batched inputs.
+
+Use [`orgqr`](@ref) to materialize `Q` from `factors` and `tau`.
+
+!!! note
+
+    Batched (`N > 2`) inputs are only supported on the CUDA and TPU backends; the CPU
+    lowering of `enzymexla.lapack.geqrf` does not handle batch dimensions yet.
+"""
+@noinline function geqrf(
+    x::TracedRArray{T,N}; location=mlir_stacktrace("geqrf", @__FILE__, @__LINE__)
+) where {T,N}
+    @assert N >= 2
+
+    batch_shape = size(x)[1:(end - 2)]
+    m, n = size(x)[(end - 1):end]
+    tau_shape = (batch_shape..., min(m, n))
+
+    # NOTE: the CPU lowering of `enzymexla.lapack.geqrf` hardcodes these result types
+    # (packed factors with the same shape as the input, `tau` of length `min(m, n)` and a
+    # rank-0 `BlasInt` `info`) and replaces the op's uses with values of those types, so
+    # they must be declared exactly like this.
+    op = enzymexla.lapack_geqrf(
+        x.mlir_data;
+        output=mlir_type(TracedRArray{T,N}, size(x)),
+        tau=mlir_type(TracedRArray{T,N - 1}, tau_shape),
+        info=mlir_type(TracedRNumber{BlasInt}),
+        location,
+    )
+
+    factors = TracedRArray{T,N}((), MLIR.IR.result(op, 1), size(x))
+    tau = TracedRArray{T,N - 1}((), MLIR.IR.result(op, 2), tau_shape)
+    info = TracedRNumber{BlasInt}((), MLIR.IR.result(op, 3))
+
+    return factors, tau, info
+end
+
+"""
+    orgqr(
+        x::TracedRArray{T,N},
+        tau::TracedRArray{T,M};
+        location=mlir_stacktrace("orgqr", @__FILE__, @__LINE__)
+    ) where {T,N,M}
+
+Materialize the orthogonal (unitary for complex `T`) factor `Q` from the packed `factors`
+and `tau` returned by [`geqrf`](@ref). The result has the same shape as `x`.
+
+`x` must have at least as many rows as columns, and `tau` must have exactly one entry per
+column of `x`. To obtain `Q` for a wide `m × n` matrix (`m < n`), first slice the packed
+factors down to their leading `m` columns.
+
+!!! note
+
+    Batched (`N > 2`) inputs are only supported on the CUDA and TPU backends.
+"""
+@noinline function orgqr(
+    x::TracedRArray{T,N},
+    tau::TracedRArray{T,M};
+    location=mlir_stacktrace("orgqr", @__FILE__, @__LINE__),
+) where {T,N,M}
+    @assert N >= 2
+    @assert M == N - 1
+    @assert size(x)[1:(end - 2)] == size(tau)[1:(end - 1)] "x and tau must have the same \
+                                                            batch dimensions"
+    # The CPU lowering derives the number of reflectors from the column count of `x`, while
+    # cuSOLVER derives it from `tau`. Requiring a tall (or square) `x` with one `tau` entry
+    # per column makes both interpretations agree.
+    @assert size(x, N - 1) >= size(x, N) "orgqr requires a tall or square input; slice the \
+                                          packed factors to their leading rows first"
+    @assert size(x, N) == size(tau, M) "tau must have one entry per column of x"
+
+    res = MLIR.IR.result(
+        enzymexla.lapack_orgqr(
+            x.mlir_data,
+            tau.mlir_data;
+            output=mlir_type(TracedRArray{T,N}, size(x)),
+            location,
+        ),
+        1,
+    )
+    return TracedRArray{T,N}((), res, size(x))
 end
 
 @noinline function reduce_window(

--- a/src/Overlay.jl
+++ b/src/Overlay.jl
@@ -345,6 +345,42 @@ for (jlop, rop, default_pivot) in (
     end
 end
 
+## `qr` needs its own loop: `LinearAlgebra.qr(A, pivot)` accepts both `NoPivot` and
+## `ColumnNorm`, and the `ColumnNorm` arm has to be intercepted too so that our error
+## surfaces instead of native `geqp3!` running on traced elements.
+for (jlop, rop) in ((:qr, :overloaded_qr), (:qr!, :overloaded_qr))
+    @eval begin
+        @reactant_overlay function LinearAlgebra.$(jlop)(x::AbstractArray; kwargs...)
+            if use_overlayed_version(x)
+                pivot = NoPivot()
+                return call_with_native(
+                    TracedLinearAlgebra.$(rop),
+                    factorization_copy(LinearAlgebra.$(jlop), x, pivot),
+                    pivot;
+                    kwargs...,
+                )
+            else
+                return call_with_native(LinearAlgebra.$(jlop), x; kwargs...)
+            end
+        end
+
+        @reactant_overlay function LinearAlgebra.$(jlop)(
+            x::AbstractArray, pivot::Union{NoPivot,ColumnNorm}; kwargs...
+        )
+            if use_overlayed_version(x)
+                return call_with_native(
+                    TracedLinearAlgebra.$(rop),
+                    factorization_copy(LinearAlgebra.$(jlop), x, pivot),
+                    pivot;
+                    kwargs...,
+                )
+            else
+                return call_with_native(LinearAlgebra.$(jlop), x, pivot; kwargs...)
+            end
+        end
+    end
+end
+
 for (jlop, rop) in ((:svd, :overloaded_svd),)
     @eval begin
         @reactant_overlay function LinearAlgebra.$(jlop)(x::AbstractArray; kwargs...)

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -9,7 +9,7 @@ using ReactantCore:
     Periodic,
     Binomial
 
-using LinearAlgebra: LinearAlgebra, RowMaximum, NoPivot
+using LinearAlgebra: LinearAlgebra, RowMaximum, NoPivot, ColumnNorm
 using Random: Random, AbstractRNG
 using EnumX: @enumx
 using Functors: Functors, @leaf

--- a/src/stdlibs/LinearAlgebra.jl
+++ b/src/stdlibs/LinearAlgebra.jl
@@ -72,6 +72,27 @@ function __init__()
                 enzymexla_name, Libdl.dlsym(libblastrampoline_handle, cname)
             )
         end
+
+        # The QR lowering binds the LAPACKE (C) interface rather than the Fortran one, so
+        # these go through a separate table. Not every BLAS/LAPACK backend forwarded by
+        # libblastrampoline exposes LAPACKE, hence the non-throwing `dlsym`: a missing
+        # symbol only makes `qr` fail to compile, instead of breaking `Reactant` at load.
+        for (cname, enzymexla_name) in [
+            # QR factorization
+            (BLAS.@blasfunc(LAPACKE_sgeqrf), :enzymexla_lapacke_sgeqrf_),
+            (BLAS.@blasfunc(LAPACKE_dgeqrf), :enzymexla_lapacke_dgeqrf_),
+            (BLAS.@blasfunc(LAPACKE_cgeqrf), :enzymexla_lapacke_cgeqrf_),
+            (BLAS.@blasfunc(LAPACKE_zgeqrf), :enzymexla_lapacke_zgeqrf_),
+            # Q from the Householder reflectors
+            (BLAS.@blasfunc(LAPACKE_sorgqr), :enzymexla_lapacke_sorgqr_),
+            (BLAS.@blasfunc(LAPACKE_dorgqr), :enzymexla_lapacke_dorgqr_),
+            (BLAS.@blasfunc(LAPACKE_cungqr), :enzymexla_lapacke_cungqr_),
+            (BLAS.@blasfunc(LAPACKE_zungqr), :enzymexla_lapacke_zungqr_),
+        ]
+            ptr = Libdl.dlsym(libblastrampoline_handle, cname; throw_error=false)
+            ptr === nothing && continue
+            MLIR.API.EnzymeJaXMapSymbol(enzymexla_name, ptr)
+        end
     end
 
     return nothing

--- a/src/stdlibs/factorization/Factorization.jl
+++ b/src/stdlibs/factorization/Factorization.jl
@@ -16,6 +16,7 @@ const BatchedAdjointFactorization{T} =
 include("Cholesky.jl")
 include("LU.jl")
 include("SVD.jl")
+include("QR.jl")
 
 # Overload \ to support batched factorization
 for FT in
@@ -81,7 +82,11 @@ function Base.:(\)(
         end
         return res
     end
-    return qr(A, ColumnNorm()) \ B
+    # Base uses `qr(A, ColumnNorm())` here, but the backend has no `geqp3`. Unpivoted QR
+    # gives the same answer for full-rank over-determined systems and an equally valid (but
+    # differently sparse) basic solution for full-rank under-determined ones. It does not
+    # handle rank-deficient `A` -- use `svd(A) \ B` for that.
+    return qr(A, NoPivot()) \ B
 end
 
 function Base.:(\)(D::Diagonal{<:TracedRNumber}, B::AnyTracedRVector)

--- a/src/stdlibs/factorization/QR.jl
+++ b/src/stdlibs/factorization/QR.jl
@@ -188,9 +188,12 @@ end
 for f_wrapper in (LinearAlgebra.TransposeFactorization, LinearAlgebra.AdjointFactorization),
     aType in (:AbstractVecOrMat, :AbstractArray)
 
+    # the message has to be built here rather than interpolated into the `@eval`'d body,
+    # where `f_wrapper` would only be looked up at call time
+    msg = "`$(nameof(f_wrapper))` is not supported yet for QR."
+
     @eval function LinearAlgebra.ldiv!(F::$(f_wrapper){<:Any,<:BatchedQR}, B::$aType)
         # TODO: implement this
-        error("`$(f_wrapper)` is not supported yet for QR.")
-        return nothing
+        return error($msg)
     end
 end

--- a/src/stdlibs/factorization/QR.jl
+++ b/src/stdlibs/factorization/QR.jl
@@ -1,0 +1,196 @@
+"""
+    BatchedQR
+
+Unpivoted QR factorization of a (batch of) matrix(es), stored in LAPACK's compact form:
+the packed `factors` and the reflector scalings `τ`. This mirrors `LinearAlgebra.QRCompactWY`,
+so `F.factors`, `F.τ`, `F.Q` and `F.R` are all available -- `F.R` is free, and `F.Q` only
+emits the LAPACK `orgqr`/`ungqr` call when it is actually requested.
+
+For an `m × n` input with `k = min(m, n)`, `F.Q` is the **thin** `m × k` factor and `F.R` is
+`k × n`, so `F.Q * F.R ≈ A` and `F.R` agrees with `LinearAlgebra.qr(A).R`. Note that Julia's
+own `qr(A).Q` is instead a square `m × m` `AbstractQ` operator.
+
+Like the other Reactant factorizations, this is meant to be used from inside traced code;
+access `F.Q` / `F.R` within the function you compile.
+
+!!! note
+
+    Only unpivoted QR is supported -- the backend has no `geqp3`. Batched (`ndims > 2`)
+    inputs are supported on the CUDA and TPU backends only.
+"""
+struct BatchedQR{T,S<:AbstractArray,Tau<:AbstractArray,I} <: BatchedFactorization{T}
+    factors::S
+    tau::Tau
+    info::I
+end
+
+function BatchedQR(factors::S, tau::Tau, info::I) where {S,Tau,I}
+    @assert ndims(tau) == ndims(factors) - 1
+    return BatchedQR{eltype(factors),S,Tau,I}(factors, tau, info)
+end
+
+# `__get_B` / `_overloaded_backslash` in Factorization.jl read `size(F, 1)` and `size(F, 2)`
+# as the dimensions of the original matrix, so these must track `factors`.
+Base.size(F::BatchedQR) = size(getfield(F, :factors))
+Base.size(F::BatchedQR, i::Integer) = size(getfield(F, :factors), i)
+Base.ndims(F::BatchedQR) = ndims(getfield(F, :factors))
+
+function Base.copy(F::BatchedQR)
+    return BatchedQR(
+        copy(getfield(F, :factors)), copy(getfield(F, :tau)), copy(getfield(F, :info))
+    )
+end
+
+function Base.getproperty(F::BatchedQR, d::Symbol)
+    d === :τ && return getfield(F, :tau)
+    d === :Q && return _qr_Q(F)
+    d === :R && return _qr_R(F)
+    return getfield(F, d)
+end
+
+Base.propertynames(::BatchedQR) = (:factors, :tau, :τ, :Q, :R, :info)
+
+Base.iterate(F::BatchedQR) = (F.Q, Val(:R))
+Base.iterate(F::BatchedQR, ::Val{:R}) = (F.R, Val(:done))
+Base.iterate(::BatchedQR, ::Val{:done}) = nothing
+
+# The `Ops` take the matrix in the trailing dimensions with the batch dimensions leading,
+# while the factorization stores everything in the usual Julia order.
+_qr_matrix_last(N::Int) = vcat(collect(Int64, 3:N), 1, 2)
+_qr_tau_matrix_last(N::Int) = vcat(collect(Int64, 2:(N - 1)), 1)
+_qr_tau_matrix_first(N::Int) = vcat(N - 1, collect(Int64, 1:(N - 2)))
+
+_qr_trailing_colons(N::Int) = ntuple(Returns(Colon()), N - 2)
+
+function _qr_Q(F::BatchedQR)
+    factors = materialize_traced_array(getfield(F, :factors))
+    tau = materialize_traced_array(getfield(F, :tau))
+    N = ndims(factors)
+    m, n = size(factors, 1), size(factors, 2)
+
+    if m < n
+        # `orgqr` derives the number of reflectors from the column count of its input, so a
+        # wide packed matrix has to be squared off first. The result is the `m × m` Q.
+        factors = materialize_traced_array(factors[:, 1:m, _qr_trailing_colons(N)...])
+    end
+
+    permdims = _qr_matrix_last(N)
+    Q = @opcall orgqr(
+        @opcall(transpose(factors, permdims)),
+        @opcall(transpose(tau, _qr_tau_matrix_last(N))),
+    )
+    return @opcall transpose(Q, invperm(permdims))
+end
+
+function _qr_R(F::BatchedQR)
+    factors = materialize_traced_array(getfield(F, :factors))
+    N = ndims(factors)
+    k = min(size(factors, 1), size(factors, 2))
+    return _qr_triu(materialize_traced_array(factors[1:k, :, _qr_trailing_colons(N)...]))
+end
+
+# `overloaded_triu` is matrix-only; this is the same iota/select trick over the leading two
+# dimensions, which keeps the emitted IR independent of the batch size.
+function _qr_triu(X::TracedRArray{T,N}) where {T,N}
+    shape = collect(Int64, size(X))
+    idxs = @opcall compare(
+        @opcall(iota(Int64, shape; iota_dimension=1)),
+        @opcall(iota(Int64, shape; iota_dimension=2));
+        comparison_direction="LE",
+    )
+    return @opcall select(idxs, X, zero(X))
+end
+
+function overloaded_qr(A::AbstractArray, args...; kwargs...)
+    return overloaded_qr(Reactant.promote_to(TracedRArray, A), args...; kwargs...)
+end
+
+function overloaded_qr(
+    A::AnyTracedRArray{T,N}, ::NoPivot; blocksize::Integer=36
+) where {T,N}
+    # blocksize is ignored: the backend picks its own blocking for `geqrf`
+    permdims = _qr_matrix_last(N)
+    factors, tau, info = @opcall geqrf(
+        @opcall(transpose(materialize_traced_array(A), permdims))
+    )
+    return BatchedQR(
+        (@opcall transpose(factors, invperm(permdims))),
+        (@opcall transpose(tau, _qr_tau_matrix_first(N))),
+        info,
+    )
+end
+
+function overloaded_qr(::AnyTracedRArray, ::ColumnNorm; kwargs...)
+    throw(
+        ArgumentError(
+            "Column-pivoted QR is not supported by the Reactant backend (there is no \
+             `geqp3` lowering). Use `qr(A)` for the unpivoted factorization, or `svd(A)` \
+             if `A` may be rank-deficient."
+        ),
+    )
+end
+
+# Least squares for `m ≥ n`, and the same basic solution Julia's unpivoted `ldiv!(::QR, B)`
+# produces for `m < n` (the caller zeroes the trailing rows).
+function _qr_solve_core(Q::AbstractMatrix, R::AbstractMatrix, B::AbstractMatrix)
+    m, k = size(Q)
+    rhs = adjoint(Q) * LinearAlgebra._cut_B(B, 1:m)
+    return UpperTriangular(materialize_traced_array(R[:, 1:k])) \ rhs
+end
+
+function LinearAlgebra.ldiv!(
+    F::BatchedQR{T,<:AbstractArray{T,N}}, B::AbstractArray{T,M}
+) where {T,N,M}
+    @assert N == M + 1
+    ldiv!(F, reshape(B, size(B, 1), 1, size(B)[2:end]...))
+    return B
+end
+
+function LinearAlgebra.ldiv!(
+    F::BatchedQR{T,<:AbstractArray{T,2}}, B::AbstractArray{T,2}
+) where {T}
+    m, n = size(F, 1), size(F, 2)
+    k = min(m, n)
+    B[1:k, :] .= _qr_solve_core(F.Q, F.R, B)
+    # `__get_B` allocates the right-hand side with `similar`, so the trailing rows of an
+    # under-determined system have to be zeroed explicitly.
+    n > k && (B[(k + 1):n, :] .= zero(T))
+    return B
+end
+
+function LinearAlgebra.ldiv!(
+    F::BatchedQR{T,<:AbstractArray{T,N}}, B::AbstractArray{T,N}
+) where {T,N}
+    batch_shape = size(F)[3:end]
+    @assert batch_shape == size(B)[3:end]
+
+    m, n = size(F, 1), size(F, 2)
+    k = min(m, n)
+    permutation = _qr_matrix_last(N)
+
+    # Q and R are materialized once, outside the batched region, so only the solve is
+    # batched.
+    Q = @opcall transpose(materialize_traced_array(F.Q), permutation)
+    R = @opcall transpose(materialize_traced_array(F.R), permutation)
+    B_permuted = @opcall transpose(materialize_traced_array(B), permutation)
+
+    res = @opcall transpose(
+        only(
+            @opcall(batch(_qr_solve_core, [Q, R, B_permuted], collect(Int64, batch_shape)))
+        ),
+        invperm(permutation),
+    )
+    B[1:k, :, _qr_trailing_colons(N)...] .= res
+    n > k && (B[(k + 1):n, :, _qr_trailing_colons(N)...] .= zero(T))
+    return B
+end
+
+for f_wrapper in (LinearAlgebra.TransposeFactorization, LinearAlgebra.AdjointFactorization),
+    aType in (:AbstractVecOrMat, :AbstractArray)
+
+    @eval function LinearAlgebra.ldiv!(F::$(f_wrapper){<:Any,<:BatchedQR}, B::$aType)
+        # TODO: implement this
+        error("`$(f_wrapper)` is not supported yet for QR.")
+        return nothing
+    end
+end

--- a/test/core/ops.jl
+++ b/test/core/ops.jl
@@ -5,6 +5,7 @@ using SpecialFunctions: SpecialFunctions
 using StableRNGs: StableRNG
 
 const RunningOnTPU = contains(string(Reactant.devices()[1]), "TPU")
+const RunningOnCPU = contains(lowercase(string(Reactant.devices()[1])), "cpu")
 const RunningOnAppleX86 = Sys.isapple() && Sys.ARCH === :x86_64
 
 @testset "abs" begin
@@ -1351,8 +1352,6 @@ end
     end
 end
 
-const RunningOnCPU = contains(lowercase(string(Reactant.devices()[1])), "cpu")
-
 function recon_from_qr(Q::AbstractMatrix, factors::AbstractMatrix)
     return Q * triu(factors[1:size(Q, 2), :])
 end
@@ -1365,8 +1364,9 @@ end
 @testset "qr factorization" begin
     # `geqrf` returns the packed LAPACK representation, so on CPU it must agree with the
     # very same routine called through `LinearAlgebra.LAPACK`.
-    @testset "geqrf vs LAPACK: $(T) $(m)x$(n)" for T in
-                                                   (Float32, Float64, ComplexF32, ComplexF64),
+    @testset "geqrf vs LAPACK: $(T) $(m)x$(n)" for T in (
+            Float32, Float64, ComplexF32, ComplexF64
+        ),
         (m, n) in ((6, 4), (4, 6), (5, 5))
 
         (T == Float64 || T == ComplexF64) && RunningOnTPU && continue

--- a/test/core/ops.jl
+++ b/test/core/ops.jl
@@ -2,6 +2,7 @@ using Reactant, Test, FileCheck
 using Reactant: Ops
 using LinearAlgebra
 using SpecialFunctions: SpecialFunctions
+using StableRNGs: StableRNG
 
 const RunningOnTPU = contains(string(Reactant.devices()[1]), "TPU")
 const RunningOnAppleX86 = Sys.isapple() && Sys.ARCH === :x86_64
@@ -1347,6 +1348,64 @@ end
 
         @test @jit(recon_from_lu(lu_ra)) ≈ @jit(apply_permutation(x_ra, perm)) atol = 1e-5 rtol =
             1e-2
+    end
+end
+
+const RunningOnCPU = contains(lowercase(string(Reactant.devices()[1])), "cpu")
+
+function recon_from_qr(Q::AbstractMatrix, factors::AbstractMatrix)
+    return Q * triu(factors[1:size(Q, 2), :])
+end
+
+function qr_thin(x)
+    factors, tau, _ = Ops.geqrf(x)
+    return Ops.orgqr(factors, tau), factors
+end
+
+@testset "qr factorization" begin
+    # `geqrf` returns the packed LAPACK representation, so on CPU it must agree with the
+    # very same routine called through `LinearAlgebra.LAPACK`.
+    @testset "geqrf vs LAPACK: $(T) $(m)x$(n)" for T in
+                                                   (Float32, Float64, ComplexF32, ComplexF64),
+        (m, n) in ((6, 4), (4, 6), (5, 5))
+
+        (T == Float64 || T == ComplexF64) && RunningOnTPU && continue
+
+        # a well-conditioned input: for a rank-deficient one the trailing reflectors are
+        # arbitrary and a blocked/unblocked path difference would show up as a mismatch
+        x = rand(StableRNG(1234), T, m, n)
+        x_ra = Reactant.to_rarray(x)
+
+        factors, tau, info = @jit Ops.geqrf(x_ra)
+
+        @test size(factors) == (m, n)
+        @test size(tau) == (min(m, n),)
+        @test size(info) == ()
+
+        if RunningOnCPU
+            factors_lapack, tau_lapack = LinearAlgebra.LAPACK.geqrf!(copy(x))
+            @test Array(factors) ≈ factors_lapack atol = 1e-5 rtol = 1e-3
+            @test Array(tau) ≈ tau_lapack atol = 1e-5 rtol = 1e-3
+            @test info == 0
+        end
+    end
+
+    # `orgqr` requires a tall (or square) input; the wide case is handled one layer up, in
+    # `LinearAlgebra.qr`. These checks are sign-convention agnostic, so they hold on every
+    # backend.
+    @testset "orgqr: $(T) $(m)x$(n)" for T in (Float32, Float64, ComplexF32, ComplexF64),
+        (m, n) in ((6, 4), (5, 5))
+
+        (T == Float64 || T == ComplexF64) && RunningOnTPU && continue
+
+        x = rand(StableRNG(1234), T, m, n)
+        x_ra = Reactant.to_rarray(x)
+
+        Q, factors = @jit qr_thin(x_ra)
+
+        @test size(Q) == (m, n)
+        @test Array(Q)' * Array(Q) ≈ Matrix{T}(I, n, n) atol = 1e-4 rtol = 1e-2
+        @test recon_from_qr(Array(Q), Array(factors)) ≈ x atol = 1e-4 rtol = 1e-2
     end
 end
 

--- a/test/integration/factorizations.jl
+++ b/test/integration/factorizations.jl
@@ -162,6 +162,89 @@ end
     end
 end
 
+const RunningOnCPU = contains(lowercase(string(Reactant.devices()[1])), "cpu")
+
+function qr_factors(A)
+    F = qr(A)
+    return F.Q, F.R
+end
+
+function qr_destructure(A)
+    Q, R = qr(A)
+    return Q, R
+end
+
+solve_with_qr(A, b) = solve_with_fact(qr, A, b)
+
+@testset "QR Factorization" begin
+    @testset "$(T) $(m)x$(n)" for T in (Float32, Float64, ComplexF32, ComplexF64),
+        (m, n) in ((6, 4), (4, 4), (4, 6))
+
+        (T == ComplexF64 || T == Float64) && RunningOnTPU && continue
+
+        k = min(m, n)
+        A = random_matrix_with_cond(T, m, n, 10.0)
+        A_ra = Reactant.to_rarray(A)
+
+        Q, R = @jit qr_factors(A_ra)
+        Q, R = Array(Q), Array(R)
+
+        @test size(Q) == (m, k)
+        @test size(R) == (k, n)
+        @test Q' * Q ≈ Matrix{T}(I, k, k) atol = 1e-4 rtol = 1e-2
+        @test Q * R ≈ A atol = 1e-4 rtol = 1e-2
+        @test R ≈ triu(R)
+
+        # same LAPACK routine on both sides, so the sign convention matches too
+        RunningOnCPU && @test R ≈ LinearAlgebra.qr(A).R atol = 1e-4 rtol = 1e-2
+    end
+
+    @testset "destructuring" begin
+        A = random_matrix_with_cond(Float32, 6, 4, 10.0)
+        A_ra = Reactant.to_rarray(A)
+
+        Q, R = @jit qr_destructure(A_ra)
+        @test Array(Q) * Array(R) ≈ A atol = 1e-4 rtol = 1e-2
+    end
+
+    @testset "least squares: $(T) $(m)x$(n)" for T in (Float32, ComplexF32),
+        (m, n) in ((6, 4), (4, 4), (4, 6))
+
+        A = random_matrix_with_cond(T, m, n, 10.0)
+        A_ra = Reactant.to_rarray(A)
+
+        b = rand(T, m)
+        b_ra = Reactant.to_rarray(b)
+
+        B = rand(T, m, 3)
+        B_ra = Reactant.to_rarray(B)
+
+        if m >= n
+            # over-determined: the least squares solution is unique, so we can compare
+            # against Julia directly
+            @test @jit(solve_with_qr(A_ra, b_ra)) ≈ solve_with_qr(A, b) atol = 1e-4 rtol =
+                1e-2
+            @test @jit(solve_with_qr(A_ra, B_ra)) ≈ solve_with_qr(A, B) atol = 1e-4 rtol =
+                1e-2
+        else
+            # under-determined: unpivoted QR returns a basic solution, which need not be
+            # the one Julia's pivoted `\` picks, so check the residual instead
+            x = Array(@jit(solve_with_qr(A_ra, b_ra)))
+            @test maximum(abs, A * x .- b) < 1e-3
+            @test all(iszero, x[(m + 1):n])
+
+            X = Array(@jit(solve_with_qr(A_ra, B_ra)))
+            @test maximum(abs, A * X .- B) < 1e-3
+            @test all(iszero, X[(m + 1):n, :])
+        end
+    end
+
+    @testset "pivoted QR is unsupported" begin
+        A_ra = Reactant.to_rarray(rand(Float32, 4, 4))
+        @test_throws ArgumentError @jit(qr(A_ra, ColumnNorm()))
+    end
+end
+
 function get_svd_algorithms(backend::String, size=nothing)
     backend = lowercase(backend)
     algorithms = ["DEFAULT"]

--- a/test/integration/factorizations.jl
+++ b/test/integration/factorizations.jl
@@ -175,6 +175,15 @@ function qr_destructure(A)
 end
 
 solve_with_qr(A, b) = solve_with_fact(qr, A, b)
+solve_with_qr!(A, b) = solve_with_fact(qr!, A, b)
+qr_adjoint_solve(A, b) = qr(A)' \ b
+# `\` on a transposed factorization delegates to the adjoint one, so reach the transpose
+# method through `ldiv!` directly
+qr_transpose_ldiv(A, b) = ldiv!(transpose(qr(A)), b)
+
+# `qr` on a plain host array inside a traced function must fall through to LinearAlgebra
+const QR_HOST_MATRIX = Matrix{Float32}(reshape(1:16, 4, 4)) + 8 * I
+qr_of_host_array(x) = x .+ sum(qr(QR_HOST_MATRIX).R)
 
 @testset "QR Factorization" begin
     @testset "$(T) $(m)x$(n)" for T in (Float32, Float64, ComplexF32, ComplexF64),
@@ -242,6 +251,51 @@ solve_with_qr(A, b) = solve_with_fact(qr, A, b)
     @testset "pivoted QR is unsupported" begin
         A_ra = Reactant.to_rarray(rand(Float32, 4, 4))
         @test_throws ArgumentError @jit(qr(A_ra, ColumnNorm()))
+    end
+
+    @testset "qr!" begin
+        A = random_matrix_with_cond(Float32, 6, 4, 10.0)
+        b = rand(Float32, 6)
+        A_ra = Reactant.to_rarray(A)
+        b_ra = Reactant.to_rarray(b)
+
+        @test @jit(solve_with_qr!(A_ra, b_ra)) ≈ solve_with_qr(A, b) atol = 1e-4 rtol = 1e-2
+    end
+
+    @testset "non-traced fallback" begin
+        # `use_overlayed_version` is false here, so the overlay must defer to LinearAlgebra
+        x_ra = Reactant.to_rarray(rand(Float32, 3))
+        @test @jit(qr_of_host_array(x_ra)) ≈ qr_of_host_array(Array(x_ra))
+    end
+
+    @testset "factorization interface" begin
+        A = random_matrix_with_cond(Float32, 6, 4, 10.0)
+        A_ra = Reactant.to_rarray(A)
+        F = @jit qr(A_ra)
+
+        @test size(F) == (6, 4)
+        @test size(F, 1) == 6
+        @test size(F, 2) == 4
+        @test ndims(F) == 2
+        @test propertynames(F) == (:factors, :tau, :τ, :Q, :R, :info)
+        @test F.τ === F.tau
+        @test size(F.tau) == (4,)
+        @test F.info == 0
+
+        F2 = copy(F)
+        @test Array(F2.factors) == Array(F.factors)
+        @test Array(F2.tau) == Array(F.tau)
+    end
+
+    @testset "adjoint/transpose factorizations are unsupported" begin
+        A = random_matrix_with_cond(Float32, 6, 4, 10.0)
+        A_ra = Reactant.to_rarray(A)
+        # `Adjoint`/`Transpose` reverse the reported size, so the RHS needs `size(F, 2)`
+        # rows -- otherwise `__get_B` throws `DimensionMismatch` before `ldiv!` is reached
+        b_ra = Reactant.to_rarray(rand(Float32, 4))
+
+        @test_throws ErrorException @jit(qr_adjoint_solve(A_ra, b_ra))
+        @test_throws ErrorException @jit(qr_transpose_ldiv(A_ra, b_ra))
     end
 end
 

--- a/test/integration/factorizations.jl
+++ b/test/integration/factorizations.jl
@@ -282,6 +282,8 @@ qr_of_host_array(x) = x .+ sum(qr(QR_HOST_MATRIX).R)
         @test size(F.tau) == (4,)
         @test F.info == 0
 
+        @test iterate(F, Val(:done)) === nothing
+
         F2 = copy(F)
         @test Array(F2.factors) == Array(F.factors)
         @test Array(F2.tau) == Array(F.tau)

--- a/test/integration/linearsolve.jl
+++ b/test/integration/linearsolve.jl
@@ -8,7 +8,32 @@ using LinearAlgebra, Random, Reactant, StableRNGs, Test
     B_ra = Reactant.to_rarray(B)
     b_ra = Reactant.to_rarray(b)
 
-    # TODO: test QR once lowering exists
+    @testset "qr (non-square)" begin
+        # over-determined: unique least squares solution, compare against Julia directly
+        A_tall = rand(StableRNG(3), Float32, 6, 4)
+        b6 = rand(StableRNG(4), Float32, 6)
+        B6 = rand(StableRNG(5), Float32, 6, 5)
+
+        A_tall_ra = Reactant.to_rarray(A_tall)
+        b6_ra = Reactant.to_rarray(b6)
+        B6_ra = Reactant.to_rarray(B6)
+
+        @test A_tall \ b6 ≈ @jit(A_tall_ra \ b6_ra) atol = 1e-5 rtol = 1e-3
+        @test A_tall \ B6 ≈ @jit(A_tall_ra \ B6_ra) atol = 1e-5 rtol = 1e-3
+
+        # under-determined: unpivoted QR yields a basic solution that need not match the
+        # one Julia's pivoted `\` picks, so check the residual
+        A_wide = rand(StableRNG(6), Float32, 4, 6)
+        A_wide_ra = Reactant.to_rarray(A_wide)
+
+        x = Array(@jit(A_wide_ra \ b_ra))
+        @test length(x) == 6
+        @test maximum(abs, A_wide * x .- b) < 1e-3
+
+        X = Array(@jit(A_wide_ra \ B_ra))
+        @test size(X) == (6, 5)
+        @test maximum(abs, A_wide * X .- B) < 1e-3
+    end
 
     @testset "lu" begin
         A_ra = Reactant.to_rarray(A)


### PR DESCRIPTION
Wrap the `enzymexla.lapack.geqrf` and `enzymexla.lapack.orgqr` dialect ops,
which lower to LAPACKE on CPU, cuSOLVER on CUDA and XLA's Qr /
ProductOfElementaryHouseholderReflectors on TPU.

The high-level `enzymexla.linalg.qr` op is deliberately bypassed: its lowering
forwards the QR op's (Q, R, info) result types straight into geqrf's
(output, tau, info), so it only produces verifiable IR when Q and R have the
same type, and the "R" it yields is the packed matrix rather than a
triangular one.

The CPU lowering of geqrf hardcodes its result types and then replaces the
op's uses, so the declared types have to match exactly: packed factors with
the shape of the input, tau of length min(m, n), and a rank-0 BlasInt info
(not Int32 as for `enzymexla.linalg.lu`, which does respect declared types).

Also register the LAPACKE symbols the CPU lowering binds. These use the C
interface rather than the Fortran one, so they need their own table; the
lookup is non-throwing so a BLAS backend without LAPACKE does not break
loading Reactant.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>