### PR TITLE
Fix proto bindings generation (gpu_topology + module include order)

### DIFF
--- a/deps/ReactantExtra/BUILD
+++ b/deps/ReactantExtra/BUILD
@@ -34,8 +34,15 @@ genrule(
         "@xla//xla:xla_data.proto",
         "@xla//xla:autotuning.proto",
         "@xla//xla:autotune_results.proto",
+        "@xla//xla/service:buffer_assignment.proto",
+        "@xla//xla/service:gpu_topology.proto",
         "@xla//xla/service:hlo.proto",
         "@xla//xla/service:metrics.proto",
+        "@xla//xla/service:shaped_slice.proto",
+        "@xla//xla/service/cpu:executable.proto",
+        "@xla//xla/backends/cpu:xnn_fusion_options.proto",
+        "@xla//xla/backends/cpu:ynn_fusion_options.proto",
+        "@xla//xla/backends/cpu/runtime:thunk.proto",
         "@xla//xla/pjrt/proto:execute_options.proto",
         "@xla//xla/pjrt/proto:compile_options.proto",
         "@xla//xla/stream_executor:device_description.proto",
@@ -84,6 +91,8 @@ genrule(
         mkdir -p $$STAGING/xla
         mkdir -p $$STAGING/xla/pjrt/proto
         mkdir -p $$STAGING/xla/service
+        mkdir -p $$STAGING/xla/service/cpu
+        mkdir -p $$STAGING/xla/backends/cpu/runtime
         mkdir -p $$STAGING/xla/stream_executor/cuda
         mkdir -p $$STAGING/xla/stream_executor/sycl
         mkdir -p $$STAGING/xla/backends/autotuner
@@ -99,8 +108,14 @@ genrule(
                 # Handle well-known types from @com_google_protobuf
                 mkdir -p $$STAGING/google/protobuf
                 cp $$src $$STAGING/google/protobuf/
+            elif echo "$$src" | grep -q "xla/service/cpu/"; then
+                cp $$src $$STAGING/xla/service/cpu/
             elif echo "$$src" | grep -q "xla/service/"; then
                 cp $$src $$STAGING/xla/service/
+            elif echo "$$src" | grep -q "xla/backends/cpu/runtime/"; then
+                cp $$src $$STAGING/xla/backends/cpu/runtime/
+            elif echo "$$src" | grep -q "xla/backends/cpu/"; then
+                cp $$src $$STAGING/xla/backends/cpu/
             elif echo "$$src" | grep -q "xla/pjrt/proto/"; then
                 cp $$src $$STAGING/xla/pjrt/proto/
             elif echo "$$src" | grep -q "xla/stream_executor/cuda/"; then

--- a/deps/ReactantExtra/make-proto-bindings.jl
+++ b/deps/ReactantExtra/make-proto-bindings.jl
@@ -197,6 +197,9 @@ function generate_bindings(staging_dir::String, output_dir::String)
         add_kwarg_constructors=false,
     )
 
+    # Fix up the order of the `include`s inside each generated module
+    reorder_module_includes(staging_dir, output_dir)
+
     # Remove headers from generated files to minimize diffs
     remove_proto_headers(output_dir)
 
@@ -204,6 +207,170 @@ function generate_bindings(staging_dir::String, output_dir::String)
     write_main_module(output_dir, proto_rel_paths)
 
     return proto_rel_paths
+end
+
+"""
+    proto_metadata(staging_dir::String) -> (packages, imports)
+
+Parse the `package` and `import` statements out of every staged proto file.
+Returns two dicts keyed by the proto path relative to `staging_dir`: the package
+split into its namespace components, and the list of imported proto paths.
+"""
+function proto_metadata(staging_dir::String)
+    packages = Dict{String,Vector{String}}()
+    imports = Dict{String,Vector{String}}()
+
+    for (rel, abs_path) in find_proto_files(staging_dir)
+        rel = replace(rel, '\\' => '/')
+        namespace = String[]
+        imported = String[]
+        for line in eachline(abs_path)
+            m = match(r"^\s*package\s+([A-Za-z0-9_.]+)\s*;", line)
+            if m !== nothing
+                namespace = String.(split(m[1], '.'))
+            end
+            m = match(r"^\s*import\s+(?:public\s+|weak\s+)?\"([^\"]+)\"\s*;", line)
+            if m !== nothing
+                push!(imported, m[1])
+            end
+        end
+        packages[rel] = namespace
+        imports[rel] = imported
+    end
+
+    return packages, imports
+end
+
+"""
+    transitive_imports(imports::Dict{String,Vector{String}}) -> Dict{String,Set{String}}
+
+Expand the direct import lists into their transitive closures.
+"""
+function transitive_imports(imports::Dict{String,Vector{String}})
+    closure = Dict{String,Set{String}}()
+
+    function visit(file, stack)
+        haskey(closure, file) && return closure[file]
+        file in stack && return Set{String}()  # import cycles are illegal, be safe anyway
+        push!(stack, file)
+        deps = Set{String}()
+        for dep in get(imports, file, String[])
+            push!(deps, dep)
+            union!(deps, visit(dep, stack))
+        end
+        delete!(stack, file)
+        closure[file] = deps
+        return deps
+    end
+
+    for file in keys(imports)
+        visit(file, Set{String}())
+    end
+
+    return closure
+end
+
+"""
+    stable_topological_sort(entries, deps) -> Vector
+
+Sort `entries` so that every entry comes after the entries it depends on, while
+otherwise preserving the original order. Entries that cannot be placed (which
+would require an import cycle) keep their original position.
+"""
+function stable_topological_sort(entries::Vector{T}, deps::Dict{T,Set{T}}) where {T}
+    remaining = copy(entries)
+    ordered = T[]
+    placed = Set{T}()
+
+    while !isempty(remaining)
+        i = findfirst(remaining) do entry
+            all(d -> d in placed || d == entry, get(deps, entry, Set{T}()))
+        end
+        if i === nothing
+            @warn "Cyclic dependency between generated modules, keeping original order" remaining
+            append!(ordered, remaining)
+            break
+        end
+        entry = popat!(remaining, i)
+        push!(ordered, entry)
+        push!(placed, entry)
+    end
+
+    return ordered
+end
+
+"""
+    reorder_module_includes(staging_dir::String, output_dir::String)
+
+ProtoBuf.jl topologically sorts the `include`s of a module using only the proto
+files that live directly in that module, so a dependency that travels through a
+submodule is invisible to it. For example `xla/service/gpu_topology.proto`
+(package `xla`) imports `xla/service/cpu/executable.proto` (package `xla.cpu`),
+which in turn imports `xla/service/hlo.proto` (package `xla`) - ProtoBuf.jl then
+emits `include("cpu/cpu.jl")` before `include("hlo_pb.jl")` and loading the
+generated code fails with an `UndefVarError`.
+
+Re-sort each generated module's `include`s using the full proto import graph.
+"""
+function reorder_module_includes(staging_dir::String, output_dir::String)
+    println("\n  Reordering module includes...")
+
+    packages, imports = proto_metadata(staging_dir)
+    closure = transitive_imports(imports)
+
+    for (root, dirs, files) in walkdir(output_dir)
+        module_name = basename(root)
+        module_file = joinpath(root, "$module_name.jl")
+        ("$module_name.jl" in files) || continue
+
+        namespace = String.(splitpath(relpath(root, output_dir)))
+        namespace == ["."] && continue
+
+        lines = readlines(module_file)
+
+        # Only the includes of this module's own files/submodules are movable;
+        # the leading `include("../pkg/pkg.jl")` lines pull in other packages.
+        idxs = findall(l -> occursin(r"^include\(\"(?!\.\.)", l), lines)
+        length(idxs) > 1 || continue
+
+        # Map each `include` to the set of proto files it brings into scope.
+        provided = Dict{String,Set{String}}()
+        for i in idxs
+            path = match(r"^include\(\"([^\"]+)\"\)", lines[i])[1]
+            covered = Set{String}()
+            for (rel, ns) in packages
+                if endswith(path, "_pb.jl")
+                    ns == namespace &&
+                        string(replace(basename(rel), ".proto" => ""), "_pb.jl") == path &&
+                        push!(covered, rel)
+                else
+                    sub = [namespace; first(splitpath(path))]
+                    length(ns) >= length(sub) &&
+                        ns[1:length(sub)] == sub &&
+                        push!(covered, rel)
+                end
+            end
+            provided[lines[i]] = covered
+        end
+
+        # `a => b` means the include `a` must come after the include `b`.
+        deps = Dict{String,Set{String}}()
+        for a in lines[idxs]
+            needed = union(
+                Set{String}(), (get(closure, f, Set{String}()) for f in provided[a])...
+            )
+            deps[a] = Set(
+                b for b in lines[idxs] if b != a && !isdisjoint(needed, provided[b])
+            )
+        end
+
+        sorted = stable_topological_sort(lines[idxs], deps)
+        sorted == lines[idxs] && continue
+
+        lines[idxs] = sorted
+        write(module_file, join(lines, '\n') * '\n')
+        println("    reordered $(relpath(module_file, output_dir))")
+    end
 end
 
 """


### PR DESCRIPTION
Fixes the nightly [Regenerate MLIR Bindings](https://github.com/EnzymeAD/Reactant.jl/actions/workflows/regenerate-mlir-bindings.yml) job, which has been failing in the **Generate Proto Bindings** step since at least Aug 17 ([latest run](https://github.com/EnzymeAD/Reactant.jl/actions/runs/32675392161/job/97282469056)).

There were two separate bugs.

### 1. Missing proto sources (the reported error)

```
ERROR: LoadError: Could not find following imports: ["xla/service/gpu_topology.proto"]
```

Upstream XLA added `import "xla/service/gpu_topology.proto"` to `xla/pjrt/proto/compile_options.proto` (the `gpu_topology` field of `ExecutableBuildOptionsProto`), but the `//:proto_files` genrule stages an explicit list of proto sources that never picked up the new transitive closure:

```
gpu_topology.proto
  -> service/cpu/executable.proto
    -> backends/cpu/runtime/thunk.proto
      -> backends/cpu/{xnn,ynn}_fusion_options.proto
      -> service/buffer_assignment.proto
      -> service/shaped_slice.proto
```

`deps/ReactantExtra/BUILD` now stages all seven, with the staging directories and path-routing branches they need. The new routing branches have to be tested **before** the existing, more general ones — `xla/service/cpu/` before `xla/service/`, and `xla/backends/cpu/...` before the `/xla/xla/` fallback — otherwise the files land in the wrong directory.

### 2. Generated code did not load

With the files staged, generation succeeded but the result failed to load:

```
UndefVarError: `buffer_assignment` not defined in `Main.Proto.xla`
```

ProtoBuf.jl ([`codegen/modules.jl`](https://github.com/JuliaIO/ProtoBuf.jl/blob/master/src/codegen/modules.jl)) topologically sorts a module's `include`s using only the proto files that live *directly* in that module, so a dependency travelling through a submodule is invisible to it. Here `gpu_topology.proto` (package `xla`) imports `cpu/executable.proto` (package `xla.cpu`), which imports back into `hlo.proto` (package `xla`) — so `include("cpu/cpu.jl")` was emitted before `hlo_pb.jl`, `shaped_slice_pb.jl` and `buffer_assignment/`.

`make-proto-bindings.jl` gains a `reorder_module_includes` post-pass that re-sorts each generated module's includes using the full proto import graph. The sort is stable, so modules without such a dependency keep byte-identical output — only `xla/xla.jl` changes today.

### Verification

Run locally against the exact pinned dependency versions (Enzyme-JAX `f76f876` → JAX `cec06d1` → XLA `753e5e5`):

- `bazel build //:proto_files` succeeds; the tar contains all 44 protos at the correct paths
- `julia --project=. make-proto-bindings.jl --force` generates cleanly, reporting `reordered xla/xla.jl`
- the generated `Proto.jl` loads, and `GpuTopologyProto` round-trips through encode/decode
- `ExecutableBuildOptionsProto.gpu_topology :: Union{Nothing, GpuTopologyProto}`
- all 11 `Proto.*` symbol paths referenced from `src/` still resolve
- reruns are byte-identical; `buildifier -mode check` passes; the script is JuliaFormatter-clean

`src/proto/` is intentionally not regenerated here — that is the nightly job's own output and will come out of the PR it opens once it is green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGmyPQ2CZ8Yr4amg6F6Fyh
