### PR TITLE
Test target GPU instead of CUDA

### DIFF
--- a/test/core/sharding/optimize_comm.jl
+++ b/test/core/sharding/optimize_comm.jl
@@ -3,7 +3,9 @@ using Reactant, Test, FileCheck
 const addressable_devices = Reactant.addressable_devices()
 
 const RunningOnTPU = contains(string(Reactant.devices()[1]), "TPU")
-const RunningOnGPU = Reactant.XLA.platform_name(Reactant.XLA.default_backend()) != "cpu"
+const RunningOnGPU =
+    lowercase(Reactant.XLA.platform_name(Reactant.XLA.default_backend())) in
+    ("cuda", "rocm")
 
 function rotate(x)
     y = x[1:100, :]

--- a/test/core/sharding/optimize_comm.jl
+++ b/test/core/sharding/optimize_comm.jl
@@ -3,7 +3,7 @@ using Reactant, Test, FileCheck
 const addressable_devices = Reactant.addressable_devices()
 
 const RunningOnTPU = contains(string(Reactant.devices()[1]), "TPU")
-const RunningOnGPU = contains(string(Reactant.devices()[1]), "CUDA")
+const RunningOnGPU = Reactant.XLA.platform_name(Reactant.XLA.default_backend()) != "cpu"
 
 function rotate(x)
     y = x[1:100, :]


### PR DESCRIPTION
This PR fixes tests running on any-GPU while it currently targets CUDA-only. The file two directories over already uses the suggested API.