### PR TITLE
Fix rtol default in TracedRNumber isapprox and add tests

### DIFF
--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -85,10 +85,16 @@ function Base.isapprox(
     norm::Function=abs,
 ) where {T<:AbstractFloat}
     return (x == y) |
-           (isfinite(x) & isfinite(y) & (norm(x - y) <= max(atol, rtol * max(norm(x), norm(y))))) |
+           (
+               isfinite(x) &
+               isfinite(y) &
+               (norm(x - y) <= max(atol, rtol * max(norm(x), norm(y))))
+           ) |
            (nans & isnan(x) & isnan(y))
 end
-Base.isapprox(x::Real, y::TracedRNumber{<:AbstractFloat}; kwargs...) = isapprox(y, x; kwargs...)
+function Base.isapprox(x::Real, y::TracedRNumber{<:AbstractFloat}; kwargs...)
+    return isapprox(y, x; kwargs...)
+end
 
 function Base.show(io::IOty, X::TracedRNumber{T}) where {T,IOty<:Union{IO,IOContext}}
     return print(io, "TracedRNumber{", T, "}(", X.paths, ")")

--- a/src/TracedRNumber.jl
+++ b/src/TracedRNumber.jl
@@ -71,6 +71,25 @@ Base.isinf(x::TracedRNumber{<:Complex}) = isinf(real(x)) | isinf(imag(x))
 Base.isinf(x::TracedRNumber{<:AbstractFloat}) = @opcall is_inf(x)
 Base.isinf(::TracedRNumber{<:Integer}) = false
 
+# Base's generic `isapprox` requires both arguments to be `Real`, which
+# `TracedRNumber` (<: RNumber, not Real) never satisfies -- dispatch falls
+# through with no matching method. Reimplement the same algorithm here using
+# `&`/`|` instead of `&&`/`||`, since traced comparisons return a traced
+# boolean rather than a native `Bool` usable in short-circuiting control flow.
+function Base.isapprox(
+    x::TracedRNumber{T},
+    y::Union{Real,TracedRNumber{<:AbstractFloat}};
+    atol::Real=0,
+    rtol::Real=(atol > 0 ? zero(T) : sqrt(eps(T))),
+    nans::Bool=false,
+    norm::Function=abs,
+) where {T<:AbstractFloat}
+    return (x == y) |
+           (isfinite(x) & isfinite(y) & (norm(x - y) <= max(atol, rtol * max(norm(x), norm(y))))) |
+           (nans & isnan(x) & isnan(y))
+end
+Base.isapprox(x::Real, y::TracedRNumber{<:AbstractFloat}; kwargs...) = isapprox(y, x; kwargs...)
+
 function Base.show(io::IOty, X::TracedRNumber{T}) where {T,IOty<:Union{IO,IOContext}}
     return print(io, "TracedRNumber{", T, "}(", X.paths, ")")
 end

--- a/test/core/math_ops.jl
+++ b/test/core/math_ops.jl
@@ -163,6 +163,73 @@ end
     @test !Bool(@jit(isinf(ConcreteRNumber(true))))
 end
 
+@testset "isapprox" begin
+    # `ConcreteRNumber` forwards `isapprox` straight to `Base` on the unwrapped
+    # values (see the `AbstractConcreteNumber` methods in ConcreteRArray.jl), so
+    # it never exercises `TracedRNumber`'s own `isapprox` method. Only calling
+    # through `@jit` traces the comparison and hits the method under test.
+    float_pairs = [
+        (1.0, 1.0),                # exactly equal
+        (1.0, 1.0 + 1e-12),        # within default rtol
+        (1.0, 1.1),                # not close by default
+        (0.0, 0.0),
+        (0.0, 1e-20),
+        (-5.0, -5.0000001),
+        (1e10, 1e10 + 100.0),      # rtol-dominated at default tolerance
+        (1.0f0, 1.0f0 + 1.0f-4),
+        (1.0f0, 2.0f0),
+        (NaN, NaN),
+        (NaN, 1.0),
+        (Inf, Inf),
+        (Inf, -Inf),
+        (-Inf, -Inf),
+        (Inf, 1.0),
+    ]
+
+    kwargs_cases = [
+        (;),
+        (; atol=1.0),                 # atol>0 with no rtol must force rtol=0, like Base
+        (; atol=200.0),
+        (; atol=1e-6),
+        (; rtol=1e-3),
+        (; atol=1.0, rtol=1e-9),
+        (; nans=true),
+        (; nans=false),
+        (; norm=abs2),
+    ]
+
+    @testset "traced vs traced: x=$x, y=$y, kwargs=$kwargs" for (x, y) in float_pairs,
+        kwargs in kwargs_cases
+
+        expected = isapprox(x, y; kwargs...)
+        x_ra = Reactant.to_rarray(x; track_numbers=Number)
+        y_ra = Reactant.to_rarray(y; track_numbers=Number)
+        got = @jit isapprox(x_ra, y_ra; kwargs...)
+        @test got isa ConcreteRNumber{Bool}
+        @test Bool(got) == expected
+    end
+
+    @testset "traced vs real: x=$x, y=$y" for (x, y) in float_pairs
+        expected = isapprox(x, y)
+        x_ra = Reactant.to_rarray(x; track_numbers=Number)
+        @test Bool(@jit(isapprox(x_ra, y))) == expected
+    end
+
+    @testset "real vs traced: x=$x, y=$y" for (x, y) in float_pairs
+        expected = isapprox(x, y)
+        y_ra = Reactant.to_rarray(y; track_numbers=Number)
+        @test Bool(@jit(isapprox(x, y_ra))) == expected
+    end
+
+    @testset "≈ operator" begin
+        x_ra = Reactant.to_rarray(1.0; track_numbers=Number)
+        y_ra = Reactant.to_rarray(1.0 + 1e-12; track_numbers=Number)
+        z_ra = Reactant.to_rarray(2.0; track_numbers=Number)
+        @test Bool(@jit(x_ra ≈ y_ra))
+        @test !Bool(@jit(x_ra ≈ z_ra))
+    end
+end
+
 @testset "mod and rem" begin
     a = [-1.1, 7.7, -3.3, 9.9, -5.5]
     b = [6.6, -2.2, -8.8, 4.4, -10.1]


### PR DESCRIPTION
## Summary
- The `TracedRNumber` `isapprox` method hardcoded `rtol=sqrt(eps(T))` regardless of `atol`. Base's `isapprox` forces `rtol=0` when `atol>0` is passed without an explicit `rtol`, so the traced version was silently using a much looser tolerance than plain Julia in that case (e.g. `isapprox(1e10, 1e10+100.0; atol=1.0)` traced to `true` instead of `false`).
- Fixed the default to `atol > 0 ? zero(T) : sqrt(eps(T))`, matching Base semantics.
- Added an `isapprox` testset in `test/core/math_ops.jl` that traces the comparison through `@jit` (required, since `ConcreteRNumber`'s `isapprox` bypasses the traced method) across a matrix of values (equal/near/far, zero, large-magnitude, NaN, ±Inf, Float32/Float64) and keyword combos (`atol`, `rtol`, both, `nans`, custom `norm`), checking against plain Julia `isapprox` as ground truth, for traced-vs-traced, traced-vs-real, and real-vs-traced argument orders, plus the `≈` operator.

## Test plan
- [x] `julia --project=test test/core/math_ops.jl` — new `isapprox` testset: 302/302 pass
- [x] Rest of `math_ops.jl` file continues to pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDKTyrG4ZevKvefgvMUtTP