### PR TITLE
Propagate execution and copy errors instead of discarding their status

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -1063,7 +1063,10 @@ REACTANT_ABI void CopyToBuffer(PjRtClient *client, PjRtBuffer *buffer,
   auto raw_buffer =
       MyValueOrThrow(PjRtRawBuffer::CreateRawAliasOfBuffer(buffer));
   auto future = raw_buffer->CopyRawHostToDevice(data, offset, size);
-  future.Await();
+  auto status = future.Await();
+  if (!status.ok()) {
+    ReactantThrowError(status.ToString().c_str());
+  }
 #if 0
   if (buffer->IsOnCpu()) {
     memcpy((char*)client->UnsafeBufferPointer(buffer) + offset, data, size);
@@ -1104,7 +1107,11 @@ REACTANT_ABI void BufferToHost(PjRtBuffer *buffer, void *data) {
   MutableBorrowingLiteral literal((const char *)data, shape);
   auto status = buffer->ToLiteralSync(&literal);
   if (!status.ok()) {
-    printf("error copying to host: %s\n", status.ToString().c_str());
+    // A failed copy must not return: the destination holds uninitialized
+    // memory, and a caller that reads it would silently compute on garbage
+    // (e.g. after a device-side allocation failure whose only prior sign was
+    // an allocator warning in the C++ logs).
+    ReactantThrowError(status.ToString().c_str());
   }
 }
 
@@ -1121,7 +1128,12 @@ REACTANT_ABI void CopyFromBuffer(PjRtClient *client, PjRtBuffer *buffer,
   }
 
   auto future = buffer->CopyRawToHost(data, offset, size);
-  future.Await();
+  auto status = future.Await();
+  if (!status.ok()) {
+    // See BufferToHost: returning here would hand the caller uninitialized
+    // host memory with no signal that anything failed.
+    ReactantThrowError(status.ToString().c_str());
+  }
 #if 0
   if (buffer->IsOnCpu()) {
     memcpy((char*)client->UnsafeBufferPointer(buffer) + offset, data, size);
@@ -1288,7 +1300,16 @@ REACTANT_ABI uint8_t FutureIsReady(FutureType *Future) {
   return Future->IsReady();
 }
 
-REACTANT_ABI void FutureAwait(FutureType *Future) { Future->Await(); }
+REACTANT_ABI void FutureAwait(FutureType *Future) {
+  // The future of an async execution resolves to the execution's status.
+  // Discarding it would report a failed execution (e.g. RESOURCE_EXHAUSTED
+  // when a temp buffer did not fit in device memory) as success, leaving the
+  // caller to read whatever happens to be in the output buffers.
+  auto status = Future->Await();
+  if (!status.ok()) {
+    ReactantThrowError(status.ToString().c_str());
+  }
+}
 
 xla::CompileOptions GenerateCompileOptions(
     int64_t device_id, const int64_t *mesh_ids, int64_t num_mesh_ids,
@@ -2729,7 +2750,13 @@ REACTANT_ABI uint8_t ifrt_future_is_ready(IfRtFutureType *Future) {
   return Future->IsReady();
 }
 
-REACTANT_ABI void ifrt_future_await(IfRtFutureType *Future) { Future->Await(); }
+REACTANT_ABI void ifrt_future_await(IfRtFutureType *Future) {
+  // See FutureAwait: the status carries execution failure.
+  auto status = Future->Await();
+  if (!status.ok()) {
+    ReactantThrowError(status.ToString().c_str());
+  }
+}
 
 #pragma region IfRtArray
 
@@ -2765,7 +2792,12 @@ REACTANT_ABI void ifrt_array_copy_to_host_buffer(HeldIfrtArray *array,
   std::optional<absl::Span<const int64_t>> byte_strides;
   auto future = array->obj()->CopyToHostBuffer(
       data, byte_strides, static_cast<ifrt::ArrayCopySemantics>(0));
-  future.Await();
+  auto status = future.Await();
+  if (!status.ok()) {
+    // See BufferToHost: returning here would hand the caller uninitialized
+    // host memory with no signal that anything failed.
+    ReactantThrowError(status.ToString().c_str());
+  }
   return;
 }
 


### PR DESCRIPTION
Fixes issue 9 of @ftynse's [ROCm findings](https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca) — "an over-limit allocation does not raise; the run *succeeds* on uninitialised memory" — which they rightly called the most dangerous defect of the nine: it doesn't add noise, it inverts conclusions, and `status=ok` invites no scrutiny.

## Root cause is in Reactant, not XLA

XLA propagates these failures correctly: BFC returns `nullptr` → `TfAllocatorAdapter::Allocate` converts to `RESOURCE_EXHAUSTED` → the GPU executable aborts → PJRT resolves the execute **future** with that status, and errors a buffer read's copy-future the same way. Reactant then threw the status away at six await points in `API.cpp`:

| site | what was dropped |
|---|---|
| `FutureAwait` | the execute future's status — `Future->Await();` with the returned `absl::Status` discarded, so `sync=true` runs reported failure as success |
| `ifrt_future_await` | same, IFRT path |
| `BufferToHost` | failed `ToLiteralSync` → `printf` to stdout, then return with the host array uninitialized |
| `CopyFromBuffer` | D2H `CopyRawToHost` future status |
| `CopyToBuffer` | H2D `CopyRawHostToDevice` future status |
| `ifrt_array_copy_to_host_buffer` | IFRT D2H future status |

The combination is exactly the reported symptom: a computation whose temps exceed device memory "succeeds" instantly, and reading the outputs hands back whatever was in memory — denormal loss, NaN gradients, with the only sign a BFC warning in the C++ stderr. All six sites now raise through `ReactantThrowError`.

## Verified end-to-end on an RTX 5090 (24 GiB)

Reproducer — a pinned 90 GiB intermediate (`optimization_barrier` prevents XLA from fusing it away; without the barrier XLA legitimately computes this without materializing, which is why naive OOM repros don't trigger it):

```julia
N = 150_000
x = Reactant.to_rarray(ones(Float32, N))
function h(x)
    A = only(Reactant.Ops.optimization_barrier(x .* x'))  # 90 GB, must materialize
    return sum(A)
end
@jit sync = true h(x)
```

| | stock `libReactantExtra` | this PR (locally rebuilt) |
|---|---|---|
| BFC log | `ran out of memory trying to allocate 83.82GiB` (warning) | same warning |
| Julia | **no error — returns `0.0`** | **throws** `RESOURCE_EXHAUSTED: Out of memory while trying to allocate 83.82GiB with allocator GPU_0_bfc on device 0. [executable_name='reactant_h']` |

Also verified the fix doesn't false-positive: the benign case where BFC warns but a retry succeeds (32 GB request on 24 GiB card that XLA satisfies after eviction/fusion) still completes and returns the correct value.

This should equally fix the ROCm sweep scenario (their `N=100` config "succeeding" with a 0.4 GiB peak at 470× speed), and it makes the [#8 intermittent-crash containment](https://gist.github.com/ftynse/5c3816a1cea5daa7dc189b937b62f9ca) less likely to launder execution failures into plausible rows.

Needs a jll rebuild to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015drPT8jCwS74HnX6vEBCxz