### PR TITLE
Keep LLVM's lazy signal handlers from displacing Julia's on ROCm

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -47,6 +47,11 @@
 #include "src/enzyme_ad/jax/compile_with_xla.h"
 #include "llvm/Support/TargetSelect.h"
 
+#if defined(REACTANT_ROCM) && !defined(_WIN32)
+#include "llvm/Support/Signals.h"
+#include <csignal>
+#endif
+
 #include "mlir/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.h"
 #include "stablehlo/dialect/ChloOps.h"
 #include "stablehlo/dialect/StablehloOps.h"
@@ -354,12 +359,68 @@ T *unwrap_absl_statusor(absl::StatusOr<T> status, char **error_msg) {
 // int google::protobuf::io::CodedInputStream::default_recursion_limit_ = 100;
 // int xla::_LayoutProto_default_instance_;
 
+#if defined(REACTANT_ROCM) && !defined(_WIN32)
+// LLVM installs its crash handlers (llvm/lib/Support/Unix/Signals.inc) lazily,
+// the first time anything reaches RegisterHandlers() -- via RemoveFileOnSignal,
+// AddSignalHandler, PrintStackTraceOnErrorSignal or CrashRecoveryContext. In
+// practice XLA's AMDGPU backend gets there through
+// llvm::sys::fs::TempFile::create during kernel codegen (the in-process lld
+// link of the HSACO writes its output through FileOutputBuffer ->
+// TempFile::create -> RemoveFileOnSignal), long after Julia has installed its
+// own handlers. The NVPTX path shells out to ptxas with tsl-created temp files
+// and never reaches LLVM's signal machinery, which is why only ROCm hits this
+// today.
+//
+// That is fatal in a Julia host. Julia implements GC safepoints as a
+// read-protected page plus a SIGSEGV handler, so SIGSEGV is ordinary control
+// flow that fires constantly on every thread. LLVM registers with SA_RESETHAND:
+// the next safepoint fault is delivered to LLVM's handler, the disposition is
+// reset to SIG_DFL, and the next concurrent safepoint fault on any other thread
+// kills the process -- exit 139, with no output from either runtime. LLVM also
+// takes SIGINT, SIGUSR2 and SIGQUIT, which are Julia's Ctrl-C, profiler and
+// backtrace-dump signals respectively.
+//
+// Force that registration to happen exactly once, here, where we can still put
+// the host's handlers back. Note we deliberately do NOT call
+// llvm::sys::unregisterHandlers(): that zeroes NumRegisteredSignals and would
+// let the next RemoveFileOnSignal() re-register. Leaving the counter non-zero
+// makes every later call early-out without touching sigaction.
+//
+// Cost: LLVM no longer prints a stack trace or unlinks its temp files on an
+// abnormal exit. Julia owns the fatal-signal path in this process anyway.
+static void TameLLVMSignalHandlers() {
+  // IntSigs + KillSigs + InfoSigs from Signals.inc. SIGUSR1 (InfoSigs) is
+  // blocked process-wide by Julia and consumed via sigwait, so LLVM's handler
+  // for it could never fire -- restore it anyway rather than rely on that.
+  static const int Sigs[] = {SIGHUP,  SIGINT,  SIGTERM, SIGUSR2, SIGILL,
+                             SIGTRAP, SIGABRT, SIGFPE,  SIGBUS,  SIGSEGV,
+                             SIGQUIT, SIGSYS,  SIGXCPU, SIGXFSZ, SIGUSR1};
+  constexpr int N = sizeof(Sigs) / sizeof(Sigs[0]);
+
+  struct sigaction Host[N];
+  for (int I = 0; I < N; ++I)
+    sigaction(Sigs[I], nullptr, &Host[I]);
+
+  // Any public entry point into Signals.inc arms the registration. This one is
+  // what XLA itself reaches; the filename never exists, so the cleanup entry is
+  // inert.
+  llvm::sys::RemoveFileOnSignal("");
+
+  for (int I = 0; I < N; ++I)
+    sigaction(Sigs[I], &Host[I], nullptr);
+}
+#endif
+
 REACTANT_ABI void InitializeLogs() {
   const char *binary = "julia";
   int argc = 1;
   char *argv[] = {(char *)binary};
   char **argv2 = &argv[0];
   tsl::port::InitMain(binary, &argc, &argv2);
+
+#if defined(REACTANT_ROCM) && !defined(_WIN32)
+  TameLLVMSignalHandlers();
+#endif
   LLVMInitializeX86Target();
   LLVMInitializeX86TargetInfo();
   LLVMInitializeX86TargetMC();


### PR DESCRIPTION
Fixes the no-traceback `exit 139` crash on AMD GPUs reported by @ftynse while bringing an Oceananigans adjoint up on gfx950 (issue 1 of [these findings](https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca); patch from [this gist](https://gist.github.com/ftynse/730ab9b19ec41c36da1111b414b599fa), applied here gated behind `REACTANT_ROCM`).

## The bug

LLVM installs its crash handlers lazily, the first time anything reaches `RegisterHandlers()` in `llvm/lib/Support/Unix/Signals.inc`. On the ROCm compile path that happens mid-flight: XLA's AMDGPU backend links each HSACO with **in-process lld**, and lld's output write goes

`lld::lldMain` → ELF `Writer.cpp` `FileOutputBuffer::create` → `createOnDiskBuffer` → `fs::TempFile::create` → `sys::RemoveFileOnSignal` → `RegisterHandlers()`

(verified against the LLVM/XLA versions pinned by this repo). That installs process-wide `SA_RESETHAND` handlers for 14 signals — including SIGSEGV, which Julia uses as *ordinary control flow*: GC safepoints are a read-protected page plus a SIGSEGV handler (`signals-unix.c` / `safepoint.c`). After the first AMD kernel compile, the next safepoint fault is delivered to LLVM's handler, the disposition resets to `SIG_DFL`, and the process dies with exit 139 and no output from either runtime — nowhere near the code that caused it. LLVM also takes SIGINT, SIGUSR2, and SIGQUIT (Julia's Ctrl-C, profiler wakeup, and backtrace dump).

The NVPTX path shells out to `ptxas` with tsl-created temp files and never touches LLVM's signal machinery — which is why CUDA has never hit this. (Also checked: lld's `CrashRecoveryContext` is inert here since nothing linked into libReactantExtra calls `CrashRecoveryContext::Enable()`.)

## The fix

`TameLLVMSignalHandlers()`, called once from `InitializeLogs()` (which Reactant's `__init__` runs before any client exists): capture the host's handlers, force LLVM's one-time registration via `RemoveFileOnSignal("")`, and restore the host's handlers. All later entry points into `Signals.inc` early-out because `NumRegisteredSignals` stays non-zero — and we deliberately do **not** call `llvm::sys::unregisterHandlers()`, which would zero that counter and re-arm the lazy registration.

Two deltas from the original gist patch:

- **Gated behind `#if defined(REACTANT_ROCM) && !defined(_WIN32)`** for now, since only the ROCm compile path is known to reach the registration. (The function is harmless on any backend, so un-gating later is a two-line change if a CUDA/CPU path ever reaches `RegisterHandlers` — e.g. via clang driver temp files.)
- **SIGUSR1 added to the restore list** (LLVM's `InfoSigs` on Linux). Julia blocks SIGUSR1 process-wide and consumes it via `sigwait` on the signal-listener thread, so LLVM's leftover handler could never actually fire — restored anyway rather than relying on that.

Cost, as the comment states: LLVM no longer prints its stack trace or unlinks temp files on abnormal exit. Julia owns the fatal-signal path in this process anyway.

## Verification

Source-level only — **no AMD GPU available locally**, so this is untested on real ROCm hardware. The diagnosis and mechanism were verified against the pinned sources (LLVM `Signals.inc` registration guard + `SA_RESETHAND` flags, the lld→`TempFile`→`RemoveFileOnSignal` chain, Julia's segv/safepoint machinery), the block passes a standalone syntax check, and clang-format is clean. @ftynse confirmed the un-gated version of this patch fixes the crash on gfx950 (their workaround was binary-patching `RegisterHandlers` to `ret` via LD_PRELOAD, same effect).

Remaining ROCm issues from the same findings doc (not addressed here): teardown `error()` calls masking real compile failures (`src/mlir/IR/{Context,Module,Block}.jl`, `src/Ops.jl`), the eager-kernel lowering unconditionally building `sm_XX` from `device_properties` that are only populated for CUDA (`src/compiler/Compiler.jl:336`, `src/xla/Device.jl:51`), and the XLA-side autotuner/command-buffer/BFC issues. Happy to file those as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015drPT8jCwS74HnX6vEBCxz