### PR TITLE
Reduce in the accumulator type, not the mapped element type

### DIFF
--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -198,15 +198,22 @@ function overloaded_mapreduce(
     dims = sort(dims)
 
     op_in_T = unwrapped_eltype(Core.Compiler.return_type(f, Tuple{T}))
-    reduce_init = __default_init(op_in_T, op)
-    riT = unwrapped_eltype(typeof(reduce_init))
-    if riT != op_in_T
-        op_in_T = riT
-        A = riT.(A)
-    end
-    reduce_init = Reactant.promote_to(TracedRNumber{op_in_T}, reduce_init)
+    # `op` may accumulate in a wider type than it consumes: `+(::Bool, ::Bool)::Int64`, so
+    # `sum` over booleans is an `Int64` in Base. `__default_init` reports that wider type
+    # (it is the type of `op`'s identity element), so reduce in it.
+    init_val = __default_init(op_in_T, op)
+    op_in_T = unwrapped_eltype(typeof(init_val))
+    reduce_init = Reactant.promote_to(TracedRNumber{op_in_T}, init_val)
 
+    # Widen *after* applying `f`, not before. `f` decides the element type actually being
+    # reduced, so converting `A` up front is undone by anything narrowing -- e.g. the
+    # predicate in `sum(x -> x == 1, a)` returns `Bool` whatever `A` was converted to.
+    # Reducing in the narrow type is silently wrong: `stablehlo.add` over `i1` is a logical
+    # `or`, and small integers wrap.
     reduce_input = materialize_traced_array(TracedUtils.elem_apply(f, A))
+    if unwrapped_eltype(reduce_input) != op_in_T
+        reduce_input = op_in_T.(reduce_input)
+    end
 
     res = @opcall reduce(reduce_input, reduce_init, dims, op)
 

--- a/test/core/map_reduction.jl
+++ b/test/core/map_reduction.jl
@@ -97,6 +97,35 @@ end
     @test @jit(sum(x_ra)) == sum(x)
 end
 
+# The reduction must run in the type `op` accumulates in, not the type `f` returns.
+# Reducing a predicate's `Bool` in `i1` made `sum` a logical `or`, so this returned
+# `true` rather than the count.
+sum_eq1(x) = sum(y -> y == 1, x)
+sum_eq1_dims(x) = sum(y -> y == 1, x; dims=1)
+sum_eq1_init(x) = sum(y -> y == 1, x; init=10)
+
+@testset "reduce over a narrowing map (#3161)" begin
+    x = [1, 1, 2, 1]
+    x_ra = Reactant.to_rarray(x)
+
+    @test @jit(sum_eq1(x_ra)) == sum_eq1(x)
+    @test Reactant.unwrapped_eltype(@jit(sum_eq1(x_ra))) === typeof(sum_eq1(x))
+    @test @jit(sum_eq1_init(x_ra)) == sum_eq1_init(x)
+
+    m = [1 1; 1 2]
+    m_ra = Reactant.to_rarray(m)
+
+    @test Array(@jit(sum_eq1_dims(m_ra))) == sum_eq1_dims(m)
+    @test eltype(Array(@jit(sum_eq1_dims(m_ra)))) === eltype(sum_eq1_dims(m))
+
+    # reductions whose `op` does not widen must keep Base's narrower type
+    b = [true, false, true]
+    b_ra = Reactant.to_rarray(b)
+
+    @test Reactant.unwrapped_eltype(@jit(prod(b_ra))) === typeof(prod(b))
+    @test Reactant.unwrapped_eltype(@jit(maximum(b_ra))) === typeof(maximum(b))
+end
+
 function fntest1(x)
     y = similar(x, 1, 1, 8)
     sum!(y, x)


### PR DESCRIPTION
Fixes #3161.

`sum(x -> x == 1, a)` returned `true` rather than the count:

```julia
julia> foo(a) = sum(x -> x == 1, a)
julia> foo([1,1])
2

julia> @jit foo(Reactant.to_rarray([1,1]))
ConcretePJRTNumber{Bool, 1}(true)
```

### Cause

The predicate returns `Bool`, and the reduction ran in `i1`, where `stablehlo.add` is a logical `or`:

```mlir
%5 = stablehlo.convert %c : (tensor<i64>) -> tensor<i1>          // init narrowed to i1
%6 = stablehlo.reduce(%4#0 init: %5) applies stablehlo.add
       across dimensions = [0] : (tensor<2xi1>, tensor<i1>) -> tensor<i1>
```

Base accumulates in whatever `op` returns, not in the mapped element type — `+(::Bool, ::Bool)::Int64`, so `sum` over booleans is an `Int64`.

`overloaded_mapreduce` already derived that wider type correctly (`__default_init` returns `op`'s identity element, whose type is the accumulator type — `Int64` for `Bool`/`Int8`/`Int32`, `UInt64` for `UInt8`, `Bool` for `prod`/`max`). The bug is that it applied the widening to `A`, the **input** of `f`:

```julia
if riT != op_in_T
    op_in_T = riT
    A = riT.(A)          # <-- widens before `f`
end
...
reduce_input = materialize_traced_array(TracedUtils.elem_apply(f, A))
```

Anything narrowing in `f` undoes it — a predicate returns `Bool` no matter what `A` was converted to — and the init constant was then silently narrowed back to `i1` to match the input. With `f = identity` the widening survives, which is why plain `sum(::Array{Bool})` was already correct and this went unnoticed.

The fix widens the result of `elem_apply(f, A)` instead.

### Scope

Only reductions whose `op` widens *and* whose `f` narrows change behavior. Measured before/after on the same machine:

| case | before | after (= Base) |
|---|---|---|
| `sum(==1, [1,1])` | `true::Bool` | `2::Int64` |
| `sum(==1, [1,1,1])` | `true::Bool` | `3::Int64` |
| `sum(==1, [1,2,1])` | `true::Bool` | `2::Int64` |
| `sum(==1, M; dims=1)` | `Bool[1 1]` | `[2 1]` |
| `sum(==1, [1,1]; init=10)` | `11` | `12` |

Unchanged and verified still matching Base: `sum` over `Bool`/`Int8`/`Int16`/`Int32`/`Int64`/`UInt8`/`Float32`/`Float64`, `prod(::Bool)→Bool`, `prod(Int8)→Int64`, `maximum(::Bool)→Bool`, `maximum(Int8)→Int8`, `minimum(Float32)`, `any`, `all`, and the `dims`/`init` variants of each.

### Tests

New `@testset "reduce over a narrowing map (#3161)"` in `test/core/map_reduction.jl`, covering the value, the result type, the `dims` and `init` variants, and that `prod`/`maximum` keep Base's narrower types.

Suites run locally on CPU (Julia 1.12.4): `map_reduction` 148 pass / 0 fail, `array_ops` 290 / 0, `ops` 340 / 0, `bcast` 16 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PH4zH9zvavbXWXomJbCq3B
