### PR TITLE
Don't let unbalanced teardowns replace the in-flight exception

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -201,8 +201,13 @@ function constant_context(; throw_error::Core.Bool=true)
 end
 
 function deactivate_constant_context!(blk::MLIR.IR.Block)
-    constant_context()[1] == blk || error("Deactivating wrong block")
-    return Base.pop!(task_local_storage(:entry_block)::Vector{__TLSEntryBlockType})
+    stack = task_local_storage(:entry_block)::Vector{__TLSEntryBlockType}
+    if isempty(stack) || !isassigned(stack, lastindex(stack))
+        MLIR.IR.unbalanced_teardown("Deactivating a constant context but none is active")
+        return nothing
+    end
+    last(stack)[1] == blk || MLIR.IR.unbalanced_teardown("Deactivating wrong block")
+    return Base.pop!(stack)
 end
 
 # constant ops

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -209,10 +209,16 @@ function activate_raising!(is_raising::Bool)
 end
 
 function deactivate_raising!(is_raising::Bool)
-    key = :reactant_is_raising
-    is_raising === last(task_local_storage(key)::Vector{Bool}) ||
-        error("Deactivating wrong Reactant raising context")
-    return pop!(task_local_storage(key)::Vector{Bool})
+    stack = task_local_storage(:reactant_is_raising)::Vector{Bool}
+    if isempty(stack)
+        MLIR.IR.unbalanced_teardown(
+            "Deactivating a Reactant raising context but none is active"
+        )
+        return nothing
+    end
+    is_raising === last(stack) ||
+        MLIR.IR.unbalanced_teardown("Deactivating wrong Reactant raising context")
+    return pop!(stack)
 end
 
 function raising(; throw_error::Bool=true)
@@ -1526,9 +1532,13 @@ for cache_type in (:callcache, :sdycache, :sdygroupidcache, :debugcache)
         end
 
         function $(deactivate_fn)(cache)
-            cache === last(task_local_storage($(Meta.quot(cache_type)))::Vector) ||
-                error("Deactivating wrong cache")
-            return pop!(task_local_storage($(Meta.quot(cache_type)))::Vector)
+            stack = task_local_storage($(Meta.quot(cache_type)))::Vector
+            if isempty(stack) || !isassigned(stack, lastindex(stack))
+                MLIR.IR.unbalanced_teardown("Deactivating a cache but none is active")
+                return nothing
+            end
+            cache === last(stack) || MLIR.IR.unbalanced_teardown("Deactivating wrong cache")
+            return pop!(stack)
         end
 
         function $(has_fn)()

--- a/src/mlir/IR/Block.jl
+++ b/src/mlir/IR/Block.jl
@@ -218,8 +218,13 @@ function activate(blk::Block)
 end
 
 function deactivate(blk::Block)
-    current_block() == blk || error("Deactivating wrong block")
-    return Base.pop!(task_local_storage(:mlir_block))
+    stack = task_local_storage(:mlir_block)::Vector{Block}
+    if isempty(stack)
+        unbalanced_teardown("Deactivating a block but no block is active")
+        return nothing
+    end
+    last(stack) == blk || unbalanced_teardown("Deactivating wrong block")
+    return Base.pop!(stack)
 end
 
 function has_block()

--- a/src/mlir/IR/Context.jl
+++ b/src/mlir/IR/Context.jl
@@ -45,8 +45,13 @@ function activate(ctx::Context)
 end
 
 function deactivate(ctx::Context)
-    current_context() == ctx || error("Deactivating wrong context")
-    return Base.pop!(task_local_storage(:mlir_context_stack)::Vector{Context})
+    stack = task_local_storage(:mlir_context_stack)::Vector{Context}
+    if isempty(stack)
+        unbalanced_teardown("Deactivating a context but no context is active")
+        return nothing
+    end
+    last(stack) == ctx || unbalanced_teardown("Deactivating wrong context")
+    return Base.pop!(stack)
 end
 
 function has_context()

--- a/src/mlir/IR/Module.jl
+++ b/src/mlir/IR/Module.jl
@@ -76,8 +76,13 @@ function activate(blk::Module)
 end
 
 function deactivate(blk::Module)
-    current_module() == blk || error("Deactivating wrong block")
-    return Base.pop!(task_local_storage(:mlir_module)::Vector{Module})
+    stack = task_local_storage(:mlir_module)::Vector{Module}
+    if isempty(stack)
+        unbalanced_teardown("Deactivating a module but no module is active")
+        return nothing
+    end
+    last(stack) == blk || unbalanced_teardown("Deactivating wrong module")
+    return Base.pop!(stack)
 end
 
 function has_module()

--- a/src/mlir/IR/Utils.jl
+++ b/src/mlir/IR/Utils.jl
@@ -2,6 +2,24 @@ function mlirIsNull(val)
     return val.ptr == C_NULL
 end
 
+"""
+    unbalanced_teardown(msg)
+
+Report an unbalanced activation-stack teardown.
+
+Teardowns run in `finally` blocks, so when a compile fails part-way the stacks
+are often legitimately unbalanced. Throwing from the `finally` would *replace*
+the in-flight exception with this secondary symptom — repeatedly, once per
+nested teardown — burying the real error. Outside of unwinding an unbalanced
+stack is a genuine bug, so throw as before; during unwinding, warn and let the
+original exception propagate.
+"""
+function unbalanced_teardown(msg::AbstractString)
+    isempty(Base.current_exceptions()) && error(msg)
+    @warn "$msg (suppressed while another exception is unwinding; the original error will propagate)"
+    return nothing
+end
+
 function print_callback(str::API.MlirStringRef, userdata)
     data = unsafe_wrap(Array, Base.convert(Ptr{Cchar}, str.data), str.length; own=false)
     write(userdata isa Base.RefValue ? userdata[] : userdata, data)

--- a/test/core/compile.jl
+++ b/test/core/compile.jl
@@ -668,3 +668,46 @@ end
         x
     ))
 end
+
+@testset "unbalanced teardowns don't mask the in-flight exception" begin
+    IR = Reactant.MLIR.IR
+    ctx1 = IR.Context()
+    ctx2 = IR.Context()
+
+    # Outside of unwinding, a mismatched deactivate is still an error.
+    IR.activate(ctx1)
+    @test_throws "Deactivating wrong context" IR.deactivate(ctx2)
+    IR.deactivate(ctx1)
+
+    # During unwinding, the original exception must survive both a mismatched
+    # and an empty-stack teardown instead of being replaced by them.
+    err = try
+        IR.activate(ctx1)
+        try
+            error("the real error")
+        finally
+            @test_warn "Deactivating wrong context" IR.deactivate(ctx2)
+            @test_warn "no context is active" IR.deactivate(ctx1)
+        end
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test err.msg == "the real error"
+
+    # Same for the compiler's raising-context stack.
+    err = try
+        Reactant.Compiler.activate_raising!(true)
+        try
+            error("the real error")
+        finally
+            @test_warn "Deactivating wrong Reactant raising context" Reactant.Compiler.deactivate_raising!(
+                false
+            )
+        end
+    catch e
+        e
+    end
+    @test err isa ErrorException
+    @test err.msg == "the real error"
+end


### PR DESCRIPTION
Fixes issue 2 of @ftynse's [ROCm findings](https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca): every failing compile that leaves an activation stack unbalanced reports as `Deactivating wrong context` / `Deactivating wrong block` / `Deactivating wrong cache` / `UndefRefError` instead of the actual error.

## The bug

Reactant maintains seven task-local activation stacks — MLIR context (`src/mlir/IR/Context.jl`), module, block, the constant-context entry block (`src/Ops.jl`), the raising flag, and the compiler caches (`src/compiler/Compiler.jl`) — each torn down from a `finally` whose mismatch branch calls `error()`. A compile that fails part-way usually leaves one of them unbalanced; the teardown then fires *during unwinding*, and an exception thrown from a `finally` **replaces** the in-flight one. Because the frames nest, so do the masks — on the ROCm workload a single nested compile failure surfaced as four different wrong answers before the real one. For anything driving Reactant programmatically (a sweep recording a `status` column per configuration), every distinct compile failure collapses into the same meaningless artifact.

## The fix

A single helper, `MLIR.IR.unbalanced_teardown(msg)`:

- **Not unwinding** (`Base.current_exceptions()` empty): `error(msg)` exactly as before — a mismatch on the success path is a genuine bug and keeps failing loudly.
- **Unwinding**: emit a warning and return, so the original exception propagates. The teardown still pops defensively, keeping the stack arithmetic consistent for outer frames.

All seven mismatch branches route through it, and the empty-stack / unassigned-final-slot cases — which previously threw `BoundsError`/`UndefRefError` from the same `finally` blocks (the gist's fourth mask) — are handled the same way via `isempty`/`isassigned` guards. Also corrects `deactivate(::Module)`'s copy-pasted "Deactivating wrong block" message.

Behavior on balanced stacks is byte-identical (same pop, same return value).

## Verification

New regression test in `test/core/compile.jl` covers: mismatch outside unwinding still throws; during unwinding both a mismatched and an empty-stack teardown warn while the original `ErrorException` survives, for the MLIR context stack and the compiler raising stack. Verified locally along with a normal `@jit` compile and a failing-trace compile behaving unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015drPT8jCwS74HnX6vEBCxz