### PR TITLE
Disable XLA command buffers by default on ROCm

### DIFF
--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -1337,6 +1337,7 @@ function compile_xla(
                 num_replicas=mlir_fn_res.num_replicas,
                 num_partitions=mlir_fn_res.num_partitions,
                 mesh_ids=mlir_fn_res.is_sharded ? global_device_ids : nothing,
+                platform=lowercase(XLA.platform_name(client)),
                 xla_debug_options=compile_options.xla_debug_options,
                 xla_executable_build_options=merge(
                     (;

--- a/src/xla/CompileOptions.jl
+++ b/src/xla/CompileOptions.jl
@@ -35,13 +35,24 @@ function get_default_compile_options()
     return proto
 end
 
-function get_debug_options(; kwargs...)
+function get_debug_options(; platform::String="", kwargs...)
     debug_options = get_default_debug_options()
 
     # default overrides. can we changed by the user by passing in kwargs
     @set! debug_options.xla_gpu_cuda_data_dir = CUDA_DATA_DIR[]
     @set! debug_options.xla_enable_enzyme_comms_opt = true
     @set! debug_options.xla_gpu_experimental_use_raft_select_k = true
+
+    if platform == "rocm"
+        # HIP graph replay of command buffers segfaults inside the HSA runtime
+        # on current ROCm stacks (deterministically, in the first execution of
+        # a while-loop command buffer). Default them off until that is fixed
+        # upstream; the user override below still wins.
+        # https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca (issue 6)
+        @set! debug_options.xla_gpu_enable_command_buffer = Vector{
+            Reactant.Proto.xla.var"DebugOptions.CommandBufferCmdType".T
+        }()
+    end
 
     if Reactant.PersistentCompileCache.kernel_cache_enabled()
         @set! debug_options.xla_gpu_kernel_cache_file = Reactant.PersistentCompileCache.get_kernel_cache_path()
@@ -70,6 +81,7 @@ function make_compile_options(;
     num_replicas::Int64=1,
     num_partitions::Int64=1,
     mesh_ids::Union{Vector{Int64},Nothing}=nothing,
+    platform::String="",
     xla_debug_options=(;),
     xla_executable_build_options=(;),
     xla_compile_options=(;),
@@ -77,7 +89,9 @@ function make_compile_options(;
     compile_options = get_default_compile_options()
     executable_build_options = compile_options.executable_build_options
 
-    @set! executable_build_options.debug_options = get_debug_options(; xla_debug_options...)
+    @set! executable_build_options.debug_options = get_debug_options(;
+        platform, xla_debug_options...
+    )
     @set! executable_build_options.num_replicas = num_replicas
     @set! executable_build_options.num_partitions = num_partitions
 

--- a/src/xla/IFRT/Array.jl
+++ b/src/xla/IFRT/Array.jl
@@ -323,6 +323,7 @@ function replicate_array_to_all_devices(array::Array, sharding, mesh, size_arr)
             device_id=-1,
             num_partitions=length(mesh.device_ids),
             mesh_ids=vec(mesh.device_ids),
+            platform=lowercase(XLA.platform_name(XLA.client(array))),
             xla_executable_build_options=(;
                 use_shardy_partitioner=true, use_spmd_partitioning=true
             ),


### PR DESCRIPTION
Mitigates issue 6 of @ftynse's [ROCm findings](https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca): `SIGSEGV` in `rocr::core::InterceptQueue::Submit` → `RocmCommandBuffer::LaunchGraph` on the first execution of a while-loop command buffer, on gfx950 / ROCm 7.1 — deterministic, after compile/spinup succeeded, and gone entirely with command buffers off (their `smoke08` vs `smoke09` runs).

## Change

`XLA.get_debug_options` / `make_compile_options` now take the client's `platform`; on `"rocm"` the `xla_gpu_enable_command_buffer` list is cleared — the per-compile equivalent of XLA's own documented escape hatch `--xla_gpu_enable_command_buffer=`. Both compile paths (PJRT `compile_mlir!` and the IFRT resharding path) pass the platform through.

The override ordering keeps this a *default*, not a lock-out: user kwargs are applied after, so `xla_debug_options=(; xla_gpu_enable_command_buffer=[...])` re-enables them — the right knob for testing whether a newer ROCm stack still crashes.

## Cost

Real and worth stating: a time-stepping loop is many small kernels, exactly the shape command buffers accelerate — disabling them pays full per-launch overhead every iteration. But a deterministic crash on the first executed step costs more, and the flag flip back is one line once the HSA/rocprofiler/XLA interaction is isolated upstream.

## Verification

Unit-checked on CUDA hardware (no AMD GPU available locally): `platform="rocm"` produces an empty command-buffer list, `platform="cuda"` keeps XLA's defaults (CONDITIONAL, CUBLAS, …, FUSION), an explicit user override wins over the ROCm default, and an end-to-end `@jit` compile on CUDA is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015drPT8jCwS74HnX6vEBCxz