### PR TITLE
Accept Integer for accelerator backend priority (32-bit)

### DIFF
--- a/src/accelerators/CPU.jl
+++ b/src/accelerators/CPU.jl
@@ -49,7 +49,7 @@ end
 function __init__()
     register_backend(
         "cpu";
-        priority=100,
+        priority=Int64(100),
         pjrt_initialize_function=make_pjrt_client,
         ifrt_initialize_function=make_ifrt_client,
     )

--- a/src/accelerators/GPU.jl
+++ b/src/accelerators/GPU.jl
@@ -73,7 +73,7 @@ function __init__()
         if Reactant_jll.host_platform.tags["gpu"] == "cuda"
             register_backend(
                 "cuda";
-                priority=500,
+                priority=Int64(500),
                 pjrt_initialize_function=make_pjrt_client,
                 ifrt_initialize_function=make_ifrt_client,
             )
@@ -82,7 +82,7 @@ function __init__()
         if Reactant_jll.host_platform.tags["gpu"] == "rocm"
             register_backend(
                 "rocm";
-                priority=500,
+                priority=Int64(500),
                 pjrt_initialize_function=make_pjrt_client,
                 ifrt_initialize_function=make_ifrt_client,
             )

--- a/src/accelerators/Registration.jl
+++ b/src/accelerators/Registration.jl
@@ -23,7 +23,7 @@ end
 
 function register_backend(
     platform_name::String;
-    priority::Int64,
+    priority::Integer,
     pjrt_initialize_function=nothing,
     ifrt_initialize_function=nothing,
     preinitialize_setup_function=Returns(nothing),
@@ -40,7 +40,7 @@ function register_backend(
     @lock BackendRegistrationLock begin
         backend = RegisteredBackend(
             platform_name,
-            priority,
+            Int64(priority),
             pjrt_initialize_function,
             ifrt_initialize_function,
             Ref(0),

--- a/src/accelerators/TPU.jl
+++ b/src/accelerators/TPU.jl
@@ -69,7 +69,7 @@ function __init__()
     if !Sys.isapple() && has_tpu() && !Reactant.precompiling()
         register_backend(
             "tpu";
-            priority=1000,
+            priority=Int64(1000),
             pjrt_initialize_function=make_pjrt_client,
             ifrt_initialize_function=make_ifrt_client,
             preinitialize_setup_function=() -> begin

--- a/src/accelerators/TT.jl
+++ b/src/accelerators/TT.jl
@@ -73,7 +73,7 @@ function __init__()
     if Sys.islinux() && has_tt() && !Reactant.precompiling()
         register_backend(
             "tt";
-            priority=1000,
+            priority=Int64(1000),
             pjrt_initialize_function=make_pjrt_client,
             ifrt_initialize_function=make_ifrt_client,
             preinitialize_setup_function=() -> begin

--- a/src/accelerators/Trainium.jl
+++ b/src/accelerators/Trainium.jl
@@ -401,7 +401,7 @@ function __init__()
     if Sys.islinux() && has_trainium() && !Reactant.precompiling()
         register_backend(
             "trainium";
-            priority=1000,
+            priority=Int64(1000),
             pjrt_initialize_function=make_pjrt_client,
             ifrt_initialize_function=make_ifrt_client,
             preinitialize_setup_function=() -> begin


### PR DESCRIPTION
## Summary
- On i686, bare integer literals are `Int32`, but `register_backend(; priority::Int64, …)` rejected them and broke `Reactant.Accelerators.CPU.__init__`.
- Widen the kwarg to `Integer` and store `Int64(priority)`; also write `priority=Int64(…)` at call sites.

## Test plan
- [ ] `using Reactant` on 32-bit Julia no longer throws `TypeError: priority expected Int64, got Int32`
- [ ] Existing 64-bit CI still green

Unblocks SciML/NeuralOperators.jl x86 CI.

Made with [Cursor](https://cursor.com)