### PR TITLE
Error on @trace if assignments to untraced mutable struct fields

### DIFF
--- a/docs/src/tutorials/control-flow.md
+++ b/docs/src/tutorials/control-flow.md
@@ -120,6 +120,13 @@ In our simple example, the condition is passed directly as an argument but
 the same mechanism is applied to conditions which are computed from within
 a function from traced arguments, leading to a traced condition.
 
+Branches can also mutate fields of a captured mutable struct, but only when
+the field already holds a traced value — the `if` result is written back into
+that location. A field holding a plain number or other untraced value has no
+location to write into, so assigning it inside `@trace if` raises an error.
+Parameterize the field type and initialize it with a traced value, e.g. via
+`ReactantCore.promote_to_traced`.
+
 ### Loops
 
 In addition to conditional evaluations, [`@trace`](@ref) also supports capturing

--- a/src/Ops.jl
+++ b/src/Ops.jl
@@ -2874,11 +2874,36 @@ end
                 Reactant.TracedUtils.set!(
                     args, path[2:end], MLIR.IR.result(if_compiled, residx)
                 )
+            else
+                check_untraced_branch_state(
+                    target, tb_traced_args, fb_traced_args, path[2:end]
+                )
             end
         end
     end
 
     return corrected_traced_results
+end
+
+# An untraced location in a mutable argument (e.g. a struct field holding a plain number)
+# has nothing the `if` result can be written back into, so a branch that assigned it a new
+# value would be a silent no-op. Note this only inspects collected result paths: a leaf the
+# tracing machinery never tracks cannot be detected here.
+function check_untraced_branch_state(target, tb_traced_args, fb_traced_args, path)
+    for branch_args in (tb_traced_args, fb_traced_args)
+        leaf = branch_args
+        for p in path
+            leaf = Reactant.Compiler.traced_getfield(leaf, p)
+        end
+        leaf === target && continue
+        error(
+            "if_condition: a branch assigned a value of type $(typeof(leaf)) to an untraced \
+             location holding $(repr(target)) (path $(path)); the assignment cannot be \
+             carried out of the branch. Make the initial value traced before the `if`, e.g. \
+             with `Reactant.ReactantCore.promote_to_traced`.",
+        )
+    end
+    return nothing
 end
 
 """

--- a/test/core/control_flow.jl
+++ b/test/core/control_flow.jl
@@ -1168,6 +1168,36 @@ end
     @test simulation.stop_iteration == 3
 end
 
+mutable struct PlainFieldCache{U,C,B}
+    u::U
+    count::C
+    done::B
+end
+
+function plain_field_assigned(u, threshold, init, assigned)
+    c = PlainFieldCache(u, init, ReactantCore.promote_to_traced(false))
+    @trace if sum(u) > threshold
+        c.count = assigned
+        c.done = true
+    end
+    return c.count, c.done
+end
+
+function plain_field_untouched(u, threshold)
+    c = PlainFieldCache(u, 0, ReactantCore.promote_to_traced(false))
+    @trace if sum(u) > threshold
+        c.done = true
+    end
+    return c.count, c.done
+end
+
+@testset "if: assignment to an untraced struct field" begin
+    u = Reactant.to_rarray(Float32[1, 1])
+    @test_throws "untraced location" @jit plain_field_assigned(u, 1.0f0, 0, 1)
+    @test_throws "untraced location" @jit plain_field_assigned(u, 1.0f0, 0.5, 2.5)
+    @test @jit(plain_field_untouched(u, 1.0f0)) == (0, true)
+end
+
 function ternary_max(x, y)
     @trace result = x > y ? x : y
     return result


### PR DESCRIPTION
## Summary

Split out of https://github.com/EnzymeAD/Reactant.jl/pull/3232#issuecomment-5623499905, where this change was flagged as independent of the enum tracing work.

When a `@trace if` branch assigns a new value to a field of a captured mutable struct whose slot is untraced (e.g. a plain `Int` or `Float64` field), the `if` result has no location to be written back into. Previously the assignment was silently discarded; `if_condition` now checks such `:resarg` paths and raises an error explaining that the field must be traced before the `if`, e.g. via `ReactantCore.promote_to_traced`.

Caveat: the check only inspects collected result paths, so it is not a general detector of unsupported mutations — a leaf the tracing machinery never tracks produces no path and remains undetectable (this is noted in a comment on `check_untraced_branch_state`).

The tutorial's conditional-control-flow section now documents the requirement on mutable struct fields.

## Test plan

- [x] `core/control_flow` passes locally (Linux CPU, PJRT): 150/150, including the new "if: assignment to an untraced struct field" testset which asserts the error fires for plain `Int` and `Float64` fields and that an untouched untraced field still works.
- [x] Verified locally that the numeric case throws `"untraced location"` with this change and silently dropped the assignment without it.

🤖 Generated with [Devin](https://devin.ai) (harness: Devin CLI, model: SWE-2 High) — local CLI session, no shareable URL.