### PR TITLE
Fix Tables ext

### DIFF
--- a/ext/ReactantTablesExt.jl
+++ b/ext/ReactantTablesExt.jl
@@ -7,13 +7,15 @@ using Tables: Tables
 # which is ambiguous with Reactant's catch-all `TracedRNumber` comparisons. A `Col` is a
 # `ScanExpr`, not something that can be promoted to a traced number, so the mixed cases
 # should always run Tables' method.
-for jlop in (:(<), :(<=))
-    @eval begin
-        function Base.$(jlop)(lhs::TracedRNumber, rhs::Tables.Col)
-            return invoke(Base.$(jlop), Tuple{Number,Tables.Col}, lhs, rhs)
-        end
-        function Base.$(jlop)(lhs::Tables.Col, rhs::TracedRNumber)
-            return invoke(Base.$(jlop), Tuple{Tables.Col,Number}, lhs, rhs)
+@static if isdefined(Tables, :Col)
+    for jlop in (:(<), :(<=))
+        @eval begin
+            function Base.$(jlop)(lhs::TracedRNumber, rhs::Tables.Col)
+                return invoke(Base.$(jlop), Tuple{Number,Tables.Col}, lhs, rhs)
+            end
+            function Base.$(jlop)(lhs::Tables.Col, rhs::TracedRNumber)
+                return invoke(Base.$(jlop), Tuple{Tables.Col,Number}, lhs, rhs)
+            end
         end
     end
 end


### PR DESCRIPTION
Importing Reactant + Tables < 1.14 would error because `Tables.Col` is not defined.