### PR TITLE
Skip the BF16 CUDA test where LLVM cannot select bf16 vectors

### DIFF
--- a/test/integration/cuda.jl
+++ b/test/integration/cuda.jl
@@ -5,6 +5,23 @@ const ReactantCUDAExt = Base.get_extension(Reactant, :ReactantCUDAExt)
 
 const RunningOnTPU = contains(string(Reactant.devices()[1]), "TPU")
 
+# LLVM's X86 backend marks bf16 vector types legal on hosts advertising avx512_bf16 but has
+# no selection patterns for them, so vectorized bf16 code aborts during instruction
+# selection. With LLVM.jl loaded (which installs a throwing fatal-error handler) that abort
+# instead unwinds out of the codegen lock and hangs the session, ignoring SIGTERM -- which
+# is a miserable thing to hit while bisecting something unrelated.
+#
+# Bounded by Julia version rather than by LLVM version: this is fixed in LLVM 19, but Julia
+# may equally ship a workaround in a 1.12 patch release while still on LLVM 18, and then
+# the test should start running again on its own.
+# See JuliaLang/julia#62666 and JuliaLLVM/LLVM.jl#581.
+const BF16IselBroken =
+    Sys.ARCH === :x86_64 &&
+    VERSION <= v"1.12.6" &&
+    Sys.islinux() &&
+    isfile("/proc/cpuinfo") &&
+    occursin("avx512_bf16", read("/proc/cpuinfo", String))
+
 @testset "Promote CuTraced" begin
     TFT = ReactantCUDAExt.CuTracedRNumber{Float64,1}
     FT = Float64
@@ -67,13 +84,21 @@ end
 end
 
 @static if VERSION >= v"1.12"
-    @testset "Square BF16 raised Kernel" begin
-        oA = collect(BFloat16, 1:1:64)
-        A = Reactant.to_rarray(oA)
-        B = Reactant.to_rarray(100 .* oA)
-        @jit raise = true square!(A, B)
-        @test all(Array(A) .≈ (oA .* oA .* 100))
-        @test all(Array(B) .≈ (oA .* 100))
+    if BF16IselBroken
+        @warn "Skipping BF16 kernel tests: this host advertises avx512_bf16 and Julia's \
+               LLVM ($(Base.libllvm_version)) cannot select bf16 vectors, so the test \
+               would abort or hang rather than fail. Re-run with \
+               `--cpu-target=$(Sys.CPU_NAME),-avx512bf16` to exercise them. \
+               See JuliaLang/julia#62666."
+    else
+        @testset "Square BF16 raised Kernel" begin
+            oA = collect(BFloat16, 1:1:64)
+            A = Reactant.to_rarray(oA)
+            B = Reactant.to_rarray(100 .* oA)
+            @jit raise = true square!(A, B)
+            @test all(Array(A) .≈ (oA .* oA .* 100))
+            @test all(Array(B) .≈ (oA .* 100))
+        end
     end
 end
 


### PR DESCRIPTION
Test-only change, independent of #3169.

### Problem

On x86 hosts advertising `avx512_bf16` (AMD Zen 4/5, Cooper Lake, Sapphire Rapids), LLVM marks bf16 vector types legal but has no selection patterns for them. `collect(BFloat16, 1:64)` — the first line of the `Square BF16 raised Kernel` testset — therefore aborts during instruction selection:

```
LLVM ERROR: Cannot select: v32bf16 = insert_subvector ...
```

With LLVM.jl loaded, which is always the case for this suite, it is worse than an abort. LLVM.jl installs a **process-global** fatal error handler that throws; the throw unwinds out of `jl_compile_codeinst_now` with the codegen lock still held, and displaying the exception needs to compile a method, which blocks on that same lock:

```
wait at julia_locks.h:131
jl_compile_codeinst_now at jitlayers.cpp:742
...
scrub_repl_backtrace at client.jl:101
```

The suite hangs forever, prints nothing, and ignores `SIGTERM`. On this machine `test/integration/cuda.jl` had never once completed — it wedged at that testset every time, which is a thoroughly unhelpful thing to run into while bisecting something unrelated.

Upstream: JuliaLang/julia#62666 (the ISel bug, with a package-free reproducer) and JuliaLLVM/LLVM.jl#581 (the handler turning the abort into a hang).

### Change

Skip that testset on affected hosts, with a warning naming the cause and the invocation that runs it anyway:

```
┌ Warning: Skipping BF16 kernel tests: this host advertises avx512_bf16 and Julia's LLVM
│ (18.1.7) cannot select bf16 vectors, so the test would abort or hang rather than fail.
│ Re-run with `--cpu-target=znver4,-avx512bf16` to exercise them. See JuliaLang/julia#62666.
```

Bounded by **Julia** version rather than LLVM version. The underlying bug is fixed in LLVM 19, but Julia may equally ship a workaround in a 1.12 patch release while still on LLVM 18, and in that case the test should start running again on its own.

### CI impact: none

CI machines do not advertise `avx512_bf16`, so the predicate is `false` there and the testset runs exactly as before. The skip only triggers on developer hardware that would otherwise hang.

Verified locally (AMD Threadripper PRO 7995WX, Julia 1.12.4):

| | before | after |
|---|---|---|
| `julia test/integration/cuda.jl` | hangs indefinitely, ignores SIGTERM | warns, 13 testsets, exit 0 |
| with `--cpu-target=znver4,-avx512bf16` | 26 pass / 0 fail | 26 pass / 0 fail |

Predicate spot-checked as `true` on 1.12.4 and `false` on 1.13.0-rc1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PH4zH9zvavbXWXomJbCq3B
