### PR TITLE
Reduce compilation latency by limiting specialization

### DIFF
--- a/src/TracedUtils.jl
+++ b/src/TracedUtils.jl
@@ -296,10 +296,11 @@ function is_pure(func)
     return true
 end
 
-function make_mlir_fn(
-    f,
-    args,
-    kwargs,
+# The tracing driver is shared; call_with_reactant specializes the traced program.
+Base.@nospecializeinfer function make_mlir_fn(
+    @nospecialize(f),
+    @nospecialize(args),
+    @nospecialize(kwargs),
     name="main",
     concretein=true;
     toscalar=false,
@@ -455,8 +456,9 @@ function make_mlir_fn(
     )
 end
 
-function prepare_mlir_fn_args(
-    args,
+# Reuse MLIR setup across argument types; make_tracer handles each argument.
+Base.@nospecializeinfer function prepare_mlir_fn_args(
+    @nospecialize(args),
     name,
     concretein,
     toscalar,
@@ -625,8 +627,9 @@ function process_linear_args!(linear_args, fnbody, do_transpose, optimize_then_p
     end
 end
 
-function finalize_mlir_fn(
-    result,
+# Return bookkeeping is shared across traced functions and their result types.
+Base.@nospecializeinfer function finalize_mlir_fn(
+    @nospecialize(result),
     traced_args,
     linear_args,
     skipped_args,
@@ -651,7 +654,7 @@ function finalize_mlir_fn(
     num_replicas,
     runtime,
     construct_function_without_args,
-    args,
+    @nospecialize(args),
     N,
     concretein,
     toscalar,

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -235,10 +235,11 @@ function raising!(f, is_raising::Bool)
     end
 end
 
-function compile_mlir!(
+# The pass pipeline is independent of the model's Julia function and argument types.
+Base.@nospecializeinfer function compile_mlir!(
     mod,
-    f,
-    args,
+    @nospecialize(f),
+    @nospecialize(args),
     compile_options::CompileOptions,
     debugcache=default_debugcache(),
     callcache=default_callcache(),


### PR DESCRIPTION
Compiling a new function or argument tuple can cause Julia to recompile substantial MLIR setup, pass-pipeline, and result-handling code. This change limits specialization of four shared helpers on function, argument, and result types, allowing their compiled code to be reused. Traced program execution and individual argument conversion retain specialization.

No dependency or precompile workload is added.

Standalone CPU/PJRT benchmarks on the Grace CPU of a DGX Spark with Julia 1.13.0 gave the following **first-call `Reactant.compile` timings**. Entries are medians across three fresh processes per workload and variant, with alternating run order and one Julia/BLAS thread. Packages were precompiled beforehand; package loading and input construction are excluded.

| Workload | Before | After |
|---|---:|---:|
| Broadcast | 5.23 s | 3.29 s |
| Network | 6.90 s | 4.75 s |
| Gradient | 9.56 s | 7.06 s |
| Nested results | 5.59 s | 3.82 s |

Compiling a second network function in the same process falls from 1.58 to 0.82 seconds. Warm tracing medians change by approximately 1% or less across these workloads; warm compilation and execution ranges overlap. Separate cold `@code_hlo optimize=false` measurements show 44–62% fewer allocated bytes.

Julia 1.12.7 measurements also show improvements. Separate stage diagnostics on 1.12 attribute the savings to Julia compilation, including inference, while MLIR and XLA timings remain within variation. Three package rebuilds per variant give medians of 78.2 s before and 76.4 s after, with overlapping ranges; the native package image is approximately 2% smaller.

Validation on each of Julia 1.12.7 and 1.13.0: 589 core CPU tests pass, 96 numerical checks pass, and all 96 paired IR comparisons match.

<details>
<summary>Minimal CPU reproducer</summary>

This reduced script exercises the broadcast case. It reports first-call compilation, the median of nine warm compilations, and compilation of a different function with the same argument types. Its smaller harness need not reproduce the table’s exact timings.

Use an environment pointing at the checkout being measured, for example through `Pkg.develop(path=...)`. Keep dependency versions and preferences identical between variants, and instantiate/precompile before measuring. Run each cold sample in a fresh Julia 1.13 process, alternating baseline and PR order:

```sh
JULIA_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
  julia --startup-file=no --project=/path/to/environment repro.jl
```

Save this as `repro.jl`:

```julia
using Reactant, Random
Reactant.set_default_backend("cpu")

loss(x, y) = sum(abs2, tanh.(x .+ y) .- y) / length(x)
summary_kernel(x, y) = (;
    total=sum(sin.(x) .* cos.(y)),
    columns=sum(x .* y; dims=1),
)

# Keep compilation of the measured target inside the timer.
Base.@nospecializeinfer function measure(@nospecialize(f), @nospecialize(args))
    return @timed Base.invokelatest(f, args...)
end
measure(identity, (nothing,)) # Warm only the measurement helper.

rng = MersenneTwister(1234)
x, y = randn(rng, Float32, 128, 32), randn(rng, Float32, 128, 32)
inputs = map(Reactant.to_rarray, (x, y))
Reactant.synchronize(inputs)

GC.gc()
first = measure(Reactant.compile, (loss, inputs))
warm = sort([measure(Reactant.compile, (loss, inputs)).time for _ in 1:9])[5]
GC.gc()
second = measure(Reactant.compile, (summary_kernel, inputs))

# Check results only after all compilation measurements.
@assert isapprox(Reactant.to_number(first.value(inputs...)), loss(x, y); rtol=5e-4)
actual, expected = second.value(inputs...), summary_kernel(x, y)
@assert isapprox(Reactant.to_number(actual.total), expected.total; rtol=5e-4)
@assert isapprox(Array(actual.columns), expected.columns; rtol=5e-4)

println((;
    first_compile_s=first.time,
    julia_compilation_s=first.compile_time,
    first_allocated_MB=first.bytes / 1e6,
    warm_compile_median_s=warm,
    second_function_compile_s=second.time,
))
```

`julia_compilation_s` includes inference and native compilation. These timings exclude execution; the assertions run the compiled functions only after all compilation measurements.

</details>

Assisted by: GPT-6 Astra