### PR TITLE
Stage device-to-device copies through the host

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -3549,8 +3549,15 @@ REACTANT_ABI void reactantXLAMemcpy(LinkableRuntime **__restrict__ lrtP,
     break;
   }
   case 3: // cudaMemcpyDeviceToDevice
-    llvm_unreachable("device to device copy unsupported");
+  {
+    // PJRT exposes no raw buffer-to-buffer copy; stage through the host.
+    auto &&[srcB, srcO, srcStart] = bufferAndOffset(lrt, src);
+    auto &&[dstB, dstO, dstStart] = bufferAndOffset(lrt, dst);
+    std::vector<char> tmp(size);
+    CopyFromBuffer(lrt->client, srcB, tmp.data(), srcO, size, srcStart);
+    CopyToBuffer(lrt->client, dstB, tmp.data(), dstO, size, dstStart);
     break;
+  }
   default: // cudaMemcpyDeviceToDevice
     llvm_unreachable("unknown copy unsupported");
     break;


### PR DESCRIPTION
mfem's `Vector` copy constructor issues `cudaMemcpy(DeviceToDevice)`, which fell into the `llvm_unreachable` arm (in a release build, undefined behavior that happened to fall through into the HtoD path). PJRT exposes no raw buffer-to-buffer copy, so bounce through a host buffer (EnzymeAD/Reactant.jl#3242 tracks doing this properly upstream).

Part of the #3223 split, now targeting main directly. Replaces #3236, which was merged into #3235's branch while the series was stacked; that merge has been backed out of #3235 so each piece can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zErYp7upmqr4NHfhod9UD
