### PR TITLE
reactantXLAExec: retry the exec pipeline on invalid IR, with and without slice motion

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3786,7 +3786,8 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     pm.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
     pm.addNestedPass<mlir::func::FuncOp>(
         stablehlo::createStablehloCanonicalizeDynamismPass());
-    pm.addPass(mlir::enzyme::createEnzymeHLOOptPass());
+    if (!getenv("REACTANT_XLA_NO_HLO_OPT"))
+      pm.addPass(mlir::enzyme::createEnzymeHLOOptPass());
 
     bool passesOk = mlir::succeeded(pm.run(*module));
     if (passesOk && failed(mlir::verify(*module))) {
@@ -3845,6 +3846,56 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
       passesOk = mlir::succeeded(pm2.run(*module));
       // Later writtenness analysis reads from the current module's func.
       funcOp = funcOp2;
+    }
+    if (passesOk && failed(mlir::verify(*module))) {
+      // Still inconsistent: run without the hlo optimizer entirely —
+      // slower kernels beat dying.
+      llvm::errs() << " exec pipeline still invalid; retrying without "
+                      "enzyme-hlo-opt\n";
+      module = mlir::OwningOpRef<mlir::ModuleOp>(
+          mlir::ModuleOp::create(mlir::OpBuilder(&context).getUnknownLoc()));
+      if (failed(parseSourceString(modstr, module->getBody(), config))) {
+        llvm::errs() << " failed to re-parse module\n";
+        exit(1);
+      }
+      auto funcOp3 = cast<func::FuncOp>(&module->getBody()->back());
+      funcOp3.setSymName(builder.getStringAttr("main"));
+      funcOp3.setVisibility(SymbolTable::Visibility::Public);
+      for (int64_t i = constcnt - 1; i >= 0; i--) {
+        auto arg = funcOp3.getArgument(argcnt + i);
+        auto TT = dyn_cast<mlir::RankedTensorType>(arg.getType());
+        auto IT = dyn_cast_or_null<mlir::IntegerType>(TT ? TT.getElementType()
+                                                         : nullptr);
+        if (!TT || !IT) {
+          llvm::errs() << " non-integer specialized scalar\n";
+          exit(1);
+        }
+        mlir::OpBuilder b3(&funcOp3.getBody().front(),
+                           funcOp3.getBody().front().begin());
+        auto cst = b3.create<mlir::stablehlo::ConstantOp>(
+            funcOp3.getLoc(),
+            mlir::SplatElementsAttr::get(TT, b3.getIntegerAttr(IT, consts[i])));
+        arg.replaceAllUsesWith(cst);
+        funcOp3.eraseArgument(argcnt + i);
+      }
+      for (int64_t i = 0; i < argcnt; i++) {
+        if (dupOf[i] < 0 && !hasDup[i])
+          funcOp3.setArgAttr(i, "tf.aliasing_output",
+                             builder.getI64IntegerAttr(i));
+      }
+      PassManager pm3(module->getContext());
+      pm3.enableVerifier(false);
+      if (constcnt) {
+        pm3.addNestedPass<mlir::func::FuncOp>(
+            stablehlo::createStablehloCanonicalizeDynamismPass());
+        pm3.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      }
+      pm3.addPass(mlir::enzyme::createEnzymeRefineArgumentsPass(types));
+      pm3.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      pm3.addNestedPass<mlir::func::FuncOp>(
+          stablehlo::createStablehloCanonicalizeDynamismPass());
+      passesOk = mlir::succeeded(pm3.run(*module));
+      funcOp = funcOp3;
     }
     // The pipeline runs unverified; catch what it produced either way.
     if (!passesOk || failed(mlir::verify(*module))) {

--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3789,10 +3789,80 @@ REACTANT_ABI void reactantXLAExec(LinkableRuntime **__restrict__ lrtP,
     pm.addPass(mlir::enzyme::createEnzymeHLOOptPass());
 
     bool passesOk = mlir::succeeded(pm.run(*module));
+    if (passesOk && failed(mlir::verify(*module))) {
+      // A hlo-opt pattern interplay (slice-of-broadcast motion) can leave
+      // type-inconsistent IR; retry the whole pipeline without that
+      // pattern group rather than dying.
+      llvm::errs() << " exec pipeline produced invalid IR; retrying without "
+                      "slice-motion patterns\n";
+      module = mlir::OwningOpRef<mlir::ModuleOp>(
+          mlir::ModuleOp::create(mlir::OpBuilder(&context).getUnknownLoc()));
+      if (failed(parseSourceString(modstr, module->getBody(), config))) {
+        llvm::errs() << " failed to re-parse module\n";
+        exit(1);
+      }
+      auto funcOp2 = cast<func::FuncOp>(&module->getBody()->back());
+      funcOp2.setSymName(builder.getStringAttr("main"));
+      funcOp2.setVisibility(SymbolTable::Visibility::Public);
+      for (int64_t i = constcnt - 1; i >= 0; i--) {
+        auto arg = funcOp2.getArgument(argcnt + i);
+        auto TT = dyn_cast<mlir::RankedTensorType>(arg.getType());
+        auto IT = dyn_cast_or_null<mlir::IntegerType>(TT ? TT.getElementType()
+                                                         : nullptr);
+        if (!TT || !IT) {
+          llvm::errs() << " non-integer specialized scalar\n";
+          exit(1);
+        }
+        mlir::OpBuilder b2(&funcOp2.getBody().front(),
+                           funcOp2.getBody().front().begin());
+        auto cst = b2.create<mlir::stablehlo::ConstantOp>(
+            funcOp2.getLoc(),
+            mlir::SplatElementsAttr::get(TT, b2.getIntegerAttr(IT, consts[i])));
+        arg.replaceAllUsesWith(cst);
+        funcOp2.eraseArgument(argcnt + i);
+      }
+      for (int64_t i = 0; i < argcnt; i++) {
+        if (dupOf[i] < 0 && !hasDup[i])
+          funcOp2.setArgAttr(i, "tf.aliasing_output",
+                             builder.getI64IntegerAttr(i));
+      }
+      PassManager pm2(module->getContext());
+      pm2.enableVerifier(false);
+      if (constcnt) {
+        pm2.addNestedPass<mlir::func::FuncOp>(
+            stablehlo::createStablehloCanonicalizeDynamismPass());
+        pm2.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      }
+      pm2.addPass(mlir::enzyme::createEnzymeRefineArgumentsPass(types));
+      pm2.addPass(mlir::stablehlo::createStablehloRefineShapesPass());
+      pm2.addNestedPass<mlir::func::FuncOp>(
+          stablehlo::createStablehloCanonicalizeDynamismPass());
+      {
+        mlir::enzyme::EnzymeHLOOptPassOptions opts;
+        opts.passses = 24575 & ~1ull;
+        pm2.addPass(mlir::enzyme::createEnzymeHLOOptPass(opts));
+      }
+      passesOk = mlir::succeeded(pm2.run(*module));
+      // Later writtenness analysis reads from the current module's func.
+      funcOp = funcOp2;
+    }
     // The pipeline runs unverified; catch what it produced either way.
     if (!passesOk || failed(mlir::verify(*module))) {
       llvm::errs() << " failed to run passes\n";
       llvm::errs() << " modstr:\n" << modstr << "\n";
+      {
+        std::error_code ec;
+        llvm::raw_fd_ostream fs("/tmp/claude-1000/failing_modstr.mlir", ec);
+        if (!ec)
+          fs << modstr;
+        llvm::raw_fd_ostream fp("/tmp/claude-1000/failing_postpass.mlir", ec);
+        if (!ec)
+          module->print(fp);
+        llvm::errs() << " types:";
+        for (auto ty : types)
+          llvm::errs() << " " << ty;
+        llvm::errs() << "\n";
+      }
       pm.dump();
       for (auto ty : types) {
         llvm::errs() << " arg: " << ty << "\n";


### PR DESCRIPTION
Two-stage insurance for the exec pipeline, plus a debugging lever:

1. A hlo-opt pattern interplay (slice-of-broadcast motion) can leave type-inconsistent IR; verify the module after the passes and, on failure, rebuild from source and retry with the slice-motion pattern group disabled. (The interplay itself is EnzymeAD/Enzyme-JAX#3000 / fixed cases in EnzymeAD/Enzyme-JAX#3024 — this keeps the runtime alive for the next one.)
2. If both optimizer attempts leave inconsistent IR, run once more without the hlo optimizer entirely — slower kernels beat dying.
3. `REACTANT_XLA_NO_HLO_OPT` skips the optimizer up front, to split optimizer miscompiles from raising ones without a rebuild.

Part of the #3223 split; stacked on #3238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
