### PR TITLE
fix: improve type inference on `mapreduce` for `TracedRArray`

### DIFF
--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -673,9 +673,9 @@ end
 
 @noinline function reshape(
     x::TracedRArray{T,N},
-    dims::Union{Vector{Int},NTuple{M,Int}};
+    dims::Vector{Int};
     location=mlir_stacktrace("reshape", @__FILE__, @__LINE__),
-) where {T,N,M}
+) where {T,N}
     @assert length(x) == prod(dims)
 
     # HLO reshape semantics collapse the opposite way

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -673,9 +673,9 @@ end
 
 @noinline function reshape(
     x::TracedRArray{T,N},
-    dims::Vector{Int};
+    dims::Union{Vector{Int},NTuple{M,Int}};
     location=mlir_stacktrace("reshape", @__FILE__, @__LINE__),
-) where {T,N}
+) where {T,N,M}
     @assert length(x) == prod(dims)
 
     # HLO reshape semantics collapse the opposite way

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -192,41 +192,60 @@ function overloaded_mapreduce(
     init=Base._InitialValue(),
 ) where {T,N}
     original_dims = dims
-    dims isa Int && (dims = Int64[dims])
-    dims isa Colon && (dims = collect(Int64, 1:N))
-    dims isa Vector{Int64} || (dims = collect(Int64, dims))
-    dims = sort(dims)
+    # don't reassign dims to avoid the "captured variable in closure" type instability 
+    normalized_dims = if dims isa Int
+        Int64[dims]
+    elseif dims isa Colon
+        collect(Int64, 1:N)
+    elseif dims isa Vector{Int64}
+        dims
+    else
+        collect(Int64, dims)
+    end |> sort
 
     op_in_T = unwrapped_eltype(Core.Compiler.return_type(f, Tuple{T}))
     # `op` may accumulate in a wider type than it consumes: `+(::Bool, ::Bool)::Int64`, so
     # `sum` over booleans is an `Int64` in Base. `__default_init` reports that wider type
     # (it is the type of `op`'s identity element), so reduce in it.
     init_val = __default_init(op_in_T, op)
-    op_in_T = unwrapped_eltype(typeof(init_val))
-    reduce_init = Reactant.promote_to(TracedRNumber{op_in_T}, init_val)
+    # TODO: double-check that this is the eltype of the output
+    op_out_T = unwrapped_eltype(typeof(init_val))
+    reduce_init = Reactant.promote_to(TracedRNumber{op_out_T}, init_val)
 
     # Widen *after* applying `f`, not before. `f` decides the element type actually being
     # reduced, so converting `A` up front is undone by anything narrowing -- e.g. the
     # predicate in `sum(x -> x == 1, a)` returns `Bool` whatever `A` was converted to.
     # Reducing in the narrow type is silently wrong: `stablehlo.add` over `i1` is a logical
     # `or`, and small integers wrap.
-    reduce_input = materialize_traced_array(TracedUtils.elem_apply(f, A))
-    if unwrapped_eltype(reduce_input) != op_in_T
-        reduce_input = op_in_T.(reduce_input)
+    reduce_input_wrongtype = materialize_traced_array(TracedUtils.elem_apply(f, A))
+    # TODO: The line above is not inferred correctly, and maybe subsequent lines aren't either.
+
+    if unwrapped_eltype(reduce_input_wrongtype) != op_out_T
+        reduce_input = op_out_T.(reduce_input_wrongtype)
+    else
+        reduce_input = reduce_input_wrongtype
     end
 
-    res = @opcall reduce(reduce_input, reduce_init, dims, op)
+    res_without_init = @opcall reduce(reduce_input, reduce_init, normalized_dims, op)
 
-    (init isa Base._InitialValue || init === nothing) || (res = op.(res, init))
+    if (init isa Base._InitialValue || init === nothing)
+        res = res_without_init
+    else
+        res = op.(res_without_init, init)
+    end
 
     if original_dims isa Colon
         @assert size(res) == () "expected size of result to be (), got $(size(res))"
-        return TracedRNumber{unwrapped_eltype(res)}((), res.mlir_data)
+        return TracedRNumber{op_out_T}((), res.mlir_data)
     end
     if res isa TracedRNumber
-        res = TracedRArray{unwrapped_eltype(res),0}((), res.mlir_data, ())
+        res = TracedRArray{op_out_T,0}((), res.mlir_data, ())
     end
-    return @opcall reshape(res, [ifelse(i in dims, 1, size(A, i)) for i in 1:N])
+    # use ntuple so that the array rank is inferrable, the corresponding method for reshape was added
+    shape = ntuple(i -> ifelse(i in normalized_dims, 1, size(A, i)), Val(N))
+    res_reshaped = @opcall reshape(res, shape)
+    # force return type inference
+    return TracedRArray{op_out_T,N}((), res_reshaped.mlir_data, shape)
 end
 
 function Base.mapreducedim!(
@@ -353,7 +372,7 @@ function Base.copyto!(
     sstart::Integer,
     n::Integer,
 ) where {T}
-    setindex!(dest, src[sstart:(sstart + n - 1)], dstart:(dstart + n - 1))
+    setindex!(dest, src[sstart:(sstart+n-1)], dstart:(dstart+n-1))
     return dest
 end
 
@@ -1016,7 +1035,7 @@ end
         end
         return TracedRNumber{
             unwrapped_eltype(
-                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A)); init)
+                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A));init)
             ),
         }
     end
@@ -1221,10 +1240,10 @@ function circshift_internal!(
         amt = shiftamt[i] % size(src, i)
         amt == 0 && continue
         if amt > 0
-            src1 = selectdim(src, i, (size(src, i) - amt + 1):size(src, i))
-            src2 = selectdim(src, i, 1:(size(src, i) - amt))
+            src1 = selectdim(src, i, (size(src, i)-amt+1):size(src, i))
+            src2 = selectdim(src, i, 1:(size(src, i)-amt))
         else
-            src1 = selectdim(src, i, (-amt + 1):size(src, i))
+            src1 = selectdim(src, i, (-amt+1):size(src, i))
             src2 = selectdim(src, i, 1:(-amt))
         end
         src = cat(materialize_traced_array(src1), materialize_traced_array(src2); dims=i)

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -193,15 +193,17 @@ function overloaded_mapreduce(
 ) where {T,N}
     original_dims = dims
     # don't reassign dims to avoid the "captured variable in closure" type instability 
-    normalized_dims = if dims isa Int
-        Int64[dims]
-    elseif dims isa Colon
-        collect(Int64, 1:N)
-    elseif dims isa Vector{Int64}
-        dims
-    else
-        collect(Int64, dims)
-    end |> sort
+    normalized_dims = sort(
+        if dims isa Int
+            Int64[dims]
+        elseif dims isa Colon
+            collect(Int64, 1:N)
+        elseif dims isa Vector{Int64}
+            dims
+        else
+            collect(Int64, dims)
+        end,
+    )
 
     op_in_T = unwrapped_eltype(Core.Compiler.return_type(f, Tuple{T}))
     # `op` may accumulate in a wider type than it consumes: `+(::Bool, ::Bool)::Int64`, so
@@ -278,7 +280,7 @@ function Base.fill!(A::AnyTracedRArray{T,N}, x::TracedRNumber{T2}) where {T,N,T2
 end
 
 function Base.fill!(A::Array{T,N}, x::TracedRNumber{T2}) where {T,N,T2}
-    throw(MethodError(fill!, (A, x)))
+    return throw(MethodError(fill!, (A, x)))
 end
 
 struct AbstractReactantArrayStyle{N} <: AbstractArrayStyle{N} end
@@ -1035,7 +1037,7 @@ end
         end
         return TracedRNumber{
             unwrapped_eltype(
-                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A)); init)
+                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A));init)
             ),
         }
     end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -210,7 +210,6 @@ function overloaded_mapreduce(
     # `sum` over booleans is an `Int64` in Base. `__default_init` reports that wider type
     # (it is the type of `op`'s identity element), so reduce in it.
     init_val = __default_init(op_in_T, op)
-    # TODO: double-check that this is the eltype of the output
     op_out_T = unwrapped_eltype(typeof(init_val))
     reduce_init = Reactant.promote_to(TracedRNumber{op_out_T}, init_val)
 
@@ -220,7 +219,7 @@ function overloaded_mapreduce(
     # Reducing in the narrow type is silently wrong: `stablehlo.add` over `i1` is a logical
     # `or`, and small integers wrap.
     reduce_input = materialize_traced_array(TracedUtils.elem_apply(f, A))
-    # TODO: The line above is not inferred correctly, and maybe subsequent lines aren't either.
+    # The line above is not inferred correctly, and maybe subsequent lines aren't either.
     if unwrapped_eltype(reduce_input) != op_in_T
         reduce_input = op_in_T.(reduce_input)
     end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -219,22 +219,15 @@ function overloaded_mapreduce(
     # predicate in `sum(x -> x == 1, a)` returns `Bool` whatever `A` was converted to.
     # Reducing in the narrow type is silently wrong: `stablehlo.add` over `i1` is a logical
     # `or`, and small integers wrap.
-    reduce_input_wrongtype = materialize_traced_array(TracedUtils.elem_apply(f, A))
+    reduce_input = materialize_traced_array(TracedUtils.elem_apply(f, A))
     # TODO: The line above is not inferred correctly, and maybe subsequent lines aren't either.
-
-    if unwrapped_eltype(reduce_input_wrongtype) != op_out_T
-        reduce_input = op_out_T.(reduce_input_wrongtype)
-    else
-        reduce_input = reduce_input_wrongtype
+    if unwrapped_eltype(reduce_input) != op_in_T
+        reduce_input = op_in_T.(reduce_input)
     end
 
-    res_without_init = @opcall reduce(reduce_input, reduce_init, normalized_dims, op)
+    res = @opcall reduce(reduce_input, reduce_init, dims, op)
 
-    if (init isa Base._InitialValue || init === nothing)
-        res = res_without_init
-    else
-        res = op.(res_without_init, init)
-    end
+    (init isa Base._InitialValue || init === nothing) || (res = op.(res, init))
 
     if original_dims isa Colon
         @assert size(res) == () "expected size of result to be (), got $(size(res))"
@@ -243,11 +236,10 @@ function overloaded_mapreduce(
     if res isa TracedRNumber
         res = TracedRArray{op_out_T,0}((), res.mlir_data, ())
     end
-    # use ntuple so that the array rank is inferrable, the corresponding method for reshape was added
-    shape = ntuple(i -> ifelse(i in normalized_dims, 1, size(A, i)), Val(N))
+    shape = [ifelse(i in dims, 1, size(A, i)) for i in 1:N]
     res_reshaped = @opcall reshape(res, shape)
     # force return type inference
-    return TracedRArray{op_out_T,N}((), res_reshaped.mlir_data, shape)
+    return res_reshaped::TracedRArray{op_out_T,N}
 end
 
 function Base.mapreducedim!(
@@ -1037,7 +1029,7 @@ end
         end
         return TracedRNumber{
             unwrapped_eltype(
-                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A));init)
+                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A)); init)
             ),
         }
     end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -191,8 +191,7 @@ function overloaded_mapreduce(
     dims=:,
     init=Base._InitialValue(),
 ) where {T,N}
-    original_dims = dims
-    # don't reassign dims to avoid the "captured variable in closure" type instability 
+    # don't reassign dims to avoid the "captured variable in closure" type instability
     normalized_dims = sort(
         if dims isa Int
             Int64[dims]
@@ -219,26 +218,30 @@ function overloaded_mapreduce(
     # Reducing in the narrow type is silently wrong: `stablehlo.add` over `i1` is a logical
     # `or`, and small integers wrap.
     reduce_input = materialize_traced_array(TracedUtils.elem_apply(f, A))
-    # The line above is not inferred correctly, and maybe subsequent lines aren't either.
-    if unwrapped_eltype(reduce_input) != op_in_T
-        reduce_input = op_in_T.(reduce_input)
+    if unwrapped_eltype(reduce_input) != op_out_T
+        reduce_input = op_out_T.(reduce_input)
     end
 
-    res = @opcall reduce(reduce_input, reduce_init, dims, op)
+    res_noinit = @opcall reduce(reduce_input, reduce_init, normalized_dims, op)
 
-    (init isa Base._InitialValue || init === nothing) || (res = op.(res, init))
+    if (init isa Base._InitialValue || init === nothing)
+        res = res_noinit
+        res_T = op_out_T
+    else
+        res = op.(res_noinit, init)
+        res_T = Base.promote_op(op, op_out_T, unwrapped_eltype(typeof(init)))
+    end
 
-    if original_dims isa Colon
+    if dims isa Colon
         @assert size(res) == () "expected size of result to be (), got $(size(res))"
-        return TracedRNumber{op_out_T}((), res.mlir_data)
+        return TracedRNumber{unwrapped_eltype(res)}((), res.mlir_data)::TracedRNumber{res_T}
     end
     if res isa TracedRNumber
-        res = TracedRArray{op_out_T,0}((), res.mlir_data, ())
+        res = TracedRArray{unwrapped_eltype(res),0}((), res.mlir_data, ())::TracedRArray{res_T,0}
     end
-    shape = [ifelse(i in dims, 1, size(A, i)) for i in 1:N]
+    shape = [ifelse(i in normalized_dims, 1, size(A, i)) for i in 1:N]
     res_reshaped = @opcall reshape(res, shape)
-    # force return type inference
-    return res_reshaped::TracedRArray{op_out_T,N}
+    return res_reshaped::TracedRArray{res_T,N}
 end
 
 function Base.mapreducedim!(
@@ -271,7 +274,7 @@ function Base.fill!(A::AnyTracedRArray{T,N}, x::TracedRNumber{T2}) where {T,N,T2
 end
 
 function Base.fill!(A::Array{T,N}, x::TracedRNumber{T2}) where {T,N,T2}
-    return throw(MethodError(fill!, (A, x)))
+    throw(MethodError(fill!, (A, x)))
 end
 
 struct AbstractReactantArrayStyle{N} <: AbstractArrayStyle{N} end

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -372,7 +372,7 @@ function Base.copyto!(
     sstart::Integer,
     n::Integer,
 ) where {T}
-    setindex!(dest, src[sstart:(sstart+n-1)], dstart:(dstart+n-1))
+    setindex!(dest, src[sstart:(sstart + n - 1)], dstart:(dstart + n - 1))
     return dest
 end
 
@@ -1035,7 +1035,7 @@ end
         end
         return TracedRNumber{
             unwrapped_eltype(
-                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A));init)
+                Base._accumulate_promote_op(op, Array{T,ndims(A)}(undef, size(A)); init)
             ),
         }
     end
@@ -1240,10 +1240,10 @@ function circshift_internal!(
         amt = shiftamt[i] % size(src, i)
         amt == 0 && continue
         if amt > 0
-            src1 = selectdim(src, i, (size(src, i)-amt+1):size(src, i))
-            src2 = selectdim(src, i, 1:(size(src, i)-amt))
+            src1 = selectdim(src, i, (size(src, i) - amt + 1):size(src, i))
+            src2 = selectdim(src, i, 1:(size(src, i) - amt))
         else
-            src1 = selectdim(src, i, (-amt+1):size(src, i))
+            src1 = selectdim(src, i, (-amt + 1):size(src, i))
             src2 = selectdim(src, i, 1:(-amt))
         end
         src = cat(materialize_traced_array(src1), materialize_traced_array(src2); dims=i)

--- a/src/TracedRArray.jl
+++ b/src/TracedRArray.jl
@@ -237,7 +237,9 @@ function overloaded_mapreduce(
         return TracedRNumber{unwrapped_eltype(res)}((), res.mlir_data)::TracedRNumber{res_T}
     end
     if res isa TracedRNumber
-        res = TracedRArray{unwrapped_eltype(res),0}((), res.mlir_data, ())::TracedRArray{res_T,0}
+        res = TracedRArray{unwrapped_eltype(res),0}(
+            (), res.mlir_data, ()
+        )::TracedRArray{res_T,0}
     end
     shape = [ifelse(i in normalized_dims, 1, size(A, i)) for i in 1:N]
     res_reshaped = @opcall reshape(res, shape)

--- a/test/core/map_reduction.jl
+++ b/test/core/map_reduction.jl
@@ -1,5 +1,6 @@
 # Tests for reduction and mapreduce operations
 using Reactant, Test, Enzyme, Statistics, FileCheck
+using Reactant: TracedRArray, TracedRNumber
 
 const RunningOnTPU = contains(string(Reactant.devices()[1]), "TPU")
 
@@ -55,6 +56,24 @@ sum_compare(x) = sum(x) > 0
     # Ensure we are tracing as scalars. Else this will fail due to > not being defined on
     # arrays
     @test @jit(sum_compare(a)) == sum_compare(x)
+end
+
+@testset "Mapreduce output type inference"  begin
+    # non-regression test for https://github.com/EnzymeAD/Reactant.jl/issues/3261
+    function infer_overloaded_mapreduce(A::Type; kwargs...)
+        kwcall_args = (
+            typeof(NamedTuple(kwargs)),
+            typeof(Reactant.TracedRArrayOverrides.overloaded_mapreduce),
+            typeof(abs2),
+            typeof(+),
+            A
+        )
+        return only(Base.return_types(Core.kwcall, kwcall_args))
+    end
+
+    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=:) === TracedRNumber{Float32}
+    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=1) === TracedRArray{Float32,2}
+    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=(1, 2)) === TracedRArray{Float32,2}
 end
 
 function mysoftmax!(x)

--- a/test/core/map_reduction.jl
+++ b/test/core/map_reduction.jl
@@ -74,64 +74,46 @@ end
 
         # various dims
         @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=:) ===
-              TracedRNumber{Float32}
+            TracedRNumber{Float32}
         @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=1) ===
-              TracedRArray{Float32,2}
+            TracedRArray{Float32,2}
         @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=(1, 2)) ===
-              TracedRArray{Float32,2}
+            TracedRArray{Float32,2}
         @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=[1]) ===
-              TracedRArray{Float32,2}
+            TracedRArray{Float32,2}
         @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,3}; dims=1:2) ===
-              TracedRArray{Float32,3}
+            TracedRArray{Float32,3}
         # init of different type
         @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; init=1.0) ===
-              TracedRNumber{Float64}
-        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=1, init=1.0) ===
-              TracedRArray{Float64,2}
+            TracedRNumber{Float64}
+        @test infer_overloaded_mapreduce(
+            abs2, +, TracedRArray{Float32,2}; dims=1, init=1.0
+        ) === TracedRArray{Float64,2}
         # f narrowing type
         @test infer_overloaded_mapreduce(x -> x == 1, +, TracedRArray{Float32,2}) ===
-              TracedRNumber{Int64}
+            TracedRNumber{Int64}
     end
 
     @testset "Inside @jit" begin
         function strict_reduction(reduction, v)
             T = Core.Compiler.return_type(reduction, Tuple{typeof(v)})
             res = reduction(v)
-            if !isconcretetype(T)
+            isconcretetype(T) ||
                 error("Inferred return type $T / actual return type $(typeof(res))")
-            else
-                return res
-            end
-        end
-        function test_matching(a, b)
-            @test a ≈ b
-            @test Reactant.unwrapped_eltype(a) == Reactant.unwrapped_eltype(b)
+            return res
         end
 
-        x_ra = Reactant.TestUtils.construct_test_array(Float32, 4)
-
-        y=@jit strict_reduction(sum, x_ra)
-        z = sum(x_ra)
-        test_matching(y, z)
-
-        y=@jit strict_reduction(maximum, x_ra)
-        z = maximum(x_ra)
-        test_matching(y, z)
+        x = Reactant.TestUtils.construct_test_array(Float32, 4)
+        x_ra = Reactant.to_rarray(x)
 
         _sum1(x) = sum(x; init=1.0)
-        y=@jit strict_reduction(_sum1, x_ra)
-        z = _sum1(x_ra)
-        test_matching(y, z)
-
         _sum2(x) = sum(x; dims=1, init=1.0)
-        y=@jit strict_reduction(_sum2, x_ra)
-        z = _sum2(x_ra)
-        test_matching(y, z)
-
-        _sum3(x) = sum(x; init=ConcreteRNumber(1.0))
-        @test_broken @jit strict_reduction(_sum3, x_ra) # TODO: why?
-        # inferred return type Union{Float64, ConcretePJRTNumber{Float64, 1}}
-        # actual return type Float64
+        @testset "$reduction" for reduction in (sum, maximum, _sum1, _sum2)
+            y = @jit strict_reduction(reduction, x_ra)
+            z = reduction(x)
+            @test y ≈ z
+            @test Reactant.unwrapped_eltype(y) == Reactant.unwrapped_eltype(z)
+        end
     end
 end
 

--- a/test/core/map_reduction.jl
+++ b/test/core/map_reduction.jl
@@ -60,23 +60,79 @@ end
 
 @testset "Mapreduce output type inference" begin
     # non-regression test for https://github.com/EnzymeAD/Reactant.jl/issues/3261
-    function infer_overloaded_mapreduce(A::Type; kwargs...)
-        kwcall_args = (
-            typeof(NamedTuple(kwargs)),
-            typeof(Reactant.TracedRArrayOverrides.overloaded_mapreduce),
-            typeof(abs2),
-            typeof(+),
-            A,
-        )
-        return only(Base.return_types(Core.kwcall, kwcall_args))
+    @testset "Inference on TracedRArray" begin
+        function infer_overloaded_mapreduce(f::Function, op::Function, A::Type; kwargs...)
+            kwcall_args = (
+                typeof(NamedTuple(kwargs)),
+                typeof(Reactant.TracedRArrayOverrides.overloaded_mapreduce),
+                typeof(f),
+                typeof(op),
+                A,
+            )
+            return only(Base.return_types(Core.kwcall, kwcall_args))
+        end
+
+        # various dims
+        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=:) ===
+              TracedRNumber{Float32}
+        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=1) ===
+              TracedRArray{Float32,2}
+        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=(1, 2)) ===
+              TracedRArray{Float32,2}
+        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=[1]) ===
+              TracedRArray{Float32,2}
+        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,3}; dims=1:2) ===
+              TracedRArray{Float32,3}
+        # init of different type
+        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; init=1.0) ===
+              TracedRNumber{Float64}
+        @test infer_overloaded_mapreduce(abs2, +, TracedRArray{Float32,2}; dims=1, init=1.0) ===
+              TracedRArray{Float64,2}
+        # f narrowing type
+        @test infer_overloaded_mapreduce(x -> x == 1, +, TracedRArray{Float32,2}) ===
+              TracedRNumber{Int64}
     end
 
-    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=:) ===
-        TracedRNumber{Float32}
-    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=1) ===
-        TracedRArray{Float32,2}
-    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=(1, 2)) ===
-        TracedRArray{Float32,2}
+    @testset "Inside @jit" begin
+        function strict_reduction(reduction, v)
+            T = Core.Compiler.return_type(reduction, Tuple{typeof(v)})
+            res = reduction(v)
+            if !isconcretetype(T)
+                error("Inferred return type $T / actual return type $(typeof(res))")
+            else
+                return res
+            end
+        end
+        function test_matching(a, b)
+            @test a ≈ b
+            @test Reactant.unwrapped_eltype(a) == Reactant.unwrapped_eltype(b)
+        end
+
+        x_ra = Reactant.TestUtils.construct_test_array(Float32, 4)
+
+        y=@jit strict_reduction(sum, x_ra)
+        z = sum(x_ra)
+        test_matching(y, z)
+
+        y=@jit strict_reduction(maximum, x_ra)
+        z = maximum(x_ra)
+        test_matching(y, z)
+
+        _sum1(x) = sum(x; init=1.0)
+        y=@jit strict_reduction(_sum1, x_ra)
+        z = _sum1(x_ra)
+        test_matching(y, z)
+
+        _sum2(x) = sum(x; dims=1, init=1.0)
+        y=@jit strict_reduction(_sum2, x_ra)
+        z = _sum2(x_ra)
+        test_matching(y, z)
+
+        _sum3(x) = sum(x; init=ConcreteRNumber(1.0))
+        @test_broken @jit strict_reduction(_sum3, x_ra) # TODO: why?
+        # inferred return type Union{Float64, ConcretePJRTNumber{Float64, 1}}
+        # actual return type Float64
+    end
 end
 
 function mysoftmax!(x)

--- a/test/core/map_reduction.jl
+++ b/test/core/map_reduction.jl
@@ -58,7 +58,7 @@ sum_compare(x) = sum(x) > 0
     @test @jit(sum_compare(a)) == sum_compare(x)
 end
 
-@testset "Mapreduce output type inference"  begin
+@testset "Mapreduce output type inference" begin
     # non-regression test for https://github.com/EnzymeAD/Reactant.jl/issues/3261
     function infer_overloaded_mapreduce(A::Type; kwargs...)
         kwcall_args = (
@@ -66,14 +66,17 @@ end
             typeof(Reactant.TracedRArrayOverrides.overloaded_mapreduce),
             typeof(abs2),
             typeof(+),
-            A
+            A,
         )
         return only(Base.return_types(Core.kwcall, kwcall_args))
     end
 
-    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=:) === TracedRNumber{Float32}
-    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=1) === TracedRArray{Float32,2}
-    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=(1, 2)) === TracedRArray{Float32,2}
+    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=:) ===
+        TracedRNumber{Float32}
+    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=1) ===
+        TracedRArray{Float32,2}
+    @test infer_overloaded_mapreduce(TracedRArray{Float32,2}; dims=(1, 2)) ===
+        TracedRArray{Float32,2}
 end
 
 function mysoftmax!(x)


### PR DESCRIPTION
Fixes #3261:

- Some of the internals of `overloaded_mapreduce` still resist inference
- The key fix is to annotate the return with the proper element type and shape
- I also fixed a variable captured in closure bug while I was at it