### PR TITLE
Add `overloaded_map!` fallback for untraced destination arrays

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -959,6 +959,12 @@ function overloaded_map!(f, y::AnyTracedRArray, x::AbstractArray, xs::AbstractAr
     return y
 end
 
+# Fallback for untraced destinations (e.g. a plain `Vector` holding traced
+# arrays), which the `Base.map!` overlay also routes here.
+function overloaded_map!(f, y::AbstractArray, x::AbstractArray, xs::AbstractArray...)
+    return Base.map!(Reactant.CallWithReactant(f), y, x, xs...)
+end
+
 function Base.mapslices(f::F, A::AnyTracedRArray; dims) where {F}
     return mapslices(f, materialize_traced_array(A); dims)
 end

--- a/test/core/array_ops.jl
+++ b/test/core/array_ops.jl
@@ -482,6 +482,20 @@ end
     @test Array(y_ra) ≈ y
 end
 
+# Untraced destination holding traced elements (SciML/OrdinaryDiffEq.jl#3369)
+function map_untraced_dest(x)
+    v = [x, x .+ 1]
+    w = map!(copy, similar(v), v)
+    return w[1] .+ w[2]
+end
+
+@testset "map! into untraced destination" begin
+    x = Reactant.TestUtils.construct_test_array(Float32, 4)
+    x_ra = Reactant.to_rarray(x)
+
+    @test Array(@jit(map_untraced_dest(x_ra))) ≈ map_untraced_dest(x)
+end
+
 map_test_1(i, xᵢ, yᵢ) = xᵢ + yᵢ + max(xᵢ, yᵢ)
 
 @testset "multi-argument map" begin


### PR DESCRIPTION
The `Base.map!` overlay routes any call whose arguments contain traced
values to `overloaded_map!`:

```julia
@reactant_overlay @noinline function Base.map!(f, y::AbstractArray, x::AbstractArray, xs::AbstractArray...)
    if (use_overlayed_version(y) || use_overlayed_version(x) || ...)
        return call_with_native(TracedRArrayOverrides.overloaded_map!, f, y, x, xs...)
    ...
```

`use_overlayed_version(::Vector)` recurses into the elements, so a plain
host `Vector` **holding** traced arrays takes the overlayed branch — but
`overloaded_map!` only had a method for `y::AnyTracedRArray`
(`AbstractArray{TracedRNumber}`), so such destinations threw:

```
MethodError: no method matching overloaded_map!(::typeof(RecursiveArrayTools.recursivecopy), ::Vector{Reactant.TracedRArray{Float64, 1}}, ::Vector{Reactant.TracedRArray{Float64, 1}})
```

This is the first failure of SciML/OrdinaryDiffEq.jl#3369 (also reported
as #2770): RecursiveArrayTools' `recursivecopy` on a `Vector`-of-arrays is
implemented as `map!(recursivecopy, similar(v), v)`.

The fix adds the missing fallback: when the destination is not a traced
array, let `Base.map!` drive the iteration and assignment while still
applying `f` under the Reactant interpreter — mirroring the overlay's own
untraced branch:

```julia
function overloaded_map!(f, y::AbstractArray, x::AbstractArray, xs::AbstractArray...)
    return Base.map!(Reactant.CallWithReactant(f), y, x, xs...)
end
```

No ambiguity: the existing `y::AnyTracedRArray` method is strictly more
specific. A regression test exercises `map!(copy, similar(v), v)` with
`v::Vector{<:TracedRArray}` under `@jit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
