### PR TITLE
Drop the rules_ml_toolchain fork override

### DIFF
--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -1,15 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "rules_ml_toolchain",
-    patch_cmds = [
-        "sed -i.bak0 '/D_FORTIFY_SOURCE/d' cc/features/BUILD gpu/cuda/legacy/crosstool/cc_toolchain_config.bzl.tpl",
-    ],
-    sha256 = "",
-    strip_prefix = "rules_ml_toolchain-d93102b7328192e6a0e4d40694dafb728f21794b",
-    urls = ["https://github.com/wsmoses/rules_ml_toolchain/archive/d93102b7328192e6a0e4d40694dafb728f21794b.tar.gz"],
-)
-
 NSYNC_COMMIT = "82b118aa7ace3132e517e2c467f8732978cf4023"
 
 NSYNC_SHA256 = ""


### PR DESCRIPTION
Undoes the WORKSPACE override of `rules_ml_toolchain` (the `wsmoses` fork pin), letting the repo come from the XLA pin like every other transitive dependency. Enzyme-JAX's XLA patches already inject the same `D_FORTIFY_SOURCE` patch_cmds the override duplicated, and upstream has absorbed the fork's CUDA 13 work (hermetic nvfatbin repo, redist versions, static-nvrtc nvfatbin dep, cuDNN whole-archive/alwayslink static linking).

**Sequencing** — draft until both hold:
1. google-ml-infra/rules_ml_toolchain#298 (the last fork-only piece: `cudnn_engines_tensor_ir_static` for static cuDNN ≥ 9.21) merges, and
2. the Enzyme-JAX bump (EnzymeAD/Enzyme-JAX#2698 or later) pins an XLA whose `rules_ml_toolchain` contains it plus the static-nvrtc nvfatbin dep (on upstream main, but not in the currently-pinned `2eddbc595`).

Until then, hermetic CUDA-13 static jll builds would miss nvfatbin/tensor_ir symbols at link. The jll workflow on this PR adjudicates directly. Near-term, the rocm `hipcc_env` breakage is handled by the compatible-now pin bump in #3178; this PR supersedes that override entirely once the pins line up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD