### PR TITLE
Query ROCm device properties for kernel lowering instead of sm_XX garbage

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -1006,6 +1006,71 @@ CudaGetStreamExecutorDeviceDescription(int32_t device_id) {
 
 #endif
 
+#ifdef REACTANT_ROCM
+
+#include "rocm/include/hip/hip_runtime.h"
+
+REACTANT_ABI void ReactantHipDeviceGetProperties(DeviceProperties *jlprops,
+                                                 int32_t device_id) {
+  hipDeviceProp_t props;
+  hipError_t err = hipGetDeviceProperties(&props, device_id);
+  if (err != hipSuccess) {
+    ReactantThrowError((std::string("hipGetDeviceProperties failed: ") +
+                        hipGetErrorString(err))
+                           .c_str());
+    return;
+  }
+
+  jlprops->totalGlobalMem = props.totalGlobalMem;
+  jlprops->sharedMemPerBlock = props.sharedMemPerBlock;
+  jlprops->regsPerBlock = props.regsPerBlock;
+  jlprops->warpSize = props.warpSize;
+  jlprops->maxThreadsPerBlock = props.maxThreadsPerBlock;
+  jlprops->maxThreadsDim[0] = props.maxThreadsDim[0];
+  jlprops->maxThreadsDim[1] = props.maxThreadsDim[1];
+  jlprops->maxThreadsDim[2] = props.maxThreadsDim[2];
+  jlprops->maxGridSize[0] = props.maxGridSize[0];
+  jlprops->maxGridSize[1] = props.maxGridSize[1];
+  jlprops->maxGridSize[2] = props.maxGridSize[2];
+  jlprops->totalConstMem = props.totalConstMem;
+  jlprops->major = props.major;
+  jlprops->minor = props.minor;
+  jlprops->multiProcessorCount = props.multiProcessorCount;
+  jlprops->canMapHostMemory = props.canMapHostMemory;
+  jlprops->l2CacheSize = props.l2CacheSize;
+  jlprops->maxThreadsPerMultiProcessor = props.maxThreadsPerMultiProcessor;
+}
+
+// Returns the LLVM target id of the device, e.g. "gfx950:sramecc+:xnack-".
+// The caller owns the returned string.
+REACTANT_ABI const char *ReactantHipDeviceGetGCNArchName(int32_t device_id) {
+  hipDeviceProp_t props;
+  hipError_t err = hipGetDeviceProperties(&props, device_id);
+  if (err != hipSuccess) {
+    ReactantThrowError((std::string("hipGetDeviceProperties failed: ") +
+                        hipGetErrorString(err))
+                           .c_str());
+    return nullptr;
+  }
+  return cstr_from_string(props.gcnArchName);
+}
+
+#else
+
+REACTANT_ABI void ReactantHipDeviceGetProperties(DeviceProperties *jlprops,
+                                                 int32_t device_id) {
+  ReactantThrowError("ReactantHipDeviceGetProperties: this build of "
+                     "libReactantExtra was compiled without ROCm support");
+}
+
+REACTANT_ABI const char *ReactantHipDeviceGetGCNArchName(int32_t device_id) {
+  ReactantThrowError("ReactantHipDeviceGetGCNArchName: this build of "
+                     "libReactantExtra was compiled without ROCm support");
+  return nullptr;
+}
+
+#endif
+
 REACTANT_ABI const char *
 deviceDescriptionToString(stream_executor::DeviceDescription *device) {
   return cstr_from_string(device->ToString());

--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -1428,6 +1428,7 @@ cc_library(
         "@xla//xla/stream_executor:kernel",
         "@xla//xla/stream_executor/cuda:all_runtime",
     ]) + if_rocm([
+        "@local_config_rocm//rocm:rocm_headers",
         "@xla//xla/service:gpu_plugin",
         "@xla//xla/pjrt/c:pjrt_c_api_gpu",
         "@xla//xla/pjrt/gpu:se_gpu_pjrt_client",

--- a/src/Reactant.jl
+++ b/src/Reactant.jl
@@ -363,6 +363,23 @@ function initialize_ptrs()
             )
         end
     end
+    # On ROCm builds libReactantExtra links the HIP runtime; map the module
+    # API for lower-jit's generated launch code (the HIP twin of the cu* set
+    # above).
+    if Libdl.dlsym(
+        Reactant_jll.libReactantExtra_handle, :hipModuleLoadData; throw_error=false
+    ) !== nothing
+        for name in (
+            "hipModuleLaunchKernel",
+            "hipModuleLoadData",
+            "hipModuleGetFunction",
+            "hipStreamSynchronize",
+        )
+            MLIR.API.EnzymeJaXMapSymbol(
+                name, Libdl.dlsym(Reactant_jll.libReactantExtra_handle, name)
+            )
+        end
+    end
 end
 
 function __init__()

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -327,14 +327,30 @@ function compile_mlir!(
             jit = "lower-jit{openmp=$(OpenMP[]) backend=cpu},symbol-dce"
         end
     else
+        is_rocm = lowercase(XLA.platform_name(client)) == "rocm"
+        gpu_backend = is_rocm ? "rocm" : "cuda"
+        # HSACO serialization links the ROCm device libraries from the toolkit.
+        is_rocm && (toolkit = get(ENV, "ROCM_PATH", "/opt/rocm"))
+
         kern = if is_raising
             "lower-kernel{backend=cpu},symbol-dce,canonicalize"
         else
-            "lower-kernel,canonicalize"
+            "lower-kernel{backend=$(gpu_backend)},canonicalize"
         end
 
-        device_properties = XLA.device_properties(XLA.default_device(client))
-        cubinChip = "sm_$(device_properties.major)$(device_properties.minor)"
+        if is_rocm
+            # LLVM target id, e.g. "gfx950:sramecc+:xnack-": the token before
+            # the first ':' is the chip; the remaining tokens are target
+            # features in "name±" form, which LLVM spells "±name".
+            arch = XLA.device_gcn_arch(XLA.default_device(client))
+            parts = split(arch, ':')
+            cubinChip = String(first(parts))
+            chipFeatures = join(("$(p[end])$(p[1:(end - 1)])" for p in parts[2:end]), ",")
+        else
+            device_properties = XLA.device_properties(XLA.default_device(client))
+            cubinChip = "sm_$(device_properties.major)$(device_properties.minor)"
+            chipFeatures = cubinFeatures()
+        end
 
         if DEBUG_KERNEL[]
             curesulthandler = dlsym(
@@ -346,7 +362,7 @@ function compile_mlir!(
         else
             extra_lowerjit_options = ""
         end
-        jit = "lower-jit{$(extra_lowerjit_options)cuOptLevel=$(cuOptLevel[]) cubinFormat=$(cubinFormat[]) indexBitWidth=$(cuindexBitWidth[])  cubinChip=$(cubinChip) cubinFeatures=$(cubinFeatures()) run_init=true toolkitPath=$toolkit},symbol-dce"
+        jit = "lower-jit{$(extra_lowerjit_options)backend=$(gpu_backend) cuOptLevel=$(cuOptLevel[]) cubinFormat=$(cubinFormat[]) indexBitWidth=$(cuindexBitWidth[])  cubinChip=$(cubinChip) cubinFeatures=$(chipFeatures) run_init=true toolkitPath=$toolkit},symbol-dce"
     end
 
     recognize_comms = true

--- a/src/mlir/libMLIR_h.jl
+++ b/src/mlir/libMLIR_h.jl
@@ -15424,6 +15424,16 @@ function ReactantCudaDeviceGetProperties(jlprops, device_id)
     )::Cvoid
 end
 
+function ReactantHipDeviceGetProperties(jlprops, device_id)
+    @ccall mlir_c.ReactantHipDeviceGetProperties(
+        jlprops::Ptr{DeviceProperties}, device_id::Int32
+    )::Cvoid
+end
+
+function ReactantHipDeviceGetGCNArchName(device_id)
+    @ccall mlir_c.ReactantHipDeviceGetGCNArchName(device_id::Int32)::Cstring
+end
+
 function ReactantCudaGetRegsSpillsMaxThreadsFromBinary(
     binary, fnname, regs, spills, maxThreads
 )

--- a/src/xla/Device.jl
+++ b/src/xla/Device.jl
@@ -52,11 +52,78 @@ function device_properties(device::AbstractDevice)
         GC.@preserve jldevprops begin
             MLIR.API.ReactantCudaDeviceGetProperties(jldevprops, local_hardware_id)
         end
+    elseif pname == "rocm"
+        if _has_hip_device_properties()
+            GC.@preserve jldevprops begin
+                MLIR.API.ReactantHipDeviceGetProperties(jldevprops, local_hardware_id)
+            end
+        else
+            # Older builds of libReactantExtra predate the HIP property query;
+            # fill CDNA-flavored defaults rather than hand back an unfilled Ref.
+            @warn "This build of libReactantExtra cannot query ROCm device \
+                   properties; using defaults" maxlog = 1
+            jldevprops[] = _default_rocm_device_properties()
+        end
     else
-        @warn "`get_properties` not implemented for platform: $(pname)" maxlog = 1
+        # Erroring beats the alternative: an unfilled Ref would hand the caller
+        # (and the cache) a struct of uninitialized memory.
+        error("`device_properties` is not implemented for platform: $(pname)")
     end
     DEVICE_PROPERTIES_CACHE[(local_hardware_id, pname)] = jldevprops[]
     return jldevprops[]
+end
+
+function _has_hip_device_properties()
+    return Libdl.dlsym(
+        Reactant_jll.libReactantExtra_handle,
+        :ReactantHipDeviceGetProperties;
+        throw_error=false,
+    ) !== nothing
+end
+
+# Conservative CDNA (Instinct-class) defaults, for libReactantExtra builds that
+# predate `ReactantHipDeviceGetProperties`. Sizes we cannot guess are 0.
+function _default_rocm_device_properties()
+    return MLIR.API.DeviceProperties(
+        0,                          # totalGlobalMem (unknown)
+        65536,                      # sharedMemPerBlock: 64 KiB LDS
+        65536,                      # regsPerBlock
+        64,                         # warpSize: CDNA wavefront
+        1024,                       # maxThreadsPerBlock
+        (1024, 1024, 1024),         # maxThreadsDim
+        (2147483647, 65536, 65536), # maxGridSize
+        2147483647,                 # totalConstMem
+        9,                          # major (gfx9xx)
+        0,                          # minor
+        0,                          # multiProcessorCount (unknown)
+        1,                          # canMapHostMemory
+        0,                          # l2CacheSize (unknown)
+        2048,                       # maxThreadsPerMultiProcessor
+    )
+end
+
+"""
+    device_gcn_arch(device::AbstractDevice)
+
+Return the LLVM target id of a ROCm device, e.g. `"gfx950:sramecc+:xnack-"`.
+Falls back to a generic default (with a warning) on builds of libReactantExtra
+that cannot query it.
+"""
+function device_gcn_arch(device::AbstractDevice)
+    pname = platform_name(client(device))
+    pname == "rocm" || error("`device_gcn_arch` requires a ROCm device, got: $(pname)")
+
+    if Libdl.dlsym(
+        Reactant_jll.libReactantExtra_handle,
+        :ReactantHipDeviceGetGCNArchName;
+        throw_error=false,
+    ) !== nothing
+        str = MLIR.API.ReactantHipDeviceGetGCNArchName(get_local_hardware_id(device))
+        return unsafe_string_and_free(str)
+    end
+    @warn "This build of libReactantExtra cannot query the ROCm gcn arch; \
+           defaulting to gfx942" maxlog = 1
+    return "gfx942"
 end
 
 function Base.show(io::IO, ::MIME"text/plain", props::MLIR.API.DeviceProperties)


### PR DESCRIPTION
Fixes issue 3 of @ftynse's [ROCm findings](https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca): eager KernelAbstractions kernels fail deep inside codegen on ROCm with no indication of the actual problem.

**Reworked per review** — ROCm no longer raises like TPU; it queries real device properties (or falls back to reasonable defaults on older jlls).

## The bug, in two layers

1. **`XLA.device_properties` returned uninitialized memory on non-CUDA platforms.** `src/xla/Device.jl` created `Ref{MLIR.API.DeviceProperties}()`, only filled it when `pname == "cuda"`, warned otherwise — then read and *cached* the unfilled Ref.
2. **The GPU branch of `compile_mlir!` built `cubinChip = "sm_$(major)$(minor)"` from those properties unconditionally**, so on ROCm every compile fed a garbage `sm_XX` string into `lower-jit`.

## The fix

**C++ (`API.cpp` + `BUILD`)** — mirror the CUDA query for HIP:
- `ReactantHipDeviceGetProperties(DeviceProperties*, device_id)` via `hipGetDeviceProperties` (`hipDeviceProp_t` is field-for-field compatible with the CUDA-derived `DeviceProperties` struct, so no ABI change).
- `ReactantHipDeviceGetGCNArchName(device_id)` returning the device's LLVM target id, e.g. `"gfx950:sramecc+:xnack-"` (same source XLA's own `RocmExecutor` uses).
- Real under `REACTANT_ROCM`, throwing stubs otherwise; `@local_config_rocm//rocm:rocm_headers` added to the `if_rocm` deps for the include.

**Julia:**
- `XLA.device_properties` dispatches on platform: CUDA query, HIP query on `"rocm"` — with a **fallback to conservative CDNA defaults** (wave64, 64 KiB LDS, 1024 threads/block, …, plus a warning) when running against a libReactantExtra that predates the new entry points, detected via `dlsym`. Platforms with no implementation now error instead of returning uninitialized memory.
- New `XLA.device_gcn_arch(device)` with the same old-jll fallback (`"gfx942"`, warned).
- `compile_mlir!` derives the lowering target from the target id on ROCm: chip = token before the first `:` (`gfx950`), features = remaining `name±` tokens converted to LLVM's `±name` spelling (`+sramecc,-xnack`). CUDA keeps the `sm_XX` / `+ptxNN` path untouched.
- Bindings hand-added to `libMLIR_h.jl` in generator style (the regenerate workflow will keep them).

## Verification

On CUDA hardware (RTX 5090): end-to-end `@jit` compile unchanged, `device_properties` still `sm_120`; target-id→chip/features conversion unit-tested (`gfx950:sramecc+:xnack-` → `gfx950` / `+sramecc,-xnack`, bare `gfx1100` → empty features); the fallback defaults struct constructs; `device_gcn_arch` correctly rejects non-ROCm devices. The HIP C++ block passes a standalone syntax check and mirrors `ReactantCudaDeviceGetProperties` 1:1 — **no AMD GPU available locally**, so the ROCm build/runtime legs need testing on real hardware (@ftynse). Needs a jll rebuild for the new entry points; until then ROCm hits the warned fallback path rather than garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015drPT8jCwS74HnX6vEBCxz
