### PR TITLE
top_k: keep the raft select_k fast path without the removed debug option

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -1385,8 +1385,6 @@ xla::CompileOptions GenerateCompileOptions(
   debug_options->set_xla_gpu_cuda_data_dir(xla_gpu_cuda_data_dir);
   debug_options->set_xla_enable_enzyme_comms_opt(xla_enable_enzyme_comms_opt);
 
-  debug_options->set_xla_gpu_experimental_use_raft_select_k(true);
-
   if (kernel_cache_enabled) {
     debug_options->set_xla_gpu_kernel_cache_file(kernel_cache_path);
   }

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -1499,6 +1499,7 @@ end
     x::TracedRArray{T,N},
     k::Integer;
     dimension::Integer=N,
+    is_stable::Bool=false,
     location=mlir_stacktrace("top_k", @__FILE__, @__LINE__),
 ) where {T,N}
     @assert 1 <= dimension <= N
@@ -1521,7 +1522,18 @@ end
     rsize = [size(x)[1:(end - 1)]..., k]
     values = mlir_type(TracedRArray{T,N}, rsize)
     indices = mlir_type(TracedRArray{Int32,N}, rsize)
-    op = chlo.top_k(x.mlir_data; values, indices, k, location)
+    # is_stable=false lets XLA:GPU dispatch eligible shapes to
+    # raft::matrix::select_k instead of full sort + slice (issue #886); the
+    # debug option that used to force this is gone upstream and the raft path
+    # is only taken for top_k ops declared unstable.
+    op = chlo.top_k(
+        x.mlir_data;
+        values,
+        indices,
+        k,
+        is_stable=MLIR.IR.Attribute(is_stable),
+        location,
+    )
     indices = add(
         TracedRArray{Int32,N}((), MLIR.IR.result(op, 2), rsize),
         fill(Int32(1), Tuple(rsize)),

--- a/src/xla/CompileOptions.jl
+++ b/src/xla/CompileOptions.jl
@@ -41,7 +41,6 @@ function get_debug_options(; kwargs...)
     # default overrides. can we changed by the user by passing in kwargs
     @set! debug_options.xla_gpu_cuda_data_dir = CUDA_DATA_DIR[]
     @set! debug_options.xla_enable_enzyme_comms_opt = true
-    @set! debug_options.xla_gpu_experimental_use_raft_select_k = true
 
     if Reactant.PersistentCompileCache.kernel_cache_enabled()
         @set! debug_options.xla_gpu_kernel_cache_file = Reactant.PersistentCompileCache.get_kernel_cache_path()


### PR DESCRIPTION
Adapts to [openxla/xla#45968](https://github.com/openxla/xla/pull/45968): `xla_gpu_experimental_use_raft_select_k` is deprecated and the field is now `reserved` in `xla.proto` at the XLA pin of EnzymeAD/Enzyme-JAX#2698, so `API.cpp`'s `set_xla_gpu_experimental_use_raft_select_k(true)` no longer compiles (several Reactant_jll build failures on that PR). That flag was how #886's exact-TopK slowness was fixed.

**Why this keeps #886 fixed** (checked against XLA source at both the current and the new pin):
- The GPU TopK specializer now gates the raft path on the op's declared stability: `use_raft = !IsTopKStable(topk)` (`xla/backends/gpu/transforms/topk_specializer.cc`). At the current pin the deprecated flag is merely OR-ed in during the transition period; at the new pin it is gone entirely.
- `chlo.top_k` carries `is_stable` at every pin we build against, forwarded through `mhlo.topk` → HLO `kTopK` → `TopkDecomposer` (unstable sort) → `TopkRewriter`, which writes `{is_stable = false}` into the `"TopK"` custom call's backend config — exactly what `IsTopKStable` reads.
- The #886 shape (n=1e9, k=100, F32, no batch) stays within the raft heuristic (min_n=1, k ≤ 128).

Changes:
- `Ops.top_k` gains an `is_stable` kwarg **defaulting to false** — the same unstable ordering the raft path already produced under the old flag — and passes it on `chlo.top_k`.
- Drop the debug-option writes in `API.cpp` and `src/xla/CompileOptions.jl` (the Julia proto setter breaks at the next proto regen anyway, since the field is reserved).

The aarch64 Reactant_jll failures on #2698 (XNNPACK fp8 arm64 kernels using `__arm_fpm_init`/`mfloat8x8_t`) are a separate toolchain-support issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD