### PR TITLE
Fix LinRange getindex with a traced index

### DIFF
--- a/src/Indexing.jl
+++ b/src/Indexing.jl
@@ -132,9 +132,12 @@ for (aT, iT) in (
     (LinRange{<:TracedRNumber}, TracedRNumber{Int}),
 )
     @eval function Base.getindex(r::$aT, index::$iT)
+        # Inline the linear interpolation: `Base.lerpi` only accepts plain `Integer`s, so
+        # it cannot take a traced index.
+        t = (index - oneunit(index)) / r.lendiv
         return convert(
             TracedRNumber{Reactant.unwrapped_eltype(r)},
-            Base.lerpi(index - oneunit(index), r.lendiv, r.start, r.stop),
+            (oneunit(t) - t) * r.start + t * r.stop,
         )
     end
 end

--- a/test/core/ranges.jl
+++ b/test/core/ranges.jl
@@ -8,6 +8,14 @@ using Reactant, Test
     @test Array{Int64}(@jit(i:j)) == collect(5:10)
 end
 
+@testset "range getindex with a traced index" begin
+    i = Reactant.to_rarray(3; track_numbers=true)
+    lr = LinRange(0.0, 1.0, 11)
+    @test Float64(@jit(getindex(lr, i))) ≈ lr[3]
+    ur = 5:16
+    @test Int64(@jit(getindex(ur, i))) == ur[3]
+end
+
 broadcast_over_range(a, kx, ky) = a .* (kx .^ 2 .+ ky' .^ 2)
 
 @testset "broadcast over ranges" begin


### PR DESCRIPTION
`getindex(::LinRange, ::TracedRNumber{<:Integer})` (and the `LinRange{<:TracedRNumber}` variants) forwarded to `Base.lerpi`, which only accepts plain `Integer`s, so any traced lookup threw a `MethodError`:

```julia
using Reactant
f(i) = LinRange(0.0, 1.0, 11)[i]
@jit f(Reactant.ConcreteRNumber(3))
```
```
ERROR: MethodError: no method matching lerpi(::Reactant.TracedRNumber{Int64}, ::Int64, ::Float64, ::Float64)
```

This PR inlines the linear interpolation (`t = (i-1)/lendiv; (1-t)*start + t*stop`, the same formula `lerpi` uses) so it accepts traced arguments, and adds a test alongside the existing range tests.

Context: hit in VLBISkyModels.jl when indexing image-grid coordinates inside an `@trace` loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)