### PR TITLE
Follow the JAX repositories that moved with its Bzlmod migration

### DIFF
--- a/deps/ReactantExtra/API.cpp
+++ b/deps/ReactantExtra/API.cpp
@@ -150,6 +150,7 @@ void reactantReleaseAddressRange(void *base, size_t nbytes);
 #include "xla/python/ifrt/index_domain.h"
 #include "xla/python/ifrt/ir/ifrt_ir_program.h"
 #include "xla/python/ifrt/memory.h"
+#include "xla/python/ifrt/rtti.h"
 #include "xla/python/ifrt/shape.h"
 #include "xla/python/ifrt/sharding.h"
 #include "xla/python/ifrt/topology.h"
@@ -772,11 +773,11 @@ REACTANT_ABI void PjRtDeviceGetAllocatorStats(PjRtDevice *device,
 
 REACTANT_ABI void ifrt_device_get_allocator_stats(ifrt::Device *device,
                                                   JLAllocatorStats *jlstats) {
-  if (!llvm::isa<ifrt::PjRtDevice>(device)) {
+  if (!ifrt::isa<ifrt::PjRtDevice>(device)) {
     ReactantThrowError(
         "ifrt_device_get_allocator_stats: only supported for ifrt-pjrt.");
   }
-  auto ifrt_pjrt_device = llvm::dyn_cast<ifrt::PjRtDevice>(device);
+  auto ifrt_pjrt_device = ifrt::dyn_cast<ifrt::PjRtDevice>(device);
   PjRtDeviceGetAllocatorStats(ifrt_pjrt_device->pjrt_device(), jlstats);
 }
 
@@ -2409,11 +2410,11 @@ REACTANT_ABI bool ifrt_DeviceIsAddressable(ifrt::Device *device) {
 }
 
 REACTANT_ABI int64_t ifrt_DeviceGetLocalHardwareId(ifrt::Device *device) {
-  if (!llvm::isa<ifrt::PjRtDevice>(device)) {
+  if (!ifrt::isa<ifrt::PjRtDevice>(device)) {
     ReactantThrowError(
         "ifrt_DeviceGetLocalHardwareId: only supported for ifrt-pjrt.");
   }
-  auto ifrt_pjrt_device = llvm::dyn_cast<ifrt::PjRtDevice>(device);
+  auto ifrt_pjrt_device = ifrt::dyn_cast<ifrt::PjRtDevice>(device);
   return ifrt_pjrt_device->pjrt_device()->local_hardware_id().value();
 }
 
@@ -2650,9 +2651,9 @@ REACTANT_ABI HeldIfrtSharding *ifrt_sharding_from_xla_hlo_sharding(
 REACTANT_ABI xla::HloSharding *
 ifrt_sharding_to_xla_hlo_sharding(HeldIfrtSharding *sharding) {
   const ifrt::Sharding *val = sharding->obj().get();
-  if (!llvm::isa<ifrt::HloSharding>(val))
+  if (!ifrt::isa<ifrt::HloSharding>(val))
     ReactantThrowError("Expected a HloSharding");
-  auto ifrt_hlo_sharding = llvm::dyn_cast<const ifrt::HloSharding>(val);
+  auto ifrt_hlo_sharding = ifrt::dyn_cast<ifrt::HloSharding>(val);
   xla::HloSharding *xla_hlo_sharding =
       new xla::HloSharding(ifrt_hlo_sharding->xla_hlo_sharding());
   return xla_hlo_sharding;
@@ -2660,7 +2661,7 @@ ifrt_sharding_to_xla_hlo_sharding(HeldIfrtSharding *sharding) {
 
 REACTANT_ABI bool
 ifrt_sharding_is_single_device_sharding(HeldIfrtSharding *sharding) {
-  return llvm::isa<const ifrt::SingleDeviceSharding>(sharding->obj().get());
+  return ifrt::isa<ifrt::SingleDeviceSharding>(sharding->obj().get());
 }
 
 REACTANT_ABI bool
@@ -3268,8 +3269,8 @@ REACTANT_ABI void pjrt_hlo_module_cost_analysis_properties(
 REACTANT_ABI void ifrt_hlo_module_cost_analysis_properties(
     ifrt::Client *client, HeldHloModule *hlo_module,
     JLHloCostAnalysisProperties *jlproperties) {
-  if (llvm::isa<ifrt::PjRtClient>(client)) {
-    auto ifrt_pjrt_client = llvm::dyn_cast<ifrt::PjRtClient>(client);
+  if (ifrt::isa<ifrt::PjRtClient>(client)) {
+    auto ifrt_pjrt_client = ifrt::dyn_cast<ifrt::PjRtClient>(client);
     return pjrt_hlo_module_cost_analysis_properties(
         ifrt_pjrt_client->pjrt_client(), hlo_module, jlproperties);
   }
@@ -3401,20 +3402,22 @@ REACTANT_ABI void addSdyPropagationPipeline(
     uint8_t debugPropagationEdgeSharding /*false*/,
     uint8_t skipConvertToReshard /*false*/, uint8_t skipInline /*false*/,
     uint8_t enableInsertExplicitCollectives /*false*/) {
-  const mlir::sdy::PropagationOptions options{keepShardingRules != 0,
-                                              "",
-                                              conservativePropagation != 0,
-                                              debugShardingOrigins != 0,
-                                              debugPropagationEdgeSharding != 0,
-                                              skipConvertToReshard != 0,
-                                              skipInline != 0,
-                                              enableInsertExplicitCollectives !=
-                                                  0};
+  // Set the options by name: shardy adds fields to this struct, and has
+  // dropped the ones skipConvertToReshard and skipInline named, which no
+  // longer have anything behind them to ask for.
+  (void)skipConvertToReshard;
+  (void)skipInline;
+  mlir::sdy::PropagationOptions options;
+  options.keepShardingRules = keepShardingRules != 0;
+  options.conservativePropagation = conservativePropagation != 0;
+  options.debugShardingOrigins = debugShardingOrigins != 0;
+  options.debugPropagationEdgeSharding = debugPropagationEdgeSharding != 0;
+  options.enableInsertExplicitCollectives = enableInsertExplicitCollectives != 0;
   mlir::sdy::addPropagationPipeline(pm, options);
 }
 
 REACTANT_ABI HeldIfrtArray *ifrt_copy_array(HeldIfrtArray *array) {
-  auto pjrtArray = dyn_cast<ifrt::PjRtArray>(array->obj().get());
+  auto pjrtArray = ifrt::dyn_cast<ifrt::PjRtArray>(array->obj().get());
   if (pjrtArray) {
     std::optional<ifrt::DeviceListRef> devices;
     std::optional<ifrt::MemoryKind> memory_kind;

--- a/deps/ReactantExtra/WORKSPACE
+++ b/deps/ReactantExtra/WORKSPACE
@@ -4,7 +4,7 @@ NSYNC_COMMIT = "82b118aa7ace3132e517e2c467f8732978cf4023"
 
 NSYNC_SHA256 = ""
 
-ENZYMEXLA_COMMIT = "aea4857fc44b6d9f95c71bfdaa365a233f1b6a6e"
+ENZYMEXLA_COMMIT = "538761ed13c402b347def13761399119ccfd9dd5"
 
 ENZYMEXLA_SHA256 = ""
 
@@ -150,10 +150,6 @@ cuda_tile_workspace("@enzyme_ad")
 #     url = "https://github.com/protocolbuffers/upb/archive/9effcbcb27f0a665f9f345030188c0b291e32482.tar.gz"
 # )
 
-load("@jax//third_party/xla:workspace.bzl", jax_xla_workspace = "repo")
-
-jax_xla_workspace()
-
 load("@xla//:workspace4.bzl", "xla_workspace4")
 
 xla_workspace4()
@@ -228,7 +224,7 @@ python_wheel_version_suffix_repository(
     name = "jax_wheel_version_suffix",
 )
 
-load("@jax//third_party/flatbuffers:workspace.bzl", flatbuffers = "repo")
+load("@enzyme_ad//third_party/flatbuffers:workspace.bzl", flatbuffers = "repo")
 
 flatbuffers()
 


### PR DESCRIPTION
JAX deleted its `WORKSPACE` (jax-ml/jax@3b3bebe4), and with it the two repository definitions `deps/ReactantExtra/WORKSPACE` loads out of it, so the Reactant_jll build against the Enzyme-JAX JAX bump fails during workspace evaluation:

```
ERROR: Failed to load Starlark extension '@@jax_deps//:deps.bzl'.
```

Two loads move:

- `@jax//third_party/xla:workspace.bzl` is gone. The call was already a no-op — `xla_workspace(NEW_XLA_PATCHES)` above it defines the `xla` repository, and a WORKSPACE keeps the first definition of a repository — so it is simply dropped.
- `@jax//third_party/flatbuffers:workspace.bzl` is gone too; Enzyme-JAX now defines that repository, building it at the version JAX's `MODULE.bazel` asks for (25.2.10, where JAX's WORKSPACE-era definition was pinned at 23.5.26).

Everything else this file loads from `@jax` — `jaxlib/jax_python_wheel.bzl`, `jax/version.py`, `build/nvidia-requirements.txt`, `third_party/external_deps`, `test_shard_count.bzl`, `third_party/rocm_wheels` — still exists.

`ENZYMEXLA_COMMIT` is bumped to the head of EnzymeAD/Enzyme-JAX#3042, which carries the Enzyme-JAX side, so CI here builds against it. **Move that pin on to the merge commit once #3042 lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AyMHG2YuT1uZgr3DY2aeQ