### PR TITLE
Accept Integer for register_backend priority kwarg

### DIFF
--- a/src/accelerators/Registration.jl
+++ b/src/accelerators/Registration.jl
@@ -29,7 +29,6 @@ function register_backend(
     preinitialize_setup_function=Returns(nothing),
 )
     @assert pjrt_initialize_function !== nothing || ifrt_initialize_function !== nothing "atleast one of pjrt_initialize_function or ifrt_initialize_function must be provided."
-    priority = Int64(priority)
 
     for backend in RegisteredBackends
         @assert backend.platform_name != platform_name "Backend with platform_name: \

--- a/src/accelerators/Registration.jl
+++ b/src/accelerators/Registration.jl
@@ -23,7 +23,7 @@ end
 
 function register_backend(
     platform_name::String;
-    priority::Integer,
+    priority::Int,
     pjrt_initialize_function=nothing,
     ifrt_initialize_function=nothing,
     preinitialize_setup_function=Returns(nothing),
@@ -44,8 +44,8 @@ function register_backend(
             priority,
             pjrt_initialize_function,
             ifrt_initialize_function,
-            Ref(Int64(0)),
-            Ref(Int64(0)),
+            Ref(0),
+            Ref(0),
             preinitialize_setup_function,
         )
         push!(RegisteredBackends, backend)

--- a/src/accelerators/Registration.jl
+++ b/src/accelerators/Registration.jl
@@ -44,8 +44,8 @@ function register_backend(
             priority,
             pjrt_initialize_function,
             ifrt_initialize_function,
-            Ref(0),
-            Ref(0),
+            Ref(Int64(0)),
+            Ref(Int64(0)),
             preinitialize_setup_function,
         )
         push!(RegisteredBackends, backend)

--- a/src/accelerators/Registration.jl
+++ b/src/accelerators/Registration.jl
@@ -43,8 +43,8 @@ function register_backend(
             priority,
             pjrt_initialize_function,
             ifrt_initialize_function,
-            Ref(0),
-            Ref(0),
+            Ref(Int64(0)),
+            Ref(Int64(0)),
             preinitialize_setup_function,
         )
         push!(RegisteredBackends, backend)

--- a/src/accelerators/Registration.jl
+++ b/src/accelerators/Registration.jl
@@ -23,12 +23,13 @@ end
 
 function register_backend(
     platform_name::String;
-    priority::Int64,
+    priority::Integer,
     pjrt_initialize_function=nothing,
     ifrt_initialize_function=nothing,
     preinitialize_setup_function=Returns(nothing),
 )
     @assert pjrt_initialize_function !== nothing || ifrt_initialize_function !== nothing "atleast one of pjrt_initialize_function or ifrt_initialize_function must be provided."
+    priority = Int64(priority)
 
     for backend in RegisteredBackends
         @assert backend.platform_name != platform_name "Backend with platform_name: \


### PR DESCRIPTION
## Summary

`using Reactant` cannot load at all on 32-bit Julia. Two `Int64`s in the backend
registration path reject the `Int32` values that integer literals produce on i686:

1. `register_backend(platform_name; priority::Int64, ...)` — `register_backend("cpu"; priority=100)`
   in `Accelerators.CPU.__init__` throws
   `TypeError: in keyword argument priority, expected Int64, got a value of type Int32`.
2. `Ref(0)` for the `pjrt_client_count` / `ifrt_client_count` fields, which are typed
   `Base.RefValue{Int64}` — `Ref(0)` is a `RefValue{Int32}` on i686 and there is no
   `convert(::Type{RefValue{Int64}}, ::RefValue{Int32})`, so the same call throws
   `MethodError` one argument further along.

Fixing only (1) turns the `TypeError` into a `MethodError` in the same `__init__`, so both
are needed. `priority` becomes `::Int` (machine `Int`, per review — every in-repo call site
passes a bare literal); the `RegisteredBackend.priority::Int64` field converts it, and the
counts get explicit `Int64` literals to match their field type.

Found while investigating [SciMLSensitivity.jl's `Core1` 32-bit CI lane](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/34650148455/job/103431340580),
where `using Reactant` fails with exactly (1):

```
ERROR: LoadError: InitError: TypeError: in keyword argument priority, expected Int64, got a value of type Int32
Stacktrace:
  [1] __init__()
    @ Reactant.Accelerators.CPU ~/.julia/packages/Reactant/ct5sa/src/accelerators/CPU.jl:50
```

## Verification

Reactant has no 32-bit CI lane (`.github/workflows/CI.yml` covers ubuntu-24.04,
ubuntu-22.04-arm, macOS, windows, TPU), and this bug is invisible on 64-bit — `Ref(0)` *is*
`RefValue{Int64}` there — so no test added here could fail before and pass after on any
job this repo runs. See #253, which asked for exactly this lane and was closed without one.

Verified instead on real i686 Julia by extracting `RegisteredBackend` / `register_backend`
verbatim from `src/accelerators/Registration.jl` at each commit and calling
`register_backend("cpu"; priority=100, pjrt_initialize_function=()->nothing)`:

| `Registration.jl` at | i686 Julia 1.12.7 |
|---|---|
| `main` (`priority::Int64`, `Ref(0)`) | `TypeError: in keyword argument priority, expected Int64, got a value of type Int32` |
| `20810d590` (`priority::Int`, `Ref(0)`) | `MethodError: Cannot convert an object of type Base.RefValue{Int32} to an object of type Base.RefValue{Int64}` |
| `8b7c28136` (this PR head) | `register_backend OK` |

This PR head also OK on i686 Julia 1.11.9, and on x86_64 Julia 1.10.11 and 1.12.7:

```
===== AFTER FIX, i686 Julia 1.12.7 =====      Julia Int = Int32   register_backend OK
===== AFTER FIX, i686 Julia 1.11.9 =====      Julia Int = Int32   register_backend OK
===== AFTER FIX, x86_64 Julia 1.12.7 =====    Julia Int = Int64   register_backend OK
===== AFTER FIX, x86_64 Julia 1.10.11 =====   Julia Int = Int64   register_backend OK
```

`JuliaFormatter` v1 (`style = "blue"`) reports the changed file already formatted.

## What was NOT verified

- **`using Reactant` end-to-end on i686.** Blocked before Reactant's `__init__` by a
  separate upstream bug: `BFloat16s` segfaults during precompilation on i686
  (`ProcessSignaled(11)`, LLVM `DAGTypeLegalizer::SoftPromoteHalfResult` during AOT
  output). Reproduced locally on i686 Julia 1.11.9 and 1.12.7, and visible on GitHub's
  i686 1.13 runner in the [most recent SciMLSensitivity x86 run](https://github.com/SciML/SciMLSensitivity.jl/actions/runs/34656934999/job/103461409522).
  Whether that run reaches Reactant's `__init__` varies run to run; the linked job above
  is one that did. That bug is not in this repo and is not addressed here.
- **Reactant's own test suite** was not run for this change — it needs XLA and hours, and
  none of it exercises a 32-bit path.
- The `downgrade` jobs and the TPU jobs failing on this PR also fail on `main` (`9eef079`);
  they are pre-existing and unrelated.

## For the reviewer

- The `Ref(0)` → `Ref(Int64(0))` hunk was reverted by a review suggestion in `26fe25a14`
  and is restored in `8b7c28136`; the table above is the evidence that it is load-bearing.
  The alternative is to type the struct fields `Base.RefValue{Int}` and keep `Ref(0)` —
  also correct, and more consistent with `priority::Int`. Say the word if you prefer that.
- Related but deliberately out of scope: `::Int64` *argument* annotations elsewhere
  (`src/Ops.jl`, `src/xla/CompileOptions.jl:68-70`, `src/xla/PJRT/LoadedExecutable.jl:66-70`)
  have the same 32-bit hazard, but they are on tracing/execution paths, not `__init__`, so
  they do not block loading. The `::Int64`s in `src/mlir/libMLIR_h.jl` are `@ccall`
  signatures and are correct as-is.

Please ignore until reviewed by @ChrisRackauckas.

---

Original fix (`a8508b11c`, `89a50694b`) authored with Devin CLI 3000.10.21 (models SWE-2
High / SWE-2 Max); local session transcript, no shareable URL:
`/home/crackauc/.local/share/devin/cli/summaries/history_56dcef04f3304e25.md`

Investigation and `8b7c28136` 🤖 Generated with [Claude Code](https://claude.com/claude-code) 2.1.269 (model: claude-opus-5[1m])

https://claude.ai/code/session_01RvyK9WmNSp261e2Ffq2SSr
