### PR TITLE
[draft] reactantXLAExec: duplicate-argument groups (kept for the cases the read-only split does not cover)

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -12,6 +12,7 @@ void reactantReleaseAddressRange(void *base, size_t nbytes);
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Pass.h"
 #include "mlir/CAPI/Wrap.h"
+#include "mlir/IR/Verifier.h"
 #include "mlir/Pass/PassManager.h"
 
 #include "Enzyme/MLIR/Dialect/Dialect.h"
@@ -3431,8 +3432,14 @@ struct LinkableRuntime {
   xla::PjRtClient *client;
   int device;
   bool shouldFreeClient;
-  DenseMap<const char *, std::map<std::vector<std::vector<int64_t>>,
-                                  xla::PjRtLoadedExecutable *>>
+  struct CachedExec {
+    xla::PjRtLoadedExecutable *exec;
+    // Per argument view: does the kernel store through it? (a view whose
+    // result is the argument passed through unchanged is read-only)
+    std::vector<uint8_t> written;
+  };
+  DenseMap<const char *,
+           std::map<std::vector<std::vector<int64_t>>, CachedExec>>
       executables;
 
   // Each allocation reserves an inaccessible address range as large as the
@@ -3657,6 +3664,24 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
   if (constcnt)
     sizeKey.emplace_back(consts, consts + constcnt);
 
+  // A kernel called with two pointers into the same allocation (mfem's
+  // Dot(x, x)) resolves to the same buffer twice: XLA forbids donating a
+  // buffer twice AND passing a donated buffer as any other argument, so
+  // the whole duplicate group is passed undonated. The first view's result
+  // (a fresh buffer) replaces the allocation's buffer; the other results
+  // are dropped, so writes are only kept through the first view. The
+  // aliasing attrs differ per pattern, so it is part of the cache key.
+  std::vector<int64_t> dupOf(argcnt, -1);
+  std::vector<uint8_t> hasDup(argcnt, 0);
+  for (int64_t i = 0; i < argcnt; i++)
+    for (int64_t j = 0; j < i; j++)
+      if (baseArrays[i] == baseArrays[j]) {
+        dupOf[i] = j;
+        hasDup[j] = 1;
+        break;
+      }
+  sizeKey.emplace_back(dupOf.begin(), dupOf.end());
+
   auto iter = cache.find(sizeKey);
 
   if (iter == cache.end()) {
@@ -3712,10 +3737,15 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     }
 
     for (int64_t i = 0; i < argcnt; i++) {
-      funcOp.setArgAttr(i, "tf.aliasing_output", builder.getI64IntegerAttr(i));
+      if (dupOf[i] < 0 && !hasDup[i])
+        funcOp.setArgAttr(i, "tf.aliasing_output",
+                          builder.getI64IntegerAttr(i));
     }
 
     PassManager pm(module->getContext());
+    // Argument refinement leaves the body dynamic until the shape
+    // refinement pass catches up; the intermediate module does not verify.
+    pm.enableVerifier(false);
 
     SmallVector<mlir::Type> types;
     for (int64_t i = 0; i < argcnt; i++) {
@@ -3737,7 +3767,9 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
         stablehlo::createStablehloCanonicalizeDynamismPass());
     pm.addPass(mlir::enzyme::createEnzymeHLOOptPass());
 
-    if (!mlir::succeeded(pm.run(*module))) {
+    bool passesOk = mlir::succeeded(pm.run(*module));
+    // The pipeline runs unverified; catch what it produced either way.
+    if (!passesOk || failed(mlir::verify(*module))) {
       llvm::errs() << " failed to run passes\n";
       llvm::errs() << " modstr:\n" << modstr << "\n";
       pm.dump();
@@ -3747,17 +3779,55 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
       exit(1);
     }
 
+    // A view the kernel never stores through returns its argument
+    // unchanged. The unchanged copy may be wrapped in layout ops and
+    // threaded through while loops as an untouched iter arg, so walk the
+    // provenance back to the argument. Record it so duplicate views of one
+    // buffer keep the written view's result.
+    std::vector<uint8_t> written(argcnt, 1);
+    {
+      auto ret = cast<func::ReturnOp>(funcOp.getBody().front().back());
+      auto resolvesToArg = [&](mlir::Value v, mlir::Value arg) {
+        while (v != arg) {
+          mlir::Operation *op = v.getDefiningOp();
+          if (!op)
+            return false;
+          if (isa<mlir::stablehlo::ReshapeOp,
+                  mlir::stablehlo::BitcastConvertOp>(op)) {
+            v = op->getOperand(0);
+            continue;
+          }
+          if (auto wh = dyn_cast<mlir::stablehlo::WhileOp>(op)) {
+            unsigned k = cast<mlir::OpResult>(v).getResultNumber();
+            mlir::Block &body = wh.getBody().front();
+            if (body.getTerminator()->getOperand(k) != body.getArgument(k))
+              return false;
+            v = wh->getOperand(k);
+            continue;
+          }
+          return false;
+        }
+        return true;
+      };
+      for (int64_t i = 0; i < argcnt && i < (int64_t)ret.getNumOperands(); i++)
+        written[i] = !resolvesToArg(ret.getOperand(i), funcOp.getArgument(i));
+    }
     auto exec =
         ClientCompileWithProto(lrt->client, wrap(module.get()), nullptr, 0);
 
-    iter = cache.try_emplace(sizeKey, exec).first;
+    iter =
+        cache
+            .try_emplace(sizeKey,
+                         LinkableRuntime::CachedExec{exec, std::move(written)})
+            .first;
   }
 
-  auto exec = iter->second;
+  auto exec = iter->second.exec;
+  auto &written = iter->second.written;
 
   uint8_t *is_arg_donatable = (uint8_t *)malloc(argcnt);
   for (int i = 0; i < argcnt; i++)
-    is_arg_donatable[i] = 1;
+    is_arg_donatable[i] = (dupOf[i] < 0 && !hasDup[i]) ? 1 : 0;
   int num_results = argcnt;
   std::vector<PjRtBuffer *> results(argcnt);
   std::vector<uint8_t> futures(argcnt, 0);
@@ -3768,10 +3838,36 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
                     future_results.data());
   free(is_arg_donatable);
   for (int64_t i = 0; i < argcnt; i++) {
-    *basePtrs[i] = results[i];
     if (futures[i]) {
       FutureAwait(future_results[i]);
       FreeFuture(future_results[i]);
+    }
+  }
+  // Each duplicate group keeps the result of the view the kernel stores
+  // through (a read-only view's result is just the stale input); with no
+  // written view any result is that same input, so the leader's serves.
+  std::vector<int64_t> keepFor(argcnt, -1);
+  for (int64_t i = 0; i < argcnt; i++) {
+    int64_t leader = dupOf[i] >= 0 ? dupOf[i] : (hasDup[i] ? i : -1);
+    if (leader >= 0 && keepFor[leader] < 0 &&
+        (leader < (int64_t)written.size() ? written[i] : 1))
+      keepFor[leader] = i;
+  }
+  for (int64_t i = 0; i < argcnt; i++)
+    if (hasDup[i] && keepFor[i] < 0)
+      keepFor[i] = i;
+  for (int64_t i = 0; i < argcnt; i++) {
+    if (dupOf[i] >= 0 || hasDup[i]) {
+      int64_t leader = dupOf[i] >= 0 ? dupOf[i] : i;
+      if (keepFor[leader] == i) {
+        // Undonated: the exec did not consume the old buffer.
+        PjRtBufferFree(*basePtrs[i]);
+        *basePtrs[i] = results[i];
+      } else {
+        PjRtBufferFree(results[i]);
+      }
+    } else {
+      *basePtrs[i] = results[i];
     }
   }
 }


### PR DESCRIPTION
A kernel whose output aliases an input (mfem's `add(z, beta, d, d)`) resolves to the same buffer twice; XLA forbids donating a buffer twice **and** passing a donated buffer as any other argument, so the whole duplicate group is passed undonated. One result must then replace the allocation's buffer — and keeping the first view's result silently kept the stale input whenever the written view came later, so in-place updates vanished (a preconditioned CG stalled at its initial residual).

Record per-view writtenness when the executable is built — a view is read-only when its result resolves back to its own argument through layout ops and untouched while iter args — and keep the written view's result for each duplicate group. The duplicate pattern joins the executable cache key, since the aliasing attributes differ per pattern.

Part of the #3223 split; targets main independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD