### PR TITLE
Reserve an address range per XLA allocation

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -1,3 +1,4 @@
+#include <sys/mman.h>
 #include <iostream>
 
 #include "mlir-c/IR.h"
@@ -3428,8 +3429,14 @@ struct LinkableRuntime {
                                   xla::PjRtLoadedExecutable *>>
       executables;
 
-  // Set of allocated pointers to size
-  std::set<void *, std::greater<void *>> allocations;
+  // Each allocation reserves an inaccessible address range as large as the
+  // buffer it stands for, so pointer arithmetic on the handle stays inside
+  // its own range (and a stray dereference faults at the offender).
+  struct AllocationInfo {
+    xla::PjRtBuffer *buffer;
+    size_t size;
+  };
+  std::map<void *, AllocationInfo, std::greater<void *>> allocations;
 
   LinkableRuntime(const std::string &backend) : registry() {
     InitializeRegistry(wrap(&registry));
@@ -3500,10 +3507,15 @@ struct LinkableRuntime {
 static std::tuple<PjRtBuffer *, /*offset*/ size_t, PjRtBuffer **>
 bufferAndOffset(LinkableRuntime *__restrict__ lrt, void *ptr) {
   auto found = lrt->allocations.lower_bound(ptr);
-  assert(found != lrt->allocations.end());
-  auto start = (PjRtBuffer **)(*found);
+  if (found == lrt->allocations.end() ||
+      (size_t)ptr >= (size_t)found->first + found->second.size) {
+    llvm::errs() << "pointer " << ptr
+                 << " does not belong to any reactant allocation\n";
+    exit(1);
+  }
   return std::tuple<PjRtBuffer *, /*offset*/ size_t, PjRtBuffer **>(
-      *start, (size_t)ptr - (size_t)start, start);
+      found->second.buffer, (size_t)ptr - (size_t)found->first,
+      &found->second.buffer);
 }
 
 REACTANT_ABI void reactantXLAThrow(const char *str) {
@@ -3564,13 +3576,26 @@ REACTANT_ABI void *reactantXLAMalloc(LinkableRuntime **__restrict__ lrtP,
   PjRtDevice *device = ClientGetDevice(lrt->client, lrt->device);
 
   auto xbuffer0 = UninitPJRTBuffer(lrt->client, device, ptype, shapeLen, shape);
-  void **xbuffer = (void **)malloc(sizeof(void *));
-  xbuffer[0] = xbuffer0;
-  auto pair = lrt->allocations.insert((void *)xbuffer);
+  size_t nbytes = 1;
+  {
+    auto sz = xbuffer0->GetOnDeviceSizeInBytes();
+    if (sz.ok() && *sz)
+      nbytes = *sz;
+  }
+  void *base = mmap(nullptr, nbytes, PROT_NONE,
+                    MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  if (base == MAP_FAILED) {
+    llvm::errs() << "failed to reserve handle range of " << nbytes
+                 << " bytes\n";
+    exit(1);
+  }
+  auto pair = lrt->allocations.try_emplace(
+      base, LinkableRuntime::AllocationInfo{(xla::PjRtBuffer *)xbuffer0,
+                                            nbytes});
   (void)pair;
   // Assert that it was actually inserted
   assert(pair.second);
-  return xbuffer;
+  return base;
 }
 
 REACTANT_ABI void reactantXLAFree(LinkableRuntime **__restrict__ lrtP,
@@ -3578,12 +3603,16 @@ REACTANT_ABI void reactantXLAFree(LinkableRuntime **__restrict__ lrtP,
   if (!buffer0)
     return;
   auto lrt = *lrtP;
-  void *buffer = *(void **)buffer0;
-  auto erased = lrt->allocations.erase((void *)buffer0);
-  assert(erased == 1);
-  (void)erased;
-  free(buffer0);
-  PjRtBufferFree((PjRtBuffer *)buffer);
+  auto found = lrt->allocations.find((void *)buffer0);
+  if (found == lrt->allocations.end()) {
+    llvm::errs() << "freeing pointer " << buffer0
+                 << " that is not a reactant allocation\n";
+    exit(1);
+  }
+  PjRtBuffer *buffer = found->second.buffer;
+  munmap(buffer0, found->second.size);
+  lrt->allocations.erase(found);
+  PjRtBufferFree(buffer);
 }
 
 REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
@@ -3601,7 +3630,8 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     auto &&[argB, argO, argP] = bufferAndOffset(lrt, args[i]);
     if (argO != 0) {
       llvm::errs() << "only zero-offset execution supported, argument " << i
-                   << " had byte offset of " << argO << "\n";
+                   << " had byte offset of " << argO << " (ptr=" << args[i]
+                   << ", resolved base=" << (void *)argP << ")\n";
       exit(1);
     }
     baseArrays[i] = argB;

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3504,8 +3504,25 @@ struct LinkableRuntime {
   }
 };
 
+static void *reactantXLAMallocImpl(LinkableRuntime *__restrict__ lrt,
+                                   uint64_t ptype, uint64_t shapeLen,
+                                   uint64_t *__restrict__ shape);
+
 static std::tuple<PjRtBuffer *, /*offset*/ size_t, PjRtBuffer **>
 bufferAndOffset(LinkableRuntime *__restrict__ lrt, void *ptr) {
+  // Kernels take optional buffers as null pointers (mfem's
+  // `geom ? geom->J.Read() : nullptr`) and guard every access on a flag;
+  // hand the executable a small dummy buffer for those arguments.
+  if (!ptr) {
+    // Fresh per use: arguments are donated, and one buffer cannot be
+    // donated twice in a single call.
+    uint64_t shape[1] = {256};
+    void *dummy = reactantXLAMallocImpl(lrt, /*s8*/ 2, 1, shape);
+    auto found = lrt->allocations.find(dummy);
+    assert(found != lrt->allocations.end());
+    return std::tuple<PjRtBuffer *, size_t, PjRtBuffer **>(
+        found->second.buffer, 0, &found->second.buffer);
+  }
   auto found = lrt->allocations.lower_bound(ptr);
   if (found == lrt->allocations.end() ||
       (size_t)ptr >= (size_t)found->first + found->second.size) {
@@ -3576,10 +3593,9 @@ REACTANT_ABI void reactantXLAMemcpy(LinkableRuntime **__restrict__ lrtP,
   }
 }
 
-REACTANT_ABI void *reactantXLAMalloc(LinkableRuntime **__restrict__ lrtP,
-                                     uint64_t ptype, uint64_t shapeLen,
-                                     uint64_t *__restrict__ shape) {
-  auto lrt = *lrtP;
+static void *reactantXLAMallocImpl(LinkableRuntime *__restrict__ lrt,
+                                   uint64_t ptype, uint64_t shapeLen,
+                                   uint64_t *__restrict__ shape) {
   PjRtDevice *device = ClientGetDevice(lrt->client, lrt->device);
 
   auto xbuffer0 = UninitPJRTBuffer(lrt->client, device, ptype, shapeLen, shape);
@@ -3603,6 +3619,12 @@ REACTANT_ABI void *reactantXLAMalloc(LinkableRuntime **__restrict__ lrtP,
   // Assert that it was actually inserted
   assert(pair.second);
   return base;
+}
+
+REACTANT_ABI void *reactantXLAMalloc(LinkableRuntime **__restrict__ lrtP,
+                                     uint64_t ptype, uint64_t shapeLen,
+                                     uint64_t *__restrict__ shape) {
+  return reactantXLAMallocImpl(*lrtP, ptype, shapeLen, shape);
 }
 
 REACTANT_ABI void reactantXLAFree(LinkableRuntime **__restrict__ lrtP,
@@ -3732,6 +3754,12 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
         stablehlo::createStablehloCanonicalizeDynamismPass());
     pm.addPass(mlir::enzyme::createEnzymeHLOOptPass());
 
+    if (getenv("REACTANT_XLA_DEBUG_EXEC")) {
+      for (int64_t i = 0; i < argcnt; i++)
+        llvm::errs() << " exec arg " << i << ": "
+                     << baseArrays[i]->on_device_shape().ToString() << "\n";
+    }
+
     if (!mlir::succeeded(pm.run(*module))) {
       llvm::errs() << " failed to run passes\n";
       llvm::errs() << " modstr:\n" << modstr << "\n";
@@ -3742,6 +3770,10 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
       exit(1);
     }
 
+    if (getenv("REACTANT_XLA_DEBUG_EXEC")) {
+      llvm::errs() << " exec module after passes:\n";
+      module->print(llvm::errs());
+    }
     auto exec =
         ClientCompileWithProto(lrt->client, wrap(module.get()), nullptr, 0);
 
@@ -3758,6 +3790,18 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
   std::vector<uint8_t> futures(argcnt, 0);
   std::vector<FutureType *> future_results(argcnt, nullptr);
   PjRtDevice *device = ClientGetDevice(lrt->client, lrt->device);
+  bool dbg = getenv("REACTANT_XLA_DEBUG_EXEC") != nullptr;
+  if (dbg) {
+    for (int64_t i = 0; i < argcnt; i++) {
+      auto sz = baseArrays[i]->GetOnDeviceSizeInBytes();
+      if (sz.ok() && *sz <= 64) {
+        auto lit = baseArrays[i]->ToLiteralSync();
+        if (lit.ok())
+          llvm::errs() << " exec in[" << i << "] = " << (*lit)->ToString()
+                       << "\n";
+      }
+    }
+  }
   XLAExecuteSharded(exec, argcnt, baseArrays.data(), device, is_arg_donatable,
                     num_results, results.data(), futures.data(),
                     future_results.data());
@@ -3767,6 +3811,17 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     if (futures[i]) {
       FutureAwait(future_results[i]);
       FreeFuture(future_results[i]);
+    }
+  }
+  if (dbg) {
+    for (int64_t i = 0; i < argcnt; i++) {
+      auto sz = results[i]->GetOnDeviceSizeInBytes();
+      if (sz.ok() && *sz <= 64) {
+        auto lit = results[i]->ToLiteralSync();
+        if (lit.ok())
+          llvm::errs() << " exec out[" << i << "] = " << (*lit)->ToString()
+                       << "\n";
+      }
     }
   }
 }

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3561,8 +3561,15 @@ REACTANT_ABI void reactantXLAMemcpy(LinkableRuntime **__restrict__ lrtP,
     break;
   }
   case 3: // cudaMemcpyDeviceToDevice
-    llvm_unreachable("device to device copy unsupported");
+  {
+    // PJRT exposes no raw buffer-to-buffer copy; stage through the host.
+    auto &&[srcB, srcO, srcStart] = bufferAndOffset(lrt, src);
+    auto &&[dstB, dstO, dstStart] = bufferAndOffset(lrt, dst);
+    std::vector<char> tmp(size);
+    CopyFromBuffer(lrt->client, srcB, tmp.data(), srcO, size, srcStart);
+    CopyToBuffer(lrt->client, dstB, tmp.data(), dstO, size, dstStart);
     break;
+  }
   default: // cudaMemcpyDeviceToDevice
     llvm_unreachable("unknown copy unsupported");
     break;

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -6,6 +6,7 @@
 
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Wrap.h"
+#include "mlir/IR/Verifier.h"
 #include "mlir/Pass/PassManager.h"
 
 #include "Enzyme/MLIR/Dialect/Dialect.h"
@@ -3425,8 +3426,14 @@ struct LinkableRuntime {
   xla::PjRtClient *client;
   int device;
   bool shouldFreeClient;
-  DenseMap<const char *, std::map<std::vector<std::vector<int64_t>>,
-                                  xla::PjRtLoadedExecutable *>>
+  struct CachedExec {
+    xla::PjRtLoadedExecutable *exec;
+    // Per argument view: does the kernel store through it? (a view whose
+    // result is the argument passed through unchanged is read-only)
+    std::vector<uint8_t> written;
+  };
+  DenseMap<const char *,
+           std::map<std::vector<std::vector<int64_t>>, CachedExec>>
       executables;
 
   // Each allocation reserves an inaccessible address range as large as the
@@ -3674,6 +3681,24 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
   if (constcnt)
     sizeKey.emplace_back(consts, consts + constcnt);
 
+  // A kernel called with two pointers into the same allocation (mfem's
+  // Dot(x, x)) resolves to the same buffer twice: XLA forbids donating a
+  // buffer twice AND passing a donated buffer as any other argument, so
+  // the whole duplicate group is passed undonated. The first view's result
+  // (a fresh buffer) replaces the allocation's buffer; the other results
+  // are dropped, so writes are only kept through the first view. The
+  // aliasing attrs differ per pattern, so it is part of the cache key.
+  std::vector<int64_t> dupOf(argcnt, -1);
+  std::vector<uint8_t> hasDup(argcnt, 0);
+  for (int64_t i = 0; i < argcnt; i++)
+    for (int64_t j = 0; j < i; j++)
+      if (baseArrays[i] == baseArrays[j]) {
+        dupOf[i] = j;
+        hasDup[j] = 1;
+        break;
+      }
+  sizeKey.emplace_back(dupOf.begin(), dupOf.end());
+
   auto iter = cache.find(sizeKey);
 
   if (iter == cache.end()) {
@@ -3694,6 +3719,8 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     mlir::OpBuilder builder(module->getContext());
     funcOp.setSymName(builder.getStringAttr("main"));
     funcOp.setVisibility(SymbolTable::Visibility::Public);
+
+
 
     // The trailing constcnt arguments are the scalars this executable is
     // specialized over: replace each with a constant of its value so the
@@ -3729,10 +3756,15 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     }
 
     for (int64_t i = 0; i < argcnt; i++) {
-      funcOp.setArgAttr(i, "tf.aliasing_output", builder.getI64IntegerAttr(i));
+      if (dupOf[i] < 0 && !hasDup[i])
+        funcOp.setArgAttr(i, "tf.aliasing_output",
+                          builder.getI64IntegerAttr(i));
     }
 
     PassManager pm(module->getContext());
+    // Argument refinement leaves the body dynamic until the shape
+    // refinement pass catches up; the intermediate module does not verify.
+    pm.enableVerifier(false);
 
     SmallVector<mlir::Type> types;
     for (int64_t i = 0; i < argcnt; i++) {
@@ -3760,7 +3792,9 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
                      << baseArrays[i]->on_device_shape().ToString() << "\n";
     }
 
-    if (!mlir::succeeded(pm.run(*module))) {
+    bool passesOk = mlir::succeeded(pm.run(*module));
+    // The pipeline runs unverified; catch what it produced either way.
+    if (!passesOk || failed(mlir::verify(*module))) {
       llvm::errs() << " failed to run passes\n";
       llvm::errs() << " modstr:\n" << modstr << "\n";
       pm.dump();
@@ -3774,17 +3808,58 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
       llvm::errs() << " exec module after passes:\n";
       module->print(llvm::errs());
     }
+
+    // A view the kernel never stores through returns its argument
+    // unchanged. The unchanged copy may be wrapped in layout ops and
+    // threaded through while loops as an untouched iter arg, so walk the
+    // provenance back to the argument. Record it so duplicate views of one
+    // buffer keep the written view's result.
+    std::vector<uint8_t> written(argcnt, 1);
+    {
+      auto ret = cast<func::ReturnOp>(funcOp.getBody().front().back());
+      auto resolvesToArg = [&](mlir::Value v, mlir::Value arg) {
+        while (v != arg) {
+          mlir::Operation *op = v.getDefiningOp();
+          if (!op)
+            return false;
+          if (isa<mlir::stablehlo::ReshapeOp,
+                  mlir::stablehlo::BitcastConvertOp>(op)) {
+            v = op->getOperand(0);
+            continue;
+          }
+          if (auto wh = dyn_cast<mlir::stablehlo::WhileOp>(op)) {
+            unsigned k = cast<mlir::OpResult>(v).getResultNumber();
+            mlir::Block &body = wh.getBody().front();
+            if (body.getTerminator()->getOperand(k) != body.getArgument(k))
+              return false;
+            v = wh->getOperand(k);
+            continue;
+          }
+          return false;
+        }
+        return true;
+      };
+      for (int64_t i = 0; i < argcnt && i < (int64_t)ret.getNumOperands();
+           i++)
+        written[i] =
+            !resolvesToArg(ret.getOperand(i), funcOp.getArgument(i));
+    }
     auto exec =
         ClientCompileWithProto(lrt->client, wrap(module.get()), nullptr, 0);
 
-    iter = cache.try_emplace(sizeKey, exec).first;
+    iter = cache
+               .try_emplace(sizeKey,
+                            LinkableRuntime::CachedExec{exec,
+                                                        std::move(written)})
+               .first;
   }
 
-  auto exec = iter->second;
+  auto exec = iter->second.exec;
+  auto &written = iter->second.written;
 
   uint8_t *is_arg_donatable = (uint8_t *)malloc(argcnt);
   for (int i = 0; i < argcnt; i++)
-    is_arg_donatable[i] = 1;
+    is_arg_donatable[i] = (dupOf[i] < 0 && !hasDup[i]) ? 1 : 0;
   int num_results = argcnt;
   std::vector<PjRtBuffer *> results(argcnt);
   std::vector<uint8_t> futures(argcnt, 0);
@@ -3802,15 +3877,48 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
       }
     }
   }
+  if (const char *dumpDir = getenv("REACTANT_XLA_DUMP_DIR")) {
+    static std::atomic<int64_t> inCounter{0};
+    int64_t execId = inCounter++;
+    for (int64_t i = 0; i < argcnt; i++) {
+      auto lit = baseArrays[i]->ToLiteralSync();
+      if (!lit.ok())
+        continue;
+      std::string path = std::string(dumpDir) + "/exec" +
+                         std::to_string(execId) + "_in" + std::to_string(i) +
+                         ".bin";
+      FILE *f = fopen(path.c_str(), "wb");
+      if (f) {
+        fwrite((*lit)->untyped_data(), 1, (*lit)->size_bytes(), f);
+        fclose(f);
+      }
+    }
+  }
   XLAExecuteSharded(exec, argcnt, baseArrays.data(), device, is_arg_donatable,
                     num_results, results.data(), futures.data(),
                     future_results.data());
   free(is_arg_donatable);
   for (int64_t i = 0; i < argcnt; i++) {
-    *basePtrs[i] = results[i];
     if (futures[i]) {
       FutureAwait(future_results[i]);
       FreeFuture(future_results[i]);
+    }
+  }
+  if (const char *dumpDir = getenv("REACTANT_XLA_DUMP_DIR")) {
+    static std::atomic<int64_t> execCounter{0};
+    int64_t execId = execCounter++;
+    for (int64_t i = 0; i < argcnt; i++) {
+      auto lit = results[i]->ToLiteralSync();
+      if (!lit.ok())
+        continue;
+      std::string path = std::string(dumpDir) + "/exec" +
+                         std::to_string(execId) + "_out" + std::to_string(i) +
+                         ".bin";
+      FILE *f = fopen(path.c_str(), "wb");
+      if (f) {
+        fwrite((*lit)->untyped_data(), 1, (*lit)->size_bytes(), f);
+        fclose(f);
+      }
     }
   }
   if (dbg) {
@@ -3822,6 +3930,39 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
           llvm::errs() << " exec out[" << i << "] = " << (*lit)->ToString()
                        << "\n";
       }
+    }
+    llvm::errs() << " dup info:";
+    for (int64_t i = 0; i < argcnt; i++)
+      llvm::errs() << " [" << i << "] dupOf=" << dupOf[i]
+                   << " hasDup=" << (int)hasDup[i]
+                   << " written=" << (i < (int64_t)written.size() ? (int)written[i] : -1);
+    llvm::errs() << "\n";
+  }
+  // Each duplicate group keeps the result of the view the kernel stores
+  // through (a read-only view's result is just the stale input); with no
+  // written view any result is that same input, so the leader's serves.
+  std::vector<int64_t> keepFor(argcnt, -1);
+  for (int64_t i = 0; i < argcnt; i++) {
+    int64_t leader = dupOf[i] >= 0 ? dupOf[i] : (hasDup[i] ? i : -1);
+    if (leader >= 0 && keepFor[leader] < 0 &&
+        (leader < (int64_t)written.size() ? written[i] : 1))
+      keepFor[leader] = i;
+  }
+  for (int64_t i = 0; i < argcnt; i++)
+    if (hasDup[i] && keepFor[i] < 0)
+      keepFor[i] = i;
+  for (int64_t i = 0; i < argcnt; i++) {
+    if (dupOf[i] >= 0 || hasDup[i]) {
+      int64_t leader = dupOf[i] >= 0 ? dupOf[i] : i;
+      if (keepFor[leader] == i) {
+        // Undonated: the exec did not consume the old buffer.
+        PjRtBufferFree(*basePtrs[i]);
+        *basePtrs[i] = results[i];
+      } else {
+        PjRtBufferFree(results[i]);
+      }
+    } else {
+      *basePtrs[i] = results[i];
     }
   }
 }

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3825,7 +3825,8 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     pm.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
     pm.addNestedPass<mlir::func::FuncOp>(
         stablehlo::createStablehloCanonicalizeDynamismPass());
-    pm.addPass(mlir::enzyme::createEnzymeHLOOptPass());
+    if (!getenv("REACTANT_XLA_NO_HLO_OPT"))
+      pm.addPass(mlir::enzyme::createEnzymeHLOOptPass());
 
     if (getenv("REACTANT_XLA_DEBUG_EXEC")) {
       for (int64_t i = 0; i < argcnt; i++)

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3670,15 +3670,46 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
 
   std::vector<std::vector<int64_t>> sizeKey;
   sizeKey.reserve(argcnt + (constcnt ? 1 : 0));
+  // A kernel argument may point into the middle of an allocation (a block
+  // operator's sub-vector view); materialize the tail as its own buffer
+  // through staged copies and write it back after the launch.
+  struct OffsetView {
+    void *tmp;
+    void *orig;
+    size_t size;
+  };
+  std::vector<OffsetView> offsetViews;
   for (int64_t i = 0; i < argcnt; i++) {
     if (getenv("REACTANT_XLA_DEBUG_EXEC"))
       llvm::errs() << " resolving arg " << i << " ptr " << args[i] << "\n";
-    auto &&[argB, argO, argP] = bufferAndOffset(lrt, args[i]);
+    auto &&[argB0, argO0, argP0] = bufferAndOffset(lrt, args[i]);
+    auto argB = argB0;
+    auto argO = argO0;
+    auto argP = argP0;
     if (argO != 0) {
-      llvm::errs() << "only zero-offset execution supported, argument " << i
-                   << " had byte offset of " << argO << " (ptr=" << args[i]
-                   << ", resolved base=" << (void *)argP << ")\n";
-      exit(1);
+      void *basePtr = (void *)((size_t)args[i] - argO);
+      auto fullIt = lrt->allocations.find(basePtr);
+      if (fullIt == lrt->allocations.end()) {
+        llvm::errs() << "offset view of unknown allocation, argument " << i
+                     << " ptr=" << args[i] << "\n";
+        exit(1);
+      }
+      size_t viewSize = fullIt->second.size - argO;
+      uint64_t shape[1] = {viewSize};
+      void *tmp = reactantXLAMallocImpl(lrt, /*s8*/ 2, 1, shape);
+      auto tmpIt = lrt->allocations.find(tmp);
+      {
+        std::vector<char> host(viewSize);
+        CopyFromBuffer(lrt->client, argB, host.data(), argO, viewSize, argP);
+        CopyToBuffer(lrt->client, tmpIt->second.buffer, host.data(), 0,
+                     viewSize, &tmpIt->second.buffer);
+      }
+      offsetViews.push_back({tmp, args[i], viewSize});
+      if (getenv("REACTANT_XLA_DEBUG_EXEC"))
+        llvm::errs() << " staged offset view arg " << i << " off " << argO
+                     << " size " << viewSize << "\n";
+      args[i] = tmp;
+      std::tie(argB, argO, argP) = bufferAndOffset(lrt, tmp);
     }
     baseArrays[i] = argB;
     basePtrs[i] = argP;
@@ -3859,6 +3890,56 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
       passesOk = mlir::succeeded(pm2.run(*module));
       // Later writtenness analysis reads from the current module's func.
       funcOp = funcOp2;
+    }
+    if (passesOk && failed(mlir::verify(*module))) {
+      // Still inconsistent: run without the hlo optimizer entirely —
+      // slower kernels beat dying.
+      llvm::errs() << " exec pipeline still invalid; retrying without "
+                      "enzyme-hlo-opt\n";
+      module = mlir::OwningOpRef<mlir::ModuleOp>(
+          mlir::ModuleOp::create(mlir::OpBuilder(&context).getUnknownLoc()));
+      if (failed(parseSourceString(modstr, module->getBody(), config))) {
+        llvm::errs() << " failed to re-parse module\n";
+        exit(1);
+      }
+      auto funcOp3 = cast<func::FuncOp>(&module->getBody()->back());
+      funcOp3.setSymName(builder.getStringAttr("main"));
+      funcOp3.setVisibility(SymbolTable::Visibility::Public);
+      for (int64_t i = constcnt - 1; i >= 0; i--) {
+        auto arg = funcOp3.getArgument(argcnt + i);
+        auto TT = dyn_cast<mlir::RankedTensorType>(arg.getType());
+        auto IT = dyn_cast_or_null<mlir::IntegerType>(
+            TT ? TT.getElementType() : nullptr);
+        if (!TT || !IT) {
+          llvm::errs() << " non-integer specialized scalar\n";
+          exit(1);
+        }
+        mlir::OpBuilder b3(&funcOp3.getBody().front(),
+                           funcOp3.getBody().front().begin());
+        auto cst = b3.create<mlir::stablehlo::ConstantOp>(
+            funcOp3.getLoc(),
+            mlir::SplatElementsAttr::get(TT, b3.getIntegerAttr(IT, consts[i])));
+        arg.replaceAllUsesWith(cst);
+        funcOp3.eraseArgument(argcnt + i);
+      }
+      for (int64_t i = 0; i < argcnt; i++) {
+        if (dupOf[i] < 0 && !hasDup[i])
+          funcOp3.setArgAttr(i, "tf.aliasing_output",
+                             builder.getI64IntegerAttr(i));
+      }
+      PassManager pm3(module->getContext());
+      pm3.enableVerifier(false);
+      if (constcnt) {
+        pm3.addNestedPass<mlir::func::FuncOp>(
+            stablehlo::createStablehloCanonicalizeDynamismPass());
+        pm3.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      }
+      pm3.addPass(mlir::enzyme::createEnzymeRefineArgumentsPass(types));
+      pm3.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      pm3.addNestedPass<mlir::func::FuncOp>(
+          stablehlo::createStablehloCanonicalizeDynamismPass());
+      passesOk = mlir::succeeded(pm3.run(*module));
+      funcOp = funcOp3;
     }
     // The pipeline runs unverified; catch what it produced either way.
     if (!passesOk || failed(mlir::verify(*module))) {
@@ -4044,6 +4125,14 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     } else {
       *basePtrs[i] = results[i];
     }
+  }
+  for (auto &ov : offsetViews) {
+    auto &&[tB, tO, tP] = bufferAndOffset(lrt, ov.tmp);
+    auto &&[oB, oO, oP] = bufferAndOffset(lrt, ov.orig);
+    std::vector<char> host(ov.size);
+    CopyFromBuffer(lrt->client, tB, host.data(), 0, ov.size, tP);
+    CopyToBuffer(lrt->client, oB, host.data(), oO, ov.size, oP);
+    reactantXLAFree(lrtP, ov.tmp);
   }
 }
 

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3515,6 +3515,9 @@ static void *reactantXLAMallocImpl(LinkableRuntime *__restrict__ lrt,
                                    uint64_t ptype, uint64_t shapeLen,
                                    uint64_t *__restrict__ shape);
 
+
+static const char *g_current_modstr = nullptr;
+
 static std::tuple<PjRtBuffer *, /*offset*/ size_t, PjRtBuffer **>
 bufferAndOffset(LinkableRuntime *__restrict__ lrt, void *ptr) {
   // Kernels take optional buffers as null pointers (mfem's
@@ -3535,6 +3538,9 @@ bufferAndOffset(LinkableRuntime *__restrict__ lrt, void *ptr) {
       (size_t)ptr >= (size_t)found->first + found->second.size) {
     llvm::errs() << "pointer " << ptr
                  << " does not belong to any reactant allocation\n";
+  if (const char *m = getenv("REACTANT_XLA_DUMP_MOD_ON_ERR"))
+    if (g_current_modstr)
+      llvm::errs() << " current modstr:\n" << g_current_modstr << "\n";
     exit(1);
   }
   return std::tuple<PjRtBuffer *, /*offset*/ size_t, PjRtBuffer **>(
@@ -3651,11 +3657,13 @@ REACTANT_ABI void reactantXLAFree(LinkableRuntime **__restrict__ lrtP,
   PjRtBufferFree(buffer);
 }
 
+
 REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
                                   const char *modstr, int64_t argcnt,
                                   void **args, int64_t constcnt,
                                   const int64_t *consts) {
   auto lrt = *lrtP;
+  g_current_modstr = modstr;
   auto &cache = lrt->executables[modstr];
   std::vector<PjRtBuffer *> baseArrays(argcnt);
   std::vector<PjRtBuffer **> basePtrs(argcnt);
@@ -3663,6 +3671,8 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
   std::vector<std::vector<int64_t>> sizeKey;
   sizeKey.reserve(argcnt + (constcnt ? 1 : 0));
   for (int64_t i = 0; i < argcnt; i++) {
+    if (getenv("REACTANT_XLA_DEBUG_EXEC"))
+      llvm::errs() << " resolving arg " << i << " ptr " << args[i] << "\n";
     auto &&[argB, argO, argP] = bufferAndOffset(lrt, args[i]);
     if (argO != 0) {
       llvm::errs() << "only zero-offset execution supported, argument " << i
@@ -3793,10 +3803,80 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     }
 
     bool passesOk = mlir::succeeded(pm.run(*module));
+    if (passesOk && failed(mlir::verify(*module))) {
+      // A hlo-opt pattern interplay (slice-of-broadcast motion) can leave
+      // type-inconsistent IR; retry the whole pipeline without that
+      // pattern group rather than dying.
+      llvm::errs() << " exec pipeline produced invalid IR; retrying without "
+                      "slice-motion patterns\n";
+      module = mlir::OwningOpRef<mlir::ModuleOp>(
+          mlir::ModuleOp::create(mlir::OpBuilder(&context).getUnknownLoc()));
+      if (failed(parseSourceString(modstr, module->getBody(), config))) {
+        llvm::errs() << " failed to re-parse module\n";
+        exit(1);
+      }
+      auto funcOp2 = cast<func::FuncOp>(&module->getBody()->back());
+      funcOp2.setSymName(builder.getStringAttr("main"));
+      funcOp2.setVisibility(SymbolTable::Visibility::Public);
+      for (int64_t i = constcnt - 1; i >= 0; i--) {
+        auto arg = funcOp2.getArgument(argcnt + i);
+        auto TT = dyn_cast<mlir::RankedTensorType>(arg.getType());
+        auto IT = dyn_cast_or_null<mlir::IntegerType>(
+            TT ? TT.getElementType() : nullptr);
+        if (!TT || !IT) {
+          llvm::errs() << " non-integer specialized scalar\n";
+          exit(1);
+        }
+        mlir::OpBuilder b2(&funcOp2.getBody().front(),
+                           funcOp2.getBody().front().begin());
+        auto cst = b2.create<mlir::stablehlo::ConstantOp>(
+            funcOp2.getLoc(),
+            mlir::SplatElementsAttr::get(TT, b2.getIntegerAttr(IT, consts[i])));
+        arg.replaceAllUsesWith(cst);
+        funcOp2.eraseArgument(argcnt + i);
+      }
+      for (int64_t i = 0; i < argcnt; i++) {
+        if (dupOf[i] < 0 && !hasDup[i])
+          funcOp2.setArgAttr(i, "tf.aliasing_output",
+                             builder.getI64IntegerAttr(i));
+      }
+      PassManager pm2(module->getContext());
+      pm2.enableVerifier(false);
+      if (constcnt) {
+        pm2.addNestedPass<mlir::func::FuncOp>(
+            stablehlo::createStablehloCanonicalizeDynamismPass());
+        pm2.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      }
+      pm2.addPass(mlir::enzyme::createEnzymeRefineArgumentsPass(types));
+      pm2.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      pm2.addNestedPass<mlir::func::FuncOp>(
+          stablehlo::createStablehloCanonicalizeDynamismPass());
+      {
+        mlir::enzyme::EnzymeHLOOptPassOptions opts;
+        opts.passses = 24575 & ~1ull;
+        pm2.addPass(mlir::enzyme::createEnzymeHLOOptPass(opts));
+      }
+      passesOk = mlir::succeeded(pm2.run(*module));
+      // Later writtenness analysis reads from the current module's func.
+      funcOp = funcOp2;
+    }
     // The pipeline runs unverified; catch what it produced either way.
     if (!passesOk || failed(mlir::verify(*module))) {
       llvm::errs() << " failed to run passes\n";
       llvm::errs() << " modstr:\n" << modstr << "\n";
+      {
+        std::error_code ec;
+        llvm::raw_fd_ostream fs("/tmp/claude-1000/failing_modstr.mlir", ec);
+        if (!ec)
+          fs << modstr;
+        llvm::raw_fd_ostream fp("/tmp/claude-1000/failing_postpass.mlir", ec);
+        if (!ec)
+          module->print(fp);
+        llvm::errs() << " types:";
+        for (auto ty : types)
+          llvm::errs() << " " << ty;
+        llvm::errs() << "\n";
+      }
       pm.dump();
       for (auto ty : types) {
         llvm::errs() << " arg: " << ty << "\n";


### PR DESCRIPTION
The handle `reactantXLAMalloc` returned was an 8-byte heap slot, which made pointer arithmetic on device handles unsound: interior pointers (`x.Read() + offset`, ubiquitous in MFEM) walked past the slot into neighbors, foreign pointers resolved to a garbage (buffer, ~30TB offset) pair, and a stray host write through a device handle silently replaced the stored `PjRtBuffer*` with data (observed: the bit pattern of -0.5, crashing much later in `CopyToBuffer`).

Reserve an inaccessible `mmap(PROT_NONE, MAP_NORESERVE)` range as large as the logical buffer instead, tracked as base → {buffer, size}: interior pointers resolve to (buffer, offset) with a bounds check, foreign pointers get a precise "does not belong to any reactant allocation" report, frees unmap the range, and any host dereference of a device handle faults at the offending instruction instead of corrupting state. Exec's zero-offset diagnostic now prints the pointer and resolved base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD